### PR TITLE
feat (assertion): support quoted args when splitting assertion string.

### DIFF
--- a/assertion_test.go
+++ b/assertion_test.go
@@ -1,0 +1,24 @@
+package venom
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_splitAssertion(t *testing.T) {
+	for _, tt := range []struct {
+		Assertion string
+		Args      []string
+	}{
+		{Assertion: `cmd arg`, Args: []string{"cmd", "arg"}},
+		{Assertion: `cmd arg1 "arg 2"`, Args: []string{"cmd", "arg1", "arg 2"}},
+		{Assertion: `cmd 'arg 1' "arg 2"`, Args: []string{"cmd", "arg 1", "arg 2"}},
+		{Assertion: `cmd 'arg 1' "'arg' 2"`, Args: []string{"cmd", "arg 1", "'arg' 2"}},
+		{Assertion: `cmd '"arg 1"' "'arg' 2"`, Args: []string{"cmd", "\"arg 1\"", "'arg' 2"}},
+	} {
+		args := splitAssertion(tt.Assertion)
+		if !reflect.DeepEqual(args, tt.Args) {
+			t.Errorf("expected args to be equal to %#v, got %#v", tt.Args, args)
+		}
+	}
+}


### PR DESCRIPTION
live example: https://play.golang.org/p/7X9XRj-I0I