### PR TITLE
fix: remove noPrintable char from Failure & Output

### DIFF
--- a/assertion.go
+++ b/assertion.go
@@ -46,7 +46,7 @@ func applyAssertions(executorResult ExecutorResult, step TestStep, defaultAssert
 	var systemerr, systemout string
 
 	if err := mapstructure.Decode(step, &sa); err != nil {
-		return false, []Failure{{Value: fmt.Sprintf("error decoding assertions: %s", err)}}, failures, systemout, systemerr
+		return false, []Failure{{Value: RemoveNotPrintableChar(fmt.Sprintf("error decoding assertions: %s", err))}}, failures, systemout, systemerr
 	}
 
 	if len(sa.Assertions) == 0 && defaultAssertions != nil {
@@ -80,7 +80,7 @@ func applyAssertions(executorResult ExecutorResult, step TestStep, defaultAssert
 func check(assertion string, executorResult ExecutorResult, l Logger) (*Failure, *Failure) {
 	assert := strings.Split(assertion, " ")
 	if len(assert) < 2 {
-		return &Failure{Value: fmt.Sprintf("invalid assertion '%s' len:'%d'", assertion, len(assert))}, nil
+		return &Failure{Value: RemoveNotPrintableChar(fmt.Sprintf("invalid assertion '%s' len:'%d'", assertion, len(assert)))}, nil
 	}
 
 	actual, ok := executorResult[assert[0]]
@@ -88,14 +88,14 @@ func check(assertion string, executorResult ExecutorResult, l Logger) (*Failure,
 		if assert[1] == "ShouldNotExist" {
 			return nil, nil
 		}
-		return &Failure{Value: fmt.Sprintf("key '%s' does not exist in result of executor: %+v", assert[0], executorResult)}, nil
+		return &Failure{Value: RemoveNotPrintableChar(fmt.Sprintf("key '%s' does not exist in result of executor: %+v", assert[0], executorResult))}, nil
 	} else if assert[1] == "ShouldNotExist" {
-		return &Failure{Value: fmt.Sprintf("key '%s' should not exist in result of executor. Value: %+v", assert[0], actual)}, nil
+		return &Failure{Value: RemoveNotPrintableChar(fmt.Sprintf("key '%s' should not exist in result of executor. Value: %+v", assert[0], actual))}, nil
 	}
 
 	f, ok := assertMap[assert[1]]
 	if !ok {
-		return &Failure{Value: fmt.Sprintf("Method not found '%s'", assert[1])}, nil
+		return &Failure{Value: RemoveNotPrintableChar(fmt.Sprintf("Method not found '%s'", assert[1]))}, nil
 	}
 	args := make([]interface{}, len(assert[2:]))
 	for i, v := range assert[2:] { // convert []string to []interface for assertions.func()...
@@ -107,7 +107,7 @@ func check(assertion string, executorResult ExecutorResult, l Logger) (*Failure,
 	if out != "" {
 		prefix := "assertion: " + assertion
 		sdump, _ := dump.Sdump(executorResult)
-		return nil, &Failure{Value: prefix + "\n" + out + "\n" + sdump}
+		return nil, &Failure{Value: RemoveNotPrintableChar(prefix + "\n" + out + "\n" + sdump)}
 	}
 	return nil, nil
 }

--- a/executors/exec/executor.go
+++ b/executors/exec/executor.go
@@ -190,8 +190,8 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	result.TimeSeconds = elapsed.Seconds()
 	result.TimeHuman = fmt.Sprintf("%s", elapsed)
 
-	result.Systemout = strings.TrimRight(result.Systemout, "\n")
-	result.Systemerr = strings.TrimRight(result.Systemerr, "\n")
+	result.Systemout = venom.RemoveNotPrintableChar(strings.TrimRight(result.Systemout, "\n"))
+	result.Systemerr = venom.RemoveNotPrintableChar(strings.TrimRight(result.Systemerr, "\n"))
 
 	return dump.ToMap(result, dump.WithDefaultLowerCaseFormatter())
 }

--- a/extract_test.go
+++ b/extract_test.go
@@ -1,0 +1,28 @@
+package venom
+
+import "testing"
+
+func Test_RemoveNotPrintableChar(t *testing.T) {
+	type args struct {
+		in string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "remove U+001B espace code (not printable)",
+			// line below contains escapce code U+001B
+			args: args{in: "python-mysqldb : [34mOK[0m"},
+			want: "python-mysqldb :  [34mOK [0m",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveNotPrintableChar(tt.args.in); got != tt.want {
+				t.Errorf("RemoveNotPrintableChar() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -10,16 +10,16 @@ func runTestCase(ts *TestSuite, tc *TestCase, bars map[string]*pb.ProgressBar, l
 	var errContext error
 	tc.Context, errContext = ts.Templater.ApplyOnContext(tc.Context)
 	if errContext != nil {
-		tc.Errors = append(tc.Errors, Failure{Value: errContext.Error()})
+		tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(errContext.Error())})
 		return
 	}
 	tcc, errContext := ContextWrap(tc)
 	if errContext != nil {
-		tc.Errors = append(tc.Errors, Failure{Value: errContext.Error()})
+		tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(errContext.Error())})
 		return
 	}
 	if err := tcc.Init(); err != nil {
-		tc.Errors = append(tc.Errors, Failure{Value: err.Error()})
+		tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(err.Error())})
 		return
 	}
 	defer tcc.Close()
@@ -33,13 +33,13 @@ func runTestCase(ts *TestSuite, tc *TestCase, bars map[string]*pb.ProgressBar, l
 
 		step, erra := ts.Templater.ApplyOnStep(stepIn)
 		if erra != nil {
-			tc.Errors = append(tc.Errors, Failure{Value: erra.Error()})
+			tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(erra.Error())})
 			break
 		}
 
 		e, err := WrapExecutor(step, tcc)
 		if err != nil {
-			tc.Errors = append(tc.Errors, Failure{Value: err.Error()})
+			tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(err.Error())})
 			break
 		}
 

--- a/process_teststep.go
+++ b/process_teststep.go
@@ -28,7 +28,7 @@ func RunTestStep(tcc TestCaseContext, e *ExecutorWrap, ts *TestSuite, tc *TestCa
 		result, err = runTestStepExecutor(tcc, e, ts, step, templater, l)
 
 		if err != nil {
-			tc.Failures = append(tc.Failures, Failure{Value: err.Error()})
+			tc.Failures = append(tc.Failures, Failure{Value: RemoveNotPrintableChar(err.Error())})
 			continue
 		}
 


### PR DESCRIPTION
otherwise, unmarshal json of TestSuite will fail with:

"invalid character '\x1b' in string literal"

Play on https://play.golang.org/p/8Ds1S9AJnN

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>