### PR TITLE
fix (venom): tc skipped format

### DIFF
--- a/process_files.go
+++ b/process_files.go
@@ -90,8 +90,8 @@ func readFiles(variables map[string]string, detailsLevel string, filesPath []str
 		nSteps := 0
 		for _, tc := range ts.TestCases {
 			nSteps += len(tc.TestSteps)
-			if tc.Skipped == 1 {
-				ts.Skipped++
+			if len(tc.Skipped) >= 1 {
+				ts.Skipped += len(tc.Skipped)
 			}
 		}
 		ts.Total = len(ts.TestCases)

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -47,7 +47,7 @@ func runTestSuite(ts *TestSuite, bars map[string]*pb.ProgressBar, detailsLevel s
 
 func runTestCases(ts *TestSuite, bars map[string]*pb.ProgressBar, detailsLevel string, l Logger) {
 	for i, tc := range ts.TestCases {
-		if tc.Skipped == 0 {
+		if len(tc.Skipped) == 0 {
 			runTestCase(ts, &tc, bars, l, detailsLevel)
 			ts.TestCases[i] = tc
 		}
@@ -58,8 +58,8 @@ func runTestCases(ts *TestSuite, bars map[string]*pb.ProgressBar, detailsLevel s
 		if len(tc.Errors) > 0 {
 			ts.Errors += len(tc.Errors)
 		}
-		if tc.Skipped > 0 {
-			ts.Skipped += tc.Skipped
+		if len(tc.Skipped) > 0 {
+			ts.Skipped += len(tc.Skipped)
 		}
 	}
 }

--- a/types.go
+++ b/types.go
@@ -118,7 +118,7 @@ type TestCase struct {
 	Errors     []Failure              `xml:"error,omitempty" json:"errors" yaml:"errors,omitempty"`
 	Failures   []Failure              `xml:"failure,omitempty" json:"failures" yaml:"failures,omitempty"`
 	Name       string                 `xml:"name,attr" json:"name" yaml:"name"`
-	Skipped    int                    `xml:"skipped,attr,omitempty" json:"skipped" yaml:"skipped,omitempty"`
+	Skipped    []Skipped              `xml:"skipped,omitempty" json:"skipped" yaml:"skipped,omitempty"`
 	Status     string                 `xml:"status,attr,omitempty" json:"status" yaml:"status,omitempty"`
 	Systemout  InnerResult            `xml:"system-out,omitempty" json:"systemout" yaml:"systemout,omitempty"`
 	Systemerr  InnerResult            `xml:"system-err,omitempty" json:"systemerr" yaml:"systemerr,omitempty"`
@@ -131,6 +131,9 @@ type TestCase struct {
 type TestStep map[string]interface{}
 
 // Failure contains data related to a failed test.
+type Skipped struct {
+	Value string `xml:",cdata" json:"value" yaml:"value,omitempty"`
+}
 type Failure struct {
 	Value   string `xml:",cdata" json:"value" yaml:"value,omitempty"`
 	Type    string `xml:"type,attr,omitempty" json:"type" yaml:"type,omitempty"`

--- a/venom.go
+++ b/venom.go
@@ -177,7 +177,7 @@ func outputTapFormat(tests Tests) ([]byte, error) {
 	for _, ts := range tests.TestSuites {
 		for _, tc := range ts.TestCases {
 			name := ts.Name + " / " + tc.Name
-			if tc.Skipped > 0 {
+			if len(tc.Skipped) > 0 {
 				t.Skip(1, name)
 				continue
 			}


### PR DESCRIPTION
Skipped is a block, not an attribute

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>