### PR TITLE
feat: parse all testsuites to check variables usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ env:
 
 install: true
 
-script: chmod +x package.sh && ./package.sh
+script:
+  - go test github.com/ovh/venom/lib
+  - chmod +x package.sh && ./package.sh
 
 before_deploy:
   - gem install mime-types -v 2.6.2

--- a/README.md
+++ b/README.md
@@ -280,13 +280,6 @@ func (Executor) Run(ctx context.Context, l venom.Logger, step venom.TestStep) (v
 		return nil, err
 	}
 
-	// Get testcase context if needed
-	varContext := ctx.Value(venom.ContextKey).(map[string]interface{})
-	if varContext == nil {
-        return nil, fmt.Errorf("Executor web need a context")
-    }
-    bar := varContext['foo']
-
 	// to something with t.Command here...
 	//...
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,12 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+)
+
+// Exit func display an error message on stderr and exit 1
+func Exit(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, args...)
+	os.Exit(1)
+}

--- a/cli/venom/template/cmd.go
+++ b/cli/venom/template/cmd.go
@@ -3,8 +3,8 @@ package template
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/ovh/venom"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )

--- a/executors/dbfixtures/executor.go
+++ b/executors/dbfixtures/executor.go
@@ -84,6 +84,12 @@ func (e Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, ste
 	return executors.Dump(r)
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // GetDefaultAssertions return the default assertions of the executor.
 func (e Executor) GetDefaultAssertions() venom.StepAssertions {
 	return venom.StepAssertions{Assertions: []string{}}

--- a/executors/exec/executor.go
+++ b/executors/exec/executor.go
@@ -43,6 +43,12 @@ type Result struct {
 	TimeHuman   string   `json:"timehuman,omitempty" yaml:"timehuman,omitempty"`
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 	return &venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}

--- a/executors/http/executor.go
+++ b/executors/http/executor.go
@@ -56,6 +56,12 @@ type Result struct {
 	Err         string      `json:"err,omitempty" yaml:"err,omitempty"`
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // GetDefaultAssertions return default assertions for this executor
 // Optional
 func (Executor) GetDefaultAssertions() venom.StepAssertions {
@@ -85,10 +91,10 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 		req.Header.Set(k, v)
 	}
 
-    tr := &http.Transport{
-        TLSClientConfig: &tls.Config{InsecureSkipVerify: t.IgnoreVerifySSL},
-    }
-    client := &http.Client{Transport: tr}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: t.IgnoreVerifySSL},
+	}
+	client := &http.Client{Transport: tr}
 
 	start := time.Now()
 	resp, err := client.Do(req)
@@ -196,7 +202,7 @@ func (e Executor) getRequest() (*http.Request, error) {
 	}
 
 	if len(e.BasicAuthUser) > 0 || len(e.BasicAuthPassword) > 0 {
-	    req.SetBasicAuth(e.BasicAuthUser, e.BasicAuthPassword)
+		req.SetBasicAuth(e.BasicAuthUser, e.BasicAuthPassword)
 	}
 
 	if writer != nil {

--- a/executors/imap/executor.go
+++ b/executors/imap/executor.go
@@ -57,6 +57,12 @@ type Result struct {
 	TimeHuman   string   `json:"timeHuman,omitempty" yaml:"timeHuman,omitempty"`
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 	return &venom.StepAssertions{Assertions: []string{"result.err ShouldNotExist"}}
@@ -184,7 +190,7 @@ func (m *Mail) move(c *imap.Client, mbox string) error {
 	seq.AddNum(m.UID)
 
 	if _, err := c.UIDMove(seq, mbox); err != nil {
-		return fmt.Errorf("Error while move msg to %s, err:%s", mbox, err.Error())
+		return fmt.Errorf("Error while move msg to %s: %v", mbox, err.Error())
 	}
 	return nil
 }

--- a/executors/ovhapi/executor.go
+++ b/executors/ovhapi/executor.go
@@ -46,6 +46,12 @@ type Result struct {
 	Err         string      `json:"err,omitempty" yaml:"err,omitempty"`
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // GetDefaultAssertions return default assertions for this executor
 // Optional
 func (Executor) GetDefaultAssertions() venom.StepAssertions {

--- a/executors/readfile/executor.go
+++ b/executors/readfile/executor.go
@@ -45,6 +45,12 @@ type Result struct {
 	Mod         map[string]string `json:"mod,omitempty" yaml:"mod,omitempty"`
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 	return &venom.StepAssertions{Assertions: []string{"result.err ShouldNotExist"}}

--- a/executors/smtp/executor.go
+++ b/executors/smtp/executor.go
@@ -43,6 +43,12 @@ type Result struct {
 	TimeHuman   string   `json:"timeHuman,omitempty" yaml:"timeHuman,omitempty"`
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 	return &venom.StepAssertions{Assertions: []string{"result.err ShouldNotExist"}}

--- a/executors/ssh/executor.go
+++ b/executors/ssh/executor.go
@@ -44,6 +44,12 @@ type Result struct {
 	TimeHuman   string   `json:"timehuman,omitempty" yaml:"timehuman,omitempty"`
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 	return &venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}

--- a/executors/web/web.go
+++ b/executors/web/web.go
@@ -38,6 +38,12 @@ type Result struct {
 	URL         string   `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
+// ZeroValueResult return an empty implemtation of this executor result
+func (Executor) ZeroValueResult() venom.ExecutorResult {
+	r, _ := executors.Dump(Result{})
+	return r
+}
+
 // Run execute TestStep
 func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step venom.TestStep) (venom.ExecutorResult, error) {
 	var ctx *webctx.WebTestCaseContext

--- a/lib/libtests_test.go
+++ b/lib/libtests_test.go
@@ -1,4 +1,4 @@
-package main
+package venom_test
 
 import (
 	"testing"

--- a/process.go
+++ b/process.go
@@ -2,16 +2,15 @@ package venom
 
 import (
 	"errors"
-	"io"
+	"fmt"
 	"strings"
-	"sync"
 
 	log "github.com/sirupsen/logrus"
 )
 
 // Process runs tests suite and return a Tests result
-func Process(path []string, variables map[string]string, exclude []string, parallel int, logLevel string, detailsLevel string, writer io.Writer) (*Tests, error) {
-	switch logLevel {
+func (v *Venom) Process(path []string, exclude []string) (*Tests, error) {
+	switch v.LogLevel {
 	case "debug":
 		log.SetLevel(log.DebugLevel)
 	case "info":
@@ -22,53 +21,104 @@ func Process(path []string, variables map[string]string, exclude []string, paral
 		log.SetLevel(log.WarnLevel)
 	}
 
-	log.SetOutput(writer)
-	switch detailsLevel {
+	log.SetOutput(v.LogOutput)
+	switch v.OutputDetails {
 	case DetailsLow, DetailsMedium, DetailsHigh:
-		log.Infof("Detail Level: %s", detailsLevel)
+		log.Infof("Detail Level: %s", v.OutputDetails)
 	default:
 		return nil, errors.New("Invalid details. Must be low, medium or high")
 	}
 
-	chanEnd := make(chan TestSuite, 1)
-	parallels := make(chan TestSuite, parallel)
-	wg := sync.WaitGroup{}
-	testsResult := &Tests{}
-
 	filesPath := getFilesPath(path, exclude)
-	wg.Add(len(filesPath))
-	chanToRun := make(chan TestSuite, len(filesPath)+1)
 
-	go computeStats(testsResult, chanEnd, &wg)
-
-	bars, err := readFiles(variables, detailsLevel, filesPath, chanToRun, writer)
-	if err != nil {
+	if err := v.readFiles(filesPath); err != nil {
 		return nil, err
 	}
 
-	pool := initBars(detailsLevel, bars)
+	//First parse the testsuites to check if all testsuites are fine (context init + variable usages)
+	if err := v.parse(); err != nil {
+		return nil, err
+	}
 
-	go func() {
-		for ts := range chanToRun {
-			parallels <- ts
-			go func(ts TestSuite) {
-				runTestSuite(&ts, bars, detailsLevel)
-				chanEnd <- ts
-				<-parallels
-			}(ts)
-		}
-	}()
+	//Then process
+	if v.OutputDetails != DetailsLow {
+		pool := v.initBars()
+		defer endBars(v.OutputDetails, pool)
+	}
 
-	wg.Wait()
+	for i := range v.testsuites {
+		ts := &v.testsuites[i]
+		v.runTestSuite(ts)
+	}
 
-	endBars(detailsLevel, pool)
+	testsResult := &Tests{}
+	v.computeStats(testsResult)
 
 	return testsResult, nil
 }
 
-func computeStats(testsResult *Tests, chanEnd <-chan TestSuite, wg *sync.WaitGroup) {
-	for t := range chanEnd {
-		testsResult.TestSuites = append(testsResult.TestSuites, t)
+func (v *Venom) parse() error {
+	missingVars := []string{}
+	extractedVars := []string{}
+	for i := range v.testsuites {
+		ts := &v.testsuites[i]
+		log.Info("Parsing testsuite %s", ts.Package)
+
+		tvars, textractedVars, err := v.parseTestSuite(ts)
+		if err != nil {
+			return err
+		}
+		for _, k := range tvars {
+			var found bool
+			for i := 0; i < len(missingVars); i++ {
+				if missingVars[i] == k {
+					found = true
+					break
+				}
+			}
+			if !found {
+				missingVars = append(missingVars, k)
+			}
+		}
+		for _, k := range textractedVars {
+			var found bool
+			for i := 0; i < len(extractedVars); i++ {
+				if extractedVars[i] == k {
+					found = true
+					break
+				}
+			}
+			if !found {
+				extractedVars = append(extractedVars, k)
+			}
+		}
+	}
+
+	reallyMissingVars := []string{}
+	for _, k := range missingVars {
+		log.Debugf("Checking variable %s", k)
+		var varExtracted bool
+		for _, e := range extractedVars {
+			if k == e {
+				varExtracted = true
+			}
+		}
+		if !varExtracted {
+			reallyMissingVars = append(reallyMissingVars, k)
+		}
+	}
+
+	if len(reallyMissingVars) > 0 {
+		return fmt.Errorf("Missing variables %v", reallyMissingVars)
+	}
+
+	return nil
+}
+
+func (v *Venom) computeStats(testsResult *Tests) {
+	for i := range v.testsuites {
+		t := &v.testsuites[i]
+		testsResult.TestSuites = append(testsResult.TestSuites, *t)
 		if t.Failures > 0 {
 			testsResult.TotalKO += t.Failures
 		} else {
@@ -79,7 +129,6 @@ func computeStats(testsResult *Tests, chanEnd <-chan TestSuite, wg *sync.WaitGro
 		}
 
 		testsResult.Total = testsResult.TotalKO + testsResult.TotalOK + testsResult.TotalSkipped
-		wg.Done()
 	}
 }
 

--- a/process_bars.go
+++ b/process_bars.go
@@ -7,26 +7,24 @@ import (
 	"gopkg.in/cheggaaa/pb.v1"
 )
 
-func initBars(detailsLevel string, bars map[string]*pb.ProgressBar) *pb.Pool {
+func (v *Venom) initBars() *pb.Pool {
 	var pool *pb.Pool
 	var pbbars []*pb.ProgressBar
-	if detailsLevel != DetailsLow {
-		// sort bars pool
-		var keys []string
-		for k := range bars {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
+	// sort bars pool
+	var keys []string
+	for k := range v.outputProgressBar {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 
-		for _, k := range keys {
-			pbbars = append(pbbars, bars[k])
-		}
-		var errs error
-		pool, errs = pb.StartPool(pbbars...)
-		if errs != nil {
-			log.Errorf("Error while prepare details bars: %s", errs)
-			pool = nil
-		}
+	for _, k := range keys {
+		pbbars = append(pbbars, v.outputProgressBar[k])
+	}
+	var errs error
+	pool, errs = pb.StartPool(pbbars...)
+	if errs != nil {
+		log.Errorf("Error while prepare details bars: %s", errs)
+		pool = nil
 	}
 	return pool
 }

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -1,24 +1,113 @@
 package venom
 
 import (
+	"regexp"
+	"strings"
+
+	"github.com/fsamin/go-dump"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/cheggaaa/pb.v1"
 )
 
-func runTestCase(ts *TestSuite, tc *TestCase, bars map[string]*pb.ProgressBar, l Logger, detailsLevel string) {
-	l.Debugf("Init context")
+func (v *Venom) initTestCaseContext(ts *TestSuite, tc *TestCase) (TestCaseContext, error) {
 	var errContext error
 	tc.Context, errContext = ts.Templater.ApplyOnContext(tc.Context)
 	if errContext != nil {
-		tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(errContext.Error())})
-		return
+		return nil, errContext
 	}
-	tcc, errContext := ContextWrap(tc)
+	tcc, errContext := v.ContextWrap(tc)
 	if errContext != nil {
-		tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(errContext.Error())})
-		return
+		return nil, errContext
 	}
 	if err := tcc.Init(); err != nil {
+		return nil, err
+	}
+	return tcc, nil
+}
+
+var varRegEx, _ = regexp.Compile("{{.*}}")
+
+//Parse the testcase to find unreplaced and extracted variables
+func (v *Venom) parseTestCase(ts *TestSuite, tc *TestCase) ([]string, []string, error) {
+	tcc, err := v.initTestCaseContext(ts, tc)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer tcc.Close()
+
+	vars := []string{}
+	extractedVars := []string{}
+
+	for _, stepIn := range tc.TestSteps {
+		step, erra := ts.Templater.ApplyOnStep(stepIn)
+		if erra != nil {
+			return nil, nil, erra
+		}
+
+		exec, err := v.WrapExecutor(step, tcc)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		withZero, ok := exec.executor.(executorWithZeroValueResult)
+		if ok {
+			defaultResult := withZero.ZeroValueResult()
+			dumpE, err := dump.ToStringMap(defaultResult, dump.WithDefaultLowerCaseFormatter())
+			if err != nil {
+				return nil, nil, err
+			}
+
+			for k := range dumpE {
+				extractedVars = append(extractedVars, tc.Name+"."+k)
+			}
+		}
+
+		dumpE, err := dump.ToStringMap(step, dump.WithDefaultLowerCaseFormatter())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for k, v := range dumpE {
+			if strings.HasPrefix(k, "extracts.") {
+				for _, extractVar := range extractPattern.FindAllString(v, -1) {
+					varname := extractVar[2:strings.Index(extractVar, "=")]
+					var found bool
+					for i := 0; i < len(extractedVars); i++ {
+						if extractedVars[i] == varname {
+							found = true
+							break
+						}
+					}
+					if !found {
+						extractedVars = append(extractedVars, tc.Name+"."+varname)
+					}
+				}
+				continue
+			}
+
+			if varRegEx.MatchString(v) {
+				var found bool
+				for i := 0; i < len(vars); i++ {
+					if vars[i] == k {
+						found = true
+						break
+					}
+				}
+				if !found {
+					s := varRegEx.FindString(v)
+					s = strings.Replace(s, "{{.", "", -1)
+					s = strings.Replace(s, "}}", "", -1)
+					vars = append(vars, s)
+				}
+			}
+		}
+
+	}
+	return vars, extractedVars, nil
+}
+
+func (v *Venom) runTestCase(ts *TestSuite, tc *TestCase, l Logger) {
+	tcc, err := v.initTestCaseContext(ts, tc)
+	if err != nil {
 		tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(err.Error())})
 		return
 	}
@@ -30,23 +119,22 @@ func runTestCase(ts *TestSuite, tc *TestCase, bars map[string]*pb.ProgressBar, l
 	l.Infof("start")
 
 	for _, stepIn := range tc.TestSteps {
-
 		step, erra := ts.Templater.ApplyOnStep(stepIn)
 		if erra != nil {
 			tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(erra.Error())})
 			break
 		}
 
-		e, err := WrapExecutor(step, tcc)
+		e, err := v.WrapExecutor(step, tcc)
 		if err != nil {
 			tc.Errors = append(tc.Errors, Failure{Value: RemoveNotPrintableChar(err.Error())})
 			break
 		}
 
-		RunTestStep(tcc, e, ts, tc, step, ts.Templater, l, detailsLevel)
+		v.RunTestStep(tcc, e, ts, tc, step, l)
 
-		if detailsLevel != DetailsLow {
-			bars[ts.Package].Increment()
+		if v.OutputDetails != DetailsLow {
+			v.outputProgressBar[ts.Package].Increment()
 		}
 		if len(tc.Failures) > 0 || len(tc.Errors) > 0 {
 			break

--- a/process_teststep.go
+++ b/process_teststep.go
@@ -4,28 +4,23 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 )
 
 //RunTestStep executes a venom testcase is a venom context
-func RunTestStep(tcc TestCaseContext, e *ExecutorWrap, ts *TestSuite, tc *TestCase, step TestStep, templater *Templater, l Logger, detailsLevel string) ExecutorResult {
-	var isOK bool
-	var errors []Failure
-	var failures []Failure
-	var systemerr, systemout string
+func (v *Venom) RunTestStep(tcc TestCaseContext, e *ExecutorWrap, ts *TestSuite, tc *TestCase, step TestStep, l Logger) ExecutorResult {
+	var assertRes assertionsApplied
 
 	var retry int
 	var result ExecutorResult
 
-	for retry = 0; retry <= e.retry && !isOK; retry++ {
-		if retry > 1 && !isOK {
-			log.Debugf("Sleep %d, it's %d attempt", e.delay, retry)
+	for retry = 0; retry <= e.retry && !assertRes.ok; retry++ {
+		if retry > 1 && !assertRes.ok {
+			l.Debugf("Sleep %d, it's %d attempt", e.delay, retry)
 			time.Sleep(time.Duration(e.delay) * time.Second)
 		}
 
 		var err error
-		result, err = runTestStepExecutor(tcc, e, ts, step, templater, l)
+		result, err = runTestStepExecutor(tcc, e, ts, step, l)
 
 		if err != nil {
 			tc.Failures = append(tc.Failures, Failure{Value: RemoveNotPrintableChar(err.Error())})
@@ -36,26 +31,26 @@ func RunTestStep(tcc TestCaseContext, e *ExecutorWrap, ts *TestSuite, tc *TestCa
 		ts.Templater.Add(tc.Name, stringifyExecutorResult(result))
 
 		if h, ok := e.executor.(executorWithDefaultAssertions); ok {
-			isOK, errors, failures, systemout, systemerr = applyChecks(&result, step, h.GetDefaultAssertions(), l)
+			assertRes = applyChecks(&result, step, h.GetDefaultAssertions(), l)
 		} else {
-			isOK, errors, failures, systemout, systemerr = applyChecks(&result, step, nil, l)
+			assertRes = applyChecks(&result, step, nil, l)
 		}
 		// add result again for extracts values
 		ts.Templater.Add(tc.Name, stringifyExecutorResult(result))
 
-		log.Debugf("result step:%+v", result)
+		l.Debugf("result step:%+v", result)
 
-		if isOK {
+		if assertRes.ok {
 			break
 		}
 	}
-	tc.Errors = append(tc.Errors, errors...)
-	tc.Failures = append(tc.Failures, failures...)
-	if retry > 1 && (len(failures) > 0 || len(errors) > 0) {
+	tc.Errors = append(tc.Errors, assertRes.errors...)
+	tc.Failures = append(tc.Failures, assertRes.failures...)
+	if retry > 1 && (len(assertRes.failures) > 0 || len(assertRes.errors) > 0) {
 		tc.Failures = append(tc.Failures, Failure{Value: fmt.Sprintf("It's a failure after %d attempts", retry)})
 	}
-	tc.Systemout.Value += systemout
-	tc.Systemerr.Value += systemerr
+	tc.Systemout.Value += assertRes.systemout
+	tc.Systemerr.Value += assertRes.systemerr
 
 	return result
 }
@@ -68,7 +63,7 @@ func stringifyExecutorResult(e ExecutorResult) map[string]string {
 	return out
 }
 
-func runTestStepExecutor(tcc TestCaseContext, e *ExecutorWrap, ts *TestSuite, step TestStep, templater *Templater, l Logger) (ExecutorResult, error) {
+func runTestStepExecutor(tcc TestCaseContext, e *ExecutorWrap, ts *TestSuite, step TestStep, l Logger) (ExecutorResult, error) {
 	if e.timeout == 0 {
 		return e.executor.Run(tcc, l, step)
 	}

--- a/tests/MyTestSuiteWithExtract.yml
+++ b/tests/MyTestSuiteWithExtract.yml
@@ -1,0 +1,16 @@
+name: MyTestSuite
+testcases:
+- name: testA
+  steps:
+  - type: exec
+    script: echo 'foo with a bar here'
+    extracts:
+      result.systemout: foo with a {{myvariable=[a-z]+}} here
+
+- name: testB
+  steps:
+  - type: exec
+    script: echo {{.testA.myvariable}}
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring bar

--- a/types.go
+++ b/types.go
@@ -72,6 +72,10 @@ type executorWithDefaultAssertions interface {
 	GetDefaultAssertions() *StepAssertions
 }
 
+type executorWithZeroValueResult interface {
+	ZeroValueResult() ExecutorResult
+}
+
 // Tests contains all informations about tests in a pipeline build
 type Tests struct {
 	XMLName      xml.Name    `xml:"testsuites" json:"-" yaml:"-"`

--- a/venom.go
+++ b/venom.go
@@ -1,17 +1,11 @@
 package venom
 
 import (
-	"bytes"
-	"encoding/json"
-	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
-	"time"
 
-	"github.com/mndrix/tap-go"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
 // Version of Venom
@@ -19,28 +13,55 @@ import (
 // Keep "const Version on one line"
 const Version = "0.16.0"
 
-// PrintFunc used by venom to print output
-var PrintFunc = fmt.Printf
+func New() *Venom {
+	v := &Venom{
+		LogLevel:             "info",
+		LogOutput:            os.Stdout,
+		OutputDetails:        "medium",
+		PrintFunc:            fmt.Printf,
+		executors:            map[string]Executor{},
+		contexts:             map[string]TestCaseContext{},
+		variables:            map[string]string{},
+		OutputFormat:         "xml",
+		OutputResume:         false,
+		OutputResumeFailures: false,
+	}
+	return v
+}
 
-var (
-	executors = map[string]Executor{}
-	contexts  = map[string]TestCaseContext{}
-)
+type Venom struct {
+	LogLevel  string
+	LogOutput io.Writer
 
-const (
-	// ContextKey is key for Test Case Context. this
-	// can be used by executors for getting context
-	ContextKey = "tcContext"
-)
+	PrintFunc func(format string, a ...interface{}) (n int, err error)
+	executors map[string]Executor
+	contexts  map[string]TestCaseContext
+
+	testsuites []TestSuite
+	variables  map[string]string
+
+	OutputDetails        string
+	outputProgressBar    map[string]*pb.ProgressBar
+	OutputFormat         string
+	OutputDir            string
+	OutputResume         bool
+	OutputResumeFailures bool
+}
+
+func (v *Venom) AddVariables(variables map[string]string) {
+	for k, variable := range variables {
+		v.variables[k] = variable
+	}
+}
 
 // RegisterExecutor register Test Executors
-func RegisterExecutor(name string, e Executor) {
-	executors[name] = e
+func (v *Venom) RegisterExecutor(name string, e Executor) {
+	v.executors[name] = e
 }
 
 // WrapExecutor initializes a test by name
 // no type -> exec is default
-func WrapExecutor(t map[string]interface{}, tcc TestCaseContext) (*ExecutorWrap, error) {
+func (v *Venom) WrapExecutor(t map[string]interface{}, tcc TestCaseContext) (*ExecutorWrap, error) {
 	var name string
 	var retry, delay, timeout int
 
@@ -67,7 +88,7 @@ func WrapExecutor(t map[string]interface{}, tcc TestCaseContext) (*ExecutorWrap,
 		return nil, errTimeout
 	}
 
-	if e, ok := executors[name]; ok {
+	if e, ok := v.executors[name]; ok {
 		ew := &ExecutorWrap{
 			executor: e,
 			retry:    retry,
@@ -81,15 +102,15 @@ func WrapExecutor(t map[string]interface{}, tcc TestCaseContext) (*ExecutorWrap,
 }
 
 // RegisterTestCaseContext new register TestCaseContext
-func RegisterTestCaseContext(name string, tcc TestCaseContext) {
-	contexts[name] = tcc
+func (v *Venom) RegisterTestCaseContext(name string, tcc TestCaseContext) {
+	v.contexts[name] = tcc
 }
 
 // ContextWrap initializes a context for a testcase
 // no type -> parent context
-func ContextWrap(tc *TestCase) (TestCaseContext, error) {
+func (v *Venom) ContextWrap(tc *TestCase) (TestCaseContext, error) {
 	if tc.Context == nil {
-		return contexts["default"], nil
+		return v.contexts["default"], nil
 	}
 	var typeName string
 	if itype, ok := tc.Context["type"]; ok {
@@ -97,10 +118,10 @@ func ContextWrap(tc *TestCase) (TestCaseContext, error) {
 	}
 
 	if typeName == "" {
-		return contexts["default"], nil
+		return v.contexts["default"], nil
 	}
-	contexts[typeName].SetTestCase(*tc)
-	return contexts[typeName], nil
+	v.contexts[typeName].SetTestCase(*tc)
+	return v.contexts[typeName], nil
 }
 
 func getAttrInt(t map[string]interface{}, name string) (int, error) {
@@ -116,136 +137,4 @@ func getAttrInt(t map[string]interface{}, name string) (int, error) {
 		out = 0
 	}
 	return out, nil
-}
-
-// Exit func display an error message on stderr and exit 1
-func Exit(format string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, args...)
-	os.Exit(1)
-}
-
-// OutputResult output result to sdtout, files...
-func OutputResult(format string, resume, resumeFailures bool, outputDir string, tests Tests, elapsed time.Duration, detailsLevel string) error {
-	var data []byte
-	var err error
-	switch format {
-	case "json":
-		data, err = json.MarshalIndent(tests, "", "  ")
-		if err != nil {
-			log.Fatalf("Error: cannot format output json (%s)", err)
-		}
-	case "tap":
-		data, err = outputTapFormat(tests)
-		if err != nil {
-			log.Fatalf("Error: cannot format output tap (%s)", err)
-		}
-	case "yml", "yaml":
-		data, err = yaml.Marshal(tests)
-		if err != nil {
-			log.Fatalf("Error: cannot format output yaml (%s)", err)
-		}
-	default:
-		dataxml, errm := xml.MarshalIndent(tests, "", "  ")
-		if errm != nil {
-			log.Fatalf("Error: cannot format xml output: %s", errm)
-		}
-		data = append([]byte(`<?xml version="1.0" encoding="utf-8"?>\n`), dataxml...)
-	}
-
-	if detailsLevel == "high" {
-		PrintFunc(string(data))
-	}
-
-	if resume {
-		outputResume(tests, elapsed, resumeFailures)
-	}
-
-	if outputDir != "" {
-		filename := outputDir + "/" + "test_results" + "." + format
-		if err := ioutil.WriteFile(filename, data, 0644); err != nil {
-			return fmt.Errorf("Error while creating file %s, err:%s", filename, err)
-		}
-	}
-	return nil
-}
-
-func outputTapFormat(tests Tests) ([]byte, error) {
-	t := tap.New()
-	buf := new(bytes.Buffer)
-	t.Writer = buf
-	t.Header(tests.Total)
-	for _, ts := range tests.TestSuites {
-		for _, tc := range ts.TestCases {
-			name := ts.Name + " / " + tc.Name
-			if len(tc.Skipped) > 0 {
-				t.Skip(1, name)
-				continue
-			}
-
-			if len(tc.Errors) > 0 {
-				t.Fail(name)
-				for _, e := range tc.Errors {
-					t.Diagnosticf("Error: %s", e.Value)
-				}
-				continue
-			}
-
-			if len(tc.Failures) > 0 {
-				t.Fail(name)
-				for _, e := range tc.Failures {
-					t.Diagnosticf("Failure: %s", e.Value)
-				}
-				continue
-			}
-
-			t.Pass(name)
-		}
-	}
-
-	return buf.Bytes(), nil
-}
-
-func outputResume(tests Tests, elapsed time.Duration, resumeFailures bool) {
-
-	if resumeFailures {
-		for _, t := range tests.TestSuites {
-			if t.Failures > 0 || t.Errors > 0 {
-				PrintFunc("FAILED %s\n", t.Name)
-				PrintFunc("--------------\n")
-
-				for _, tc := range t.TestCases {
-					for _, f := range tc.Failures {
-						PrintFunc("%s\n", f.Value)
-					}
-					for _, f := range tc.Errors {
-						PrintFunc("%s\n", f.Value)
-					}
-				}
-				PrintFunc("-=-=-=-=-=-=-=-=-\n")
-			}
-		}
-	}
-
-	totalTestCases := 0
-	totalTestSteps := 0
-	for _, t := range tests.TestSuites {
-		if t.Failures > 0 || t.Errors > 0 {
-			PrintFunc("FAILED %s\n", t.Name)
-		}
-		totalTestCases += len(t.TestCases)
-		for _, tc := range t.TestCases {
-			totalTestSteps += len(tc.TestSteps)
-		}
-	}
-
-	PrintFunc("Total:%d TotalOK:%d TotalKO:%d TotalSkipped:%d TotalTestSuite:%d TotalTestCase:%d TotalTestStep:%d Duration:%s\n",
-		tests.Total,
-		tests.TotalOK,
-		tests.TotalKO,
-		tests.TotalSkipped,
-		len(tests.TestSuites),
-		totalTestCases,
-		totalTestSteps,
-		elapsed,
-	)
 }

--- a/venom_output.go
+++ b/venom_output.go
@@ -1,0 +1,139 @@
+package venom
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	tap "github.com/mndrix/tap-go"
+	log "github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// OutputResult output result to sdtout, files...
+func (v *Venom) OutputResult(tests Tests, elapsed time.Duration) error {
+	var data []byte
+	var err error
+	switch v.OutputFormat {
+	case "json":
+		data, err = json.MarshalIndent(tests, "", "  ")
+		if err != nil {
+			log.Fatalf("Error: cannot format output json (%s)", err)
+		}
+	case "tap":
+		data, err = outputTapFormat(tests)
+		if err != nil {
+			log.Fatalf("Error: cannot format output tap (%s)", err)
+		}
+	case "yml", "yaml":
+		data, err = yaml.Marshal(tests)
+		if err != nil {
+			log.Fatalf("Error: cannot format output yaml (%s)", err)
+		}
+	default:
+		dataxml, errm := xml.MarshalIndent(tests, "", "  ")
+		if errm != nil {
+			log.Fatalf("Error: cannot format xml output: %s", errm)
+		}
+		data = append([]byte(`<?xml version="1.0" encoding="utf-8"?>\n`), dataxml...)
+	}
+
+	if v.OutputDetails == "high" {
+		v.PrintFunc(string(data))
+	}
+
+	if v.OutputResume {
+		v.outputResume(tests, elapsed)
+	}
+
+	if v.OutputDir != "" {
+		filename := v.OutputDir + "/" + "test_results" + "." + v.OutputFormat
+		if err := ioutil.WriteFile(filename, data, 0644); err != nil {
+			return fmt.Errorf("Error while creating file %s: %v", filename, err)
+		}
+	}
+	return nil
+}
+
+func outputTapFormat(tests Tests) ([]byte, error) {
+	t := tap.New()
+	buf := new(bytes.Buffer)
+	t.Writer = buf
+	t.Header(tests.Total)
+	for _, ts := range tests.TestSuites {
+		for _, tc := range ts.TestCases {
+			name := ts.Name + " / " + tc.Name
+			if len(tc.Skipped) > 0 {
+				t.Skip(1, name)
+				continue
+			}
+
+			if len(tc.Errors) > 0 {
+				t.Fail(name)
+				for _, e := range tc.Errors {
+					t.Diagnosticf("Error: %s", e.Value)
+				}
+				continue
+			}
+
+			if len(tc.Failures) > 0 {
+				t.Fail(name)
+				for _, e := range tc.Failures {
+					t.Diagnosticf("Failure: %s", e.Value)
+				}
+				continue
+			}
+
+			t.Pass(name)
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (v *Venom) outputResume(tests Tests, elapsed time.Duration) {
+	if v.OutputResumeFailures {
+		for _, t := range tests.TestSuites {
+			if t.Failures > 0 || t.Errors > 0 {
+				v.PrintFunc("FAILED %s\n", t.Name)
+				v.PrintFunc("--------------\n")
+
+				for _, tc := range t.TestCases {
+					for _, f := range tc.Failures {
+						v.PrintFunc("%s\n", f.Value)
+					}
+					for _, f := range tc.Errors {
+						v.PrintFunc("%s\n", f.Value)
+					}
+				}
+				v.PrintFunc("-=-=-=-=-=-=-=-=-\n\n")
+			}
+		}
+	}
+
+	totalTestCases := 0
+	totalTestSteps := 0
+	for _, t := range tests.TestSuites {
+		if t.Failures > 0 || t.Errors > 0 {
+			v.PrintFunc("FAILED %s\n", t.Name)
+		}
+		totalTestCases += len(t.TestCases)
+		for _, tc := range t.TestCases {
+			totalTestSteps += len(tc.TestSteps)
+		}
+	}
+
+	v.PrintFunc("Total:%d TotalOK:%d TotalKO:%d TotalSkipped:%d TotalTestSuite:%d TotalTestCase:%d TotalTestStep:%d Duration:%s\n",
+		tests.Total,
+		tests.TotalOK,
+		tests.TotalKO,
+		tests.TotalSkipped,
+		len(tests.TestSuites),
+		totalTestCases,
+		totalTestSteps,
+		elapsed,
+	)
+}


### PR DESCRIPTION
It includes a bit of refacto.

On venom.Process it parse all testsuites to find :
* variables usages
* all extracted variables (including default extractible variables in the executor result structure).

If a variable is used but it not extracted, not extractible and not set as `--var`. An error is raised

example: 
````
➜  tests git:(master) ✗ pwd
$GOPATH/src/github.com/ovh/venom/tests
➜  tests git:(master) ✗ venom run *.yml
FATA[0001] Missing variables [mysqlhost postgreshost]
➜  tests git:(master) ✗ venom run *.yml --var mysqlhost=localhost:5555
FATA[0001] Missing variables [postgreshost]
````