### PR TITLE
fix: no need to check err on os.stat

### DIFF
--- a/process_files.go
+++ b/process_files.go
@@ -30,10 +30,9 @@ func getFilesPath(path []string, exclude []string) ([]string, error) {
 	for _, p := range path {
 		p = strings.TrimSpace(p)
 
-		fileInfo, err := os.Stat(p)
-		if err != nil {
-			return nil, err
-		}
+		// no need to check err on os.stat.
+		// if we put ./test/*.yml, it will fail and it's normal
+		fileInfo, _ := os.Stat(p)
 
 		if fileInfo != nil && fileInfo.IsDir() {
 			p = p + string(os.PathSeparator) + "*.yml"
@@ -42,7 +41,7 @@ func getFilesPath(path []string, exclude []string) ([]string, error) {
 		fpaths, errg := filepath.Glob(p)
 		if errg != nil {
 			log.Errorf("Error reading files on path:%s :%s", path, errg)
-			return nil, err
+			return nil, errg
 		}
 		for _, fp := range fpaths {
 			toExclude := false


### PR DESCRIPTION
this will avoid that:

```
VENOM - try fo find var cds.build.cdsro in cds variables
VENOM - var cds.build.cdsro is found with value cds -w -f ~/.cds/it.ro.json
VENOM - try fo find var cds.build.cds in cds variables
VENOM - var cds.build.cds is found with value cds -w -f ~/.cds/it.rw.json
VENOM - try fo find var cds.build.cdsctl in cds variables
VENOM - var cds.build.cdsctl is found with value cdsctl
VENOM - Fail on venom: stat ./tests/*.yml: no such file or directory
Starting step /plugin-venom-7
Starting plugin: plugin-venom version 73
End of step /plugin-venom-7 [Fail]
```

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>