### PR TITLE
Update the output from `venom template` to match reality.

### DIFF
--- a/cli/venom/template/cmd.go
+++ b/cli/venom/template/cmd.go
@@ -41,7 +41,7 @@ func template() {
 					},
 					{
 						"script":     "echo 'bar'",
-						"assertions": []string{"result.stdout ShouldNotContainSubstring foo"},
+						"assertions": []string{"result.systemout ShouldNotContainSubstring foo"},
 					},
 				},
 			},


### PR DESCRIPTION
Without this fix, the sample template produced by `venom template` creates an error and creates a bad taste in someone's mouth who is new to `venom`.