### PR TITLE
Remove all references to `--parallel`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,18 @@ Usage:
   venom run [flags]
 
 Flags:
-      --details string        Output Details Level : low, medium, high (default "medium")
-      --env                   Inject environment variables. export FOO=BAR -> you can use {{.FOO}} in your tests (default true)
-      --exclude stringSlice   --exclude filaA.yaml --exclude filaB.yaml --exclude fileC*.yaml
-      --format string         --format:yaml, json, xml, tap (default "xml")
-      --log string            Log Level : debug, info or warn (default "warn")
-      --output-dir string     Output Directory: create tests results file inside this directory
-      --parallel int          --parallel=2 : launches 2 Test Suites in parallel (default 1)
-      --resume                Output Resume: one line with Total, TotalOK, TotalKO, TotalSkipped, TotalTestSuite (default true)
-      --resumeFailures        Output Resume Failures (default true)
-      --var stringSlice       --var cds='cds -f config.json' --var cds2='cds -f config.json'
-      --var-from-file         --var-from-file filename.yaml : yaml|json, must contains map[string]string
+      --details string         Output Details Level : low, medium, high (default "low")
+      --env                    Inject environment variables. export FOO=BAR -> you can use {{.FOO}} in your tests (default true)
+      --exclude stringSlice    --exclude filaA.yaml --exclude filaB.yaml --exclude fileC*.yaml
+      --format string          --format:yaml, json, xml, tap (default "xml")
+      --log string             Log Level : debug, info or warn (default "warn")
+      --no-check-variables     Don't check variables before run
+      --output-dir string      Output Directory: create tests results file inside this directory
+      --resume                 Output Resume: one line with Total, TotalOK, TotalKO, TotalSkipped, TotalTestSuite
+      --resumeFailures         Output Resume Failures
+      --strict                 Exit with an error code if one test fails
+      --var stringSlice        --var cds='cds -f config.json' --var cds2='cds -f config.json'
+      --var-from-file string   --var-from-file filename.yaml : yaml|json, must contains map[string]string'
 ```
 
 ## TestSuite files
@@ -136,7 +137,7 @@ testcases:
 
 ```bash
 cd $GOPATH/src/github.com/ovh/cds/tests
-venom run --var cdsro='cds -f $HOME/.cds/it.user.ro.json' --var cds='cds -f $HOME/.cds/it.user.rw.json' --parallel=5
+venom run --var cdsro='cds -f $HOME/.cds/it.user.ro.json' --var cds='cds -f $HOME/.cds/it.user.rw.json'
 ```
 
 ## RUN Venom with file var
@@ -149,7 +150,7 @@ cds: 'cds -f $HOME/.cds/it.user.rw.json'
 
 ```bash
 cd $GOPATH/src/github.com/ovh/cds/tests
-venom run --var-from-file vars.yaml --parallel=5
+venom run --var-from-file vars.yaml
 ```
 
 ## RUN Venom, with an export xUnit


### PR DESCRIPTION
I'm not sure where the references to `--parallel` came from, but
the functionality doesn't exist.

Discovered while trying to figure out how to group test cases and
then later discovered that the functionality is just outright missing.