### PR TITLE
Executor variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ type Result struct {
 	Command     string `json:"command,omitempty" yaml:"command,omitempty"`
 	Systemout   string   `json:"systemout,omitempty" yaml:"systemout,omitempty"` // put in testcase.Systemout by venom if present
 	Systemerr   string   `json:"systemerr,omitempty" yaml:"systemerr,omitempty"` // put in testcase.Systemerr by venom if present
-	Executor    Executor `json:"executor,omitempty" yaml:"executor,omitempty"`  
+	Executor    Executor `json:"executor,omitempty" yaml:"executor,omitempty"`
 }
 
 // GetDefaultAssertions return default assertions for this executor

--- a/README.md
+++ b/README.md
@@ -275,12 +275,12 @@ func (Executor) GetDefaultAssertions() venom.StepAssertions {
 func (Executor) Run(ctx context.Context, l venom.Logger, step venom.TestStep) (venom.ExecutorResult, error) {
 
 	// transform step to Executor Instance
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
 
-	// to something with t.Command here...
+	// to something with e.Command here...
 	//...
 
 	systemout := "foo"
@@ -289,9 +289,9 @@ func (Executor) Run(ctx context.Context, l venom.Logger, step venom.TestStep) (v
 	// prepare result
 	r := Result{
 		Code:    ouputCode, // return Output Code
-		Command: t.Command, // return Command executed
+		Command: e.Command, // return Command executed
 		Systemout:  systemout,    // return Output string
-		Executor: t, // return executor, useful for display Executor context in failure
+		Executor: e, // return executor, useful for display Executor context in failure
 	}
 
 	return dump.ToMap(r)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ venom run  --details=low --format=xml --output-dir="."
 
 ## Executors
 
+* **dbfixtures**: https://github.com/ovh/venom/tree/master/executors/dbfixtures
 * **exec**: https://github.com/ovh/venom/tree/master/executors/exec `exec` is the default type for a step
 * **http**: https://github.com/ovh/venom/tree/master/executors/http
 * **imap**: https://github.com/ovh/venom/tree/master/executors/imap
@@ -167,7 +168,6 @@ venom run  --details=low --format=xml --output-dir="."
 * **smtp**: https://github.com/ovh/venom/tree/master/executors/smtp
 * **ssh**: https://github.com/ovh/venom/tree/master/executors/ssh
 * **web**: https://github.com/ovh/venom/tree/master/executors/web
-* **dbfixtures**: https://github.com/ovh/venom/tree/master/executors/dbfixtures
 
 
 ## Assertion

--- a/executors/exec/executor.go
+++ b/executors/exec/executor.go
@@ -57,16 +57,16 @@ func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 // Run execute TestStep of type exec
 func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step venom.TestStep) (venom.ExecutorResult, error) {
 
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
 
-	if t.Script == "" {
+	if e.Script == "" {
 		return nil, fmt.Errorf("Invalid command")
 	}
 
-	scriptContent := t.Script
+	scriptContent := e.Script
 
 	// Default shell is sh
 	shell := "/bin/sh"
@@ -145,7 +145,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	stdoutreader := bufio.NewReader(stdout)
 	stderrreader := bufio.NewReader(stderr)
 
-	result := Result{Executor: t}
+	result := Result{Executor: e}
 	outchan := make(chan bool)
 	go func() {
 		for {
@@ -178,7 +178,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 		result.Err = err.Error()
 		result.Code = "127"
 		l.Debugf(err.Error())
-		return dump.ToMap(t, nil, dump.WithDefaultLowerCaseFormatter())
+		return dump.ToMap(e, nil, dump.WithDefaultLowerCaseFormatter())
 	}
 
 	_ = <-outchan

--- a/executors/http/executor.go
+++ b/executors/http/executor.go
@@ -79,27 +79,27 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	}()
 
 	// transform step to Executor Instance
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
 
 	// dirty: mapstructure doesn't like decoding map[interface{}]interface{}, let's force manually
-	t.MultipartForm = step["multipart_form"]
+	e.MultipartForm = step["multipart_form"]
 
-	r := Result{Executor: t}
+	r := Result{Executor: e}
 
-	req, err := t.getRequest()
+	req, err := e.getRequest()
 	if err != nil {
 		return nil, err
 	}
 
-	for k, v := range t.Headers {
+	for k, v := range e.Headers {
 		req.Header.Set(k, v)
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: t.IgnoreVerifySSL},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: e.IgnoreVerifySSL},
 	}
 	client := &http.Client{Transport: tr}
 
@@ -118,7 +118,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	if resp.Body != nil {
 		defer resp.Body.Close()
 
-		if !t.SkipBody {
+		if !e.SkipBody {
 			var errr error
 			bb, errr = ioutil.ReadAll(resp.Body)
 			if errr != nil {
@@ -138,7 +138,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 		}
 	}
 
-	if !t.SkipHeaders {
+	if !e.SkipHeaders {
 		r.Headers = make(map[string]string)
 		for k, v := range resp.Header {
 			r.Headers[k] = v[0]

--- a/executors/imap/executor.go
+++ b/executors/imap/executor.go
@@ -70,15 +70,15 @@ func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 
 // Run execute TestStep of type exec
 func (Executor) Run(ctx venom.TestCaseContext, l venom.Logger, step venom.TestStep) (venom.ExecutorResult, error) {
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
 
 	start := time.Now()
 
-	result := Result{Executor: t}
-	find, errs := t.getMail(l)
+	result := Result{Executor: e}
+	find, errs := e.getMail(l)
 	if errs != nil {
 		result.Err = errs.Error()
 	}

--- a/executors/ovhapi/executor.go
+++ b/executors/ovhapi/executor.go
@@ -67,8 +67,8 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	}
 
 	// transform step to Executor Instance
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
 
@@ -78,7 +78,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	if endpoint, err = ctx.GetString("endpoint"); err != nil {
 		return nil, err
 	}
-	if !t.NoAuth {
+	if !e.NoAuth {
 		if applicationKey, err = ctx.GetString("applicationKey"); err != nil {
 			return nil, err
 		}
@@ -91,12 +91,12 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	}
 
 	// set default values
-	if t.Method == "" {
-		t.Method = "GET"
+	if e.Method == "" {
+		e.Method = "GET"
 	}
 
 	// init result
-	r := Result{Executor: t}
+	r := Result{Executor: e}
 
 	start := time.Now()
 	// prepare ovh api client
@@ -111,7 +111,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	}
 
 	// get request body from file or from field
-	requestBody, err := t.getRequestBody()
+	requestBody, err := e.getRequestBody()
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	// do api call
 	resp := new(interface{})
 
-	if err = client.CallAPI(t.Method, t.Path, requestBody, resp, !t.NoAuth); err != nil {
+	if err = client.CallAPI(e.Method, e.Path, requestBody, resp, !e.NoAuth); err != nil {
 		apiError, ok := err.(*ovh.APIError)
 		if !ok {
 			return nil, err

--- a/executors/readfile/executor.go
+++ b/executors/readfile/executor.go
@@ -59,18 +59,18 @@ func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 // Run execute TestStep of type exec
 func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step venom.TestStep) (venom.ExecutorResult, error) {
 
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
 
-	if t.Path == "" {
+	if e.Path == "" {
 		return nil, fmt.Errorf("Invalid path")
 	}
 
 	start := time.Now()
 
-	result, errr := t.readfile(t.Path)
+	result, errr := e.readfile(e.Path)
 	if errr != nil {
 		result.Err = errr.Error()
 	}

--- a/executors/smtp/executor.go
+++ b/executors/smtp/executor.go
@@ -56,15 +56,15 @@ func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 
 // Run execute TestStep of type exec
 func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step venom.TestStep) (venom.ExecutorResult, error) {
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
 
 	start := time.Now()
 
-	result := Result{Executor: t}
-	errs := t.sendEmail(l)
+	result := Result{Executor: e}
+	errs := e.sendEmail(l)
 	if errs != nil {
 		result.Err = errs.Error()
 	}

--- a/executors/ssh/executor.go
+++ b/executors/ssh/executor.go
@@ -57,19 +57,19 @@ func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 
 // Run execute TestStep of type exec
 func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step venom.TestStep) (venom.ExecutorResult, error) {
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
 
-	if t.Command == "" {
+	if e.Command == "" {
 		return nil, fmt.Errorf("Invalid command")
 	}
 
 	start := time.Now()
-	result := Result{Executor: t}
+	result := Result{Executor: e}
 
-	client, session, err := connectToHost(t.User, t.Password, t.PrivateKey, t.Host)
+	client, session, err := connectToHost(e.User, e.Password, e.PrivateKey, e.Host)
 	if err != nil {
 		result.Err = err.Error()
 	} else {
@@ -79,7 +79,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 
 		session.Stderr = stderr
 		session.Stdout = stdout
-		if err := session.Run(t.Command); err != nil {
+		if err := session.Run(e.Command); err != nil {
 			if exiterr, ok := err.(*ssh.ExitError); ok {
 				status := exiterr.ExitStatus()
 				result.Code = strconv.Itoa(status)

--- a/executors/web/web.go
+++ b/executors/web/web.go
@@ -57,26 +57,26 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	start := time.Now()
 
 	// transform step to Executor Instance
-	var t Executor
-	if err := mapstructure.Decode(step, &t); err != nil {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
-	r := &Result{Executor: t}
+	r := &Result{Executor: e}
 
 	// Check action to realise
-	if t.Action.Click != nil {
-		s, err := find(ctx.Page, t.Action.Click.Find, r)
+	if e.Action.Click != nil {
+		s, err := find(ctx.Page, e.Action.Click.Find, r)
 		if err != nil {
 			return nil, err
 		}
 		if err := s.Click(); err != nil {
 			return nil, err
 		}
-		if t.Action.Click.Wait != 0 {
-			time.Sleep(time.Duration(t.Action.Click.Wait) * time.Second)
+		if e.Action.Click.Wait != 0 {
+			time.Sleep(time.Duration(e.Action.Click.Wait) * time.Second)
 		}
-	} else if t.Action.Fill != nil {
-		for _, f := range t.Action.Fill {
+	} else if e.Action.Fill != nil {
+		for _, f := range e.Action.Fill {
 			s, err := findOne(ctx.Page, f.Find, r)
 			if err != nil {
 				return nil, err
@@ -91,30 +91,30 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 			}
 		}
 
-	} else if t.Action.Find != "" {
-		_, err := find(ctx.Page, t.Action.Find, r)
+	} else if e.Action.Find != "" {
+		_, err := find(ctx.Page, e.Action.Find, r)
 		if err != nil {
 			return nil, err
 		}
-	} else if t.Action.Navigate != nil {
-		if err := ctx.Page.Navigate(t.Action.Navigate.Url); err != nil {
+	} else if e.Action.Navigate != nil {
+		if err := ctx.Page.Navigate(e.Action.Navigate.Url); err != nil {
 			return nil, err
 		}
-		if t.Action.Navigate.Reset {
+		if e.Action.Navigate.Reset {
 			if err := ctx.Page.Reset(); err != nil {
 				return nil, err
 			}
-			if err := ctx.Page.Navigate(t.Action.Navigate.Url); err != nil {
+			if err := ctx.Page.Navigate(e.Action.Navigate.Url); err != nil {
 				return nil, err
 			}
 		}
-	} else if t.Action.Wait != 0 {
-		time.Sleep(time.Duration(t.Action.Wait) * time.Second)
+	} else if e.Action.Wait != 0 {
+		time.Sleep(time.Duration(e.Action.Wait) * time.Second)
 	}
 
 	// take a screenshot
-	if t.Screenshot != "" {
-		if err := ctx.Page.Screenshot(t.Screenshot); err != nil {
+	if e.Screenshot != "" {
+		if err := ctx.Page.Screenshot(e.Screenshot); err != nil {
 			return nil, err
 		}
 	}

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -68,6 +68,7 @@ func (l *Logger) WithField(key string, value interface{}) venom.Logger {
 //TestCase instanciates a veom testcase
 func TestCase(t *testing.T, name string, variables map[string]string) *T {
 	v := venom.New()
+	v.RegisterExecutor(dbfixtures.Name, dbfixtures.New())
 	v.RegisterExecutor(exec.Name, exec.New())
 	v.RegisterExecutor(http.Name, http.New())
 	v.RegisterExecutor(imap.Name, imap.New())
@@ -75,7 +76,6 @@ func TestCase(t *testing.T, name string, variables map[string]string) *T {
 	v.RegisterExecutor(smtp.Name, smtp.New())
 	v.RegisterExecutor(ssh.Name, ssh.New())
 	v.RegisterExecutor(web.Name, web.New())
-	v.RegisterExecutor(dbfixtures.Name, dbfixtures.New())
 	v.RegisterTestCaseContext(defaultctx.Name, defaultctx.New())
 	v.RegisterTestCaseContext(webctx.Name, webctx.New())
 

--- a/process_files.go
+++ b/process_files.go
@@ -29,7 +29,7 @@ func getFilesPath(path []string, exclude []string) ([]string, error) {
 
 	for _, p := range path {
 		p = strings.TrimSpace(p)
-		
+
 		// no need to check err on os.stat.
 		// if we put ./test/*.yml, it will fail and it's normal
 		fileInfo, _ := os.Stat(p)

--- a/types.go
+++ b/types.go
@@ -49,13 +49,13 @@ type CommonTestCaseContext struct {
 }
 
 // SetTestCase set testcase in context
-func (t *CommonTestCaseContext) SetTestCase(tc TestCase) {
-	t.TestCase = tc
+func (tcc *CommonTestCaseContext) SetTestCase(tc TestCase) {
+	tcc.TestCase = tc
 }
 
 // GetName Get the context name
-func (t *CommonTestCaseContext) GetName() string {
-	return t.Name
+func (tcc *CommonTestCaseContext) GetName() string {
+	return tcc.Name
 }
 
 // ExecutorWrap contains an executor implementation and some attributes

--- a/venom_output.go
+++ b/venom_output.go
@@ -59,35 +59,35 @@ func (v *Venom) OutputResult(tests Tests, elapsed time.Duration) error {
 }
 
 func outputTapFormat(tests Tests) ([]byte, error) {
-	t := tap.New()
+	tapValue := tap.New()
 	buf := new(bytes.Buffer)
-	t.Writer = buf
-	t.Header(tests.Total)
+	tapValue.Writer = buf
+	tapValue.Header(tests.Total)
 	for _, ts := range tests.TestSuites {
 		for _, tc := range ts.TestCases {
 			name := ts.Name + " / " + tc.Name
 			if len(tc.Skipped) > 0 {
-				t.Skip(1, name)
+				tapValue.Skip(1, name)
 				continue
 			}
 
 			if len(tc.Errors) > 0 {
-				t.Fail(name)
+				tapValue.Fail(name)
 				for _, e := range tc.Errors {
-					t.Diagnosticf("Error: %s", e.Value)
+					tapValue.Diagnosticf("Error: %s", e.Value)
 				}
 				continue
 			}
 
 			if len(tc.Failures) > 0 {
-				t.Fail(name)
+				tapValue.Fail(name)
 				for _, e := range tc.Failures {
-					t.Diagnosticf("Failure: %s", e.Value)
+					tapValue.Diagnosticf("Failure: %s", e.Value)
 				}
 				continue
 			}
 
-			t.Pass(name)
+			tapValue.Pass(name)
 		}
 	}
 


### PR DESCRIPTION
This is a trivial PR centered around the use of `go-rename` at various places.


Clean up various variable names, notably freeing `t` from overloaded use.

`t`'s overloaded use included:

* `testing.T`
* `TestSuite`
* `Executor`
* `tap.Tap`

Give each their own distinct meaning, leaving `t` for `testing.T` as
this is the idiomatic way `t` is used.  Renames performed using `go-rename(1)`.

There is also a tiny amount of whitespace and alpha-sorting that felt like small repo churn and was included in this PR as separate commits.  The aim of this PR is to improve code readability.