### PR TITLE
Add a flag to stop running TestSuite on TestCase failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Flags:
       --parallel int          --parallel=2 : launches 2 Test Suites in parallel (default 1)
       --resume                Output Resume: one line with Total, TotalOK, TotalKO, TotalSkipped, TotalTestSuite (default true)
       --resumeFailures        Output Resume Failures (default true)
+      --stop-on-failure       Stop running Test Suite on first Test Case failure
       --var stringSlice       --var cds='cds -f config.json' --var cds2='cds -f config.json'
       --var-from-file         --var-from-file filename.yaml : yaml|json, must contains map[string]string
 ```

--- a/cli/venom/run/cmd.go
+++ b/cli/venom/run/cmd.go
@@ -46,6 +46,7 @@ var (
 	strict         bool
 	noCheckVars    bool
 	parallel       int
+	stopOnFailure  bool
 	v              *venom.Venom
 )
 
@@ -56,6 +57,7 @@ func init() {
 	Cmd.Flags().StringVarP(&format, "format", "", "xml", "--format:yaml, json, xml, tap")
 	Cmd.Flags().BoolVarP(&withEnv, "env", "", true, "Inject environment variables. export FOO=BAR -> you can use {{.FOO}} in your tests")
 	Cmd.Flags().BoolVarP(&strict, "strict", "", false, "Exit with an error code if one test fails")
+	Cmd.Flags().BoolVarP(&stopOnFailure, "stop-on-failure", "", false, "Stop running Test Suite on first Test Case failure")
 	Cmd.Flags().BoolVarP(&noCheckVars, "no-check-variables", "", false, "Don't check variables before run")
 	Cmd.Flags().IntVarP(&parallel, "parallel", "", 1, "--parallel=2 : launches 2 Test Suites in parallel")
 	Cmd.PersistentFlags().StringVarP(&logLevel, "log", "", "warn", "Log Level : debug, info or warn")
@@ -104,6 +106,7 @@ var Cmd = &cobra.Command{
 		v.OutputResume = resume
 		v.OutputResumeFailures = resumeFailures
 		v.Parallel = parallel
+		v.StopOnFailure = stopOnFailure
 
 		mapvars := make(map[string]string)
 		if withEnv {

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -63,6 +63,11 @@ func (v *Venom) runTestCases(ts *TestSuite, l Logger) {
 		if len(tc.Skipped) > 0 {
 			ts.Skipped += len(tc.Skipped)
 		}
+
+		if v.StopOnFailure && (len(tc.Failures) > 0 || len(tc.Errors) > 0) {
+			// break TestSuite
+			return
+		}
 	}
 }
 

--- a/venom.go
+++ b/venom.go
@@ -49,6 +49,7 @@ type Venom struct {
 	OutputDir            string
 	OutputResume         bool
 	OutputResumeFailures bool
+	StopOnFailure        bool
 }
 
 func (v *Venom) AddVariables(variables map[string]string) {


### PR DESCRIPTION
This allows running tests as usual, but will stop a TestSuite at the
first TestCase failure.
This makes sense in case there are dependencies between TestCases, eg.
the first TestCase creates a resource on a REST API, and following
TestCases are doing some stuff with this resource.

I tested it locally (with and without the new flag), but did not find a
proper place in the repository to add unit tests for that feature.