### PR TITLE
Capture exec outputs with no line break

### DIFF
--- a/executors/exec/executor.go
+++ b/executors/exec/executor.go
@@ -154,6 +154,9 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 		for {
 			line, errs := stdoutreader.ReadString('\n')
 			if errs != nil {
+				// ReadString returns what has been read even though an error was encoutered
+				// ie. capture outputs with no '\n' at the end
+				result.Systemout += line
 				stdout.Close()
 				close(outchan)
 				return
@@ -168,6 +171,9 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 		for {
 			line, errs := stderrreader.ReadString('\n')
 			if errs != nil {
+				// ReadString returns what has been read even though an error was encoutered
+				// ie. capture outputs with no '\n' at the end
+				result.Systemerr += line
 				stderr.Close()
 				close(errchan)
 				return


### PR DESCRIPTION
This should solve issue #140.

When a script outputs something with no '\n' at the end, the executor
did not capture the output. Golang `ReadString` documentation specifies
that it's safe to use the read string even if an error occured (that's
rather unusual in Go...):

    ```
    ReadString reads until the first occurrence of delim in the input,
    returning a string containing the data up to and including the
    delimiter. If ReadString encounters an error before finding a
    delimiter, it returns the data read before the error and the error
    itself (often io.EOF). ReadString returns err != nil if and only if
    the returned data does not end in delim. For simple uses, a Scanner
    may be more convenient.
    ```