### PR TITLE
Document bodyjson keys being lowercase

### DIFF
--- a/executors/http/README.md
+++ b/executors/http/README.md
@@ -77,7 +77,7 @@ result.error
 - result.executor.executor.multipartform: multipartform if exists
 - result.err: if exists, this field contains error
 - result.body: body of HTTP response
-- result.bodyjson: body of HTTP response if it's a json. You can access json data as result.bodyjson.yourkey for example
+- result.bodyjson: body of HTTP response if it's a json. You can access json data as result.bodyjson.yourkey for example. Note that json keys are lowercased automatically (eg. use result.bodyjson.yourkey, not result.bodyjson.YourKey)
 - result.headers: headers of HTTP response
 - result.statuscode: Status Code of HTTP response
 


### PR DESCRIPTION
This bugged me for a while, so it's probably worth it adding it to the
README file.