### PR TITLE
fix: join workdir path with migration folder too in DBFixtures executor.

### DIFF
--- a/executors/dbfixtures/executor.go
+++ b/executors/dbfixtures/executor.go
@@ -77,8 +77,9 @@ func (e Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, ste
 	} else if e.Migrations != "" {
 		l.Debugf("loading migrations from folder %s\n", e.Migrations)
 
+		dir := path.Join(workdir, e.Migrations)
 		migrations := &migrate.FileMigrationSource{
-			Dir: e.Migrations,
+			Dir: dir,
 		}
 		n, errMigrate := migrate.Exec(db, e.Database, migrations, migrate.Up)
 		if errMigrate != nil {


### PR DESCRIPTION
The `DBFixtures` executor can use an array of paths to schema files, or can use the path to a folder containing all migrations to apply. In his PR https://github.com/ovh/venom/pull/145, @marcaudefroy forgot to join the workdir of the migration folder path, which lead to issues with testsuites in version 2 using relative paths.