### PR TITLE
executors/imap: return an error when one of the Headers cannot be decoded

### DIFF
--- a/executors/imap/decode.go
+++ b/executors/imap/decode.go
@@ -12,7 +12,6 @@ import (
 	"mime/quotedprintable"
 	"net/mail"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/yesnault/go-imap/imap"
 
 	"github.com/ovh/venom"
@@ -22,7 +21,7 @@ func decodeHeader(msg *mail.Message, headerName string) (string, error) {
 	dec := new(mime.WordDecoder)
 	s, err := dec.DecodeHeader(msg.Header.Get(headerName))
 	if err != nil {
-		return msg.Header.Get(headerName), fmt.Errorf("Error while decode header %s:%s", headerName, msg.Header.Get(headerName))
+		return msg.Header.Get(headerName), err
 	}
 	return s, nil
 }
@@ -46,18 +45,15 @@ func extract(rsp imap.Response, l venom.Logger) (*Mail, error) {
 	}
 	tm.Subject, err = decodeHeader(mmsg, "Subject")
 	if err != nil {
-		log.Warnf("Cannot decode Subject header: %s", err)
-		return nil, nil
+		return nil, fmt.Errorf("Cannot decode Subject header: %s", err)
 	}
 	tm.From, err = decodeHeader(mmsg, "From")
 	if err != nil {
-		log.Warnf("Cannot decode From header: %s", err)
-		return nil, nil
+		return nil, fmt.Errorf("Cannot decode From header: %s", err)
 	}
 	tm.To, err = decodeHeader(mmsg, "To")
 	if err != nil {
-		log.Warnf("Cannot decode To header: %s", err)
-		return nil, nil
+		return nil, fmt.Errorf("Cannot decode To header: %s", err)
 	}
 
 	encoding := mmsg.Header.Get("Content-Transfer-Encoding")

--- a/executors/imap/executor.go
+++ b/executors/imap/executor.go
@@ -138,7 +138,8 @@ func (e *Executor) getMail(l venom.Logger) (*Mail, error) {
 	for _, msg := range messages {
 		m, erre := extract(msg, l)
 		if erre != nil {
-			return nil, erre
+			l.Warnf("Cannot extract the content of the mail: %s", erre)
+			continue
 		}
 
 		found, errs := e.isSearched(m)


### PR DESCRIPTION
If one of the `Subject`, `From`, `To` headers cannot be decode properly, we should return an error and leave the choice to the calling function to decide what to do about it. The `extract` has no knowledge about the search filters that will be used to filter the mails anyway.