### PR TITLE
fix(executor/imap): add flag InsecureSkipVerify

### DIFF
--- a/executors/imap/README.md
+++ b/executors/imap/README.md
@@ -22,7 +22,7 @@ testcases:
     searchsubject: 'Title of mail with *'
     searchbody: '.*a body content.*'
     assertions:
-    - result.err ShouldNotExist
+    - result.err ShouldNotBeEmpty
 ```
 
 * imaphost: imap host
@@ -35,6 +35,7 @@ testcases:
 * searchbody: optional
 * mbox: optional, default is INBOX
 * mboxonsuccess: optional. If not empty, move found mail (matching criteria) to another mbox.
+* insecureSkipVerify, default false
 
 Input must contain at least one of searchfrom, searchto, searchsubject or searchbody.
 
@@ -47,5 +48,5 @@ Input must contain at least one of searchfrom, searchto, searchsubject or search
 ## Default assertion
 
 ```yaml
-result.err ShouldNotExist
+result.err ShouldNotBeEmpty
 ```

--- a/executors/imap/decode.go
+++ b/executors/imap/decode.go
@@ -68,8 +68,9 @@ func extract(rsp imap.Response) (*Mail, error) {
 	executor.Debugf("Mail Content-Transfer-Encoding is %s ", encoding)
 
 	contentType, params, err := mime.ParseMediaType(mmsg.Header.Get("Content-Type"))
+	// it's not a problem if there is an error on decoding content-type here
 	if err != nil {
-		return nil, fmt.Errorf("Error while reading Content-Type:%s", err)
+		executor.Debugf("error while reading Content-Type:%s - ignoring this error", err)
 	}
 	if contentType == "multipart/mixed" || contentType == "multipart/alternative" {
 		if boundary, ok := params["boundary"]; ok {


### PR DESCRIPTION
and ignore error on content-type, it's possible to not be able to decode this field, even with a real imap srv

the default assertion move to ShouldNotBeEmpty, the key err was already here (we don't see this behaviour with a real assertion)

Signed-off-by: Yvonnick Esnault <yvonnick@esnau.lt>