### PR TITLE
executor/grpc: Fix documentation and configuration

### DIFF
--- a/executors/grpc/README.md
+++ b/executors/grpc/README.md
@@ -27,6 +27,8 @@ In your yaml file, you can use:
   - data optional: data to marshal to json and send as a request
   - headers optional: data to send as additional headers
   - connect_timeout optional: The maximum time, in seconds, to wait for connection to be established. Defaults to 10 seconds.
+  - default_fields optional: whether json formatter should emit default fields
+  - include_text_separator optional: when protobuf string formatter is invoked to format multiple messages, all messages after the first one will be prefixed with character (0x1E).
 ```
 
 Example:
@@ -49,18 +51,6 @@ testcases:
     - result.code ShouldEqual 0
     - result.bodyjson.foo ShouldEqual bar
 
-```
-
-Multiline script:
-
-```yaml
-name: Title of TestSuite
-testcases:
-- name: multiline script
-  steps:
-  - script: |
-            echo "Foo" \
-            echo "Bar"
 ```
 
 ## Output

--- a/executors/grpc/executor.go
+++ b/executors/grpc/executor.go
@@ -37,8 +37,8 @@ type Executor struct {
 	Service              string                 `json:"service" yaml:"service"`
 	Method               string                 `json:"method" yaml:"method"`
 	Plaintext            bool                   `json:"plaintext,omitempty" yaml:"plaintext,omitempty"`
-	JsonDefaultFields    bool                   `json:"default_field" yaml:"default_field"`
-	IncludeTextSeparator bool                   `json:"include_test_separator" yaml:"include_test_separator"`
+	JsonDefaultFields    bool                   `json:"default_fields" yaml:"default_fields"`
+	IncludeTextSeparator bool                   `json:"include_text_separator" yaml:"include_text_separator"`
 	Data                 map[string]interface{} `json:"data" yaml:"data"`
 	Headers              map[string]string      `json:"headers" yaml:"headers"`
 	ConnectTimeout       *int64                 `json:"connect_timeout" yaml:"connect_timeout"`


### PR DESCRIPTION
Fix documentation for gRPC executor missing some available
configuration and also accidentally copied text from README of other
executor.

Fix decoding names of configuration fields.