### PR TITLE
Add system to save the html when an error occurred during the element selection

### DIFF
--- a/executors/web/web.go
+++ b/executors/web/web.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 	"time"
 
@@ -67,7 +68,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 
 	// Check action to realise
 	if e.Action.Click != nil {
-		s, err := find(ctx.Page, e.Action.Click.Find, r)
+		s, err := find(testCaseContext, ctx.Page, e.Action.Click.Find, r)
 		if err != nil {
 			return nil, err
 		}
@@ -79,7 +80,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 		}
 	} else if e.Action.Fill != nil {
 		for _, f := range e.Action.Fill {
-			s, err := findOne(ctx.Page, f.Find, r)
+			s, err := findOne(testCaseContext, ctx.Page, f.Find, r)
 			if err != nil {
 				return nil, err
 			}
@@ -93,7 +94,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 			}
 		}
 	} else if e.Action.Find != "" {
-		s, err := find(ctx.Page, e.Action.Find, r)
+		s, err := find(testCaseContext, ctx.Page, e.Action.Find, r)
 		if err != nil {
 			return nil, err
 		} else if s != nil {
@@ -135,7 +136,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 			}
 		}
 	} else if e.Action.Select != nil {
-		s, err := findOne(ctx.Page, e.Action.Select.Find, r)
+		s, err := findOne(testCaseContext, ctx.Page, e.Action.Select.Find, r)
 		if err != nil {
 			return nil, err
 		}
@@ -146,7 +147,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 			time.Sleep(time.Duration(e.Action.Select.Wait) * time.Second)
 		}
 	} else if e.Action.UploadFile != nil {
-		s, err := find(ctx.Page, e.Action.UploadFile.Find, r)
+		s, err := find(testCaseContext, ctx.Page, e.Action.UploadFile.Find, r)
 		if err != nil {
 			return nil, err
 		}
@@ -159,7 +160,7 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 			time.Sleep(time.Duration(e.Action.UploadFile.Wait) * time.Second)
 		}
 	} else if e.Action.SelectFrame != nil {
-		s, err := findOne(ctx.Page, e.Action.SelectFrame.Find, r)
+		s, err := findOne(testCaseContext, ctx.Page, e.Action.SelectFrame.Find, r)
 		if err != nil {
 			return nil, err
 		}
@@ -212,13 +213,15 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	return executors.Dump(r)
 }
 
-func find(page *agouti.Page, search string, r *Result) (*agouti.Selection, error) {
+func find(testCaseContext venom.TestCaseContext, page *agouti.Page, search string, r *Result) (*agouti.Selection, error) {
 	s := page.Find(search)
 	if s == nil {
+		generateHtmlFile(testCaseContext, page)
 		return nil, fmt.Errorf("Cannot find element %s", search)
 	}
 	nbElement, errC := s.Count()
 	if errC != nil {
+		generateHtmlFile(testCaseContext, page)
 		if !strings.Contains(errC.Error(), "element not found") {
 			return nil, fmt.Errorf("Cannot count element %s: %s", search, errC)
 		}
@@ -228,17 +231,31 @@ func find(page *agouti.Page, search string, r *Result) (*agouti.Selection, error
 	return s, nil
 }
 
-func findOne(page *agouti.Page, search string, r *Result) (*agouti.Selection, error) {
+func findOne(testCaseContext venom.TestCaseContext, page *agouti.Page, search string, r *Result) (*agouti.Selection, error) {
 	s := page.Find(search)
 	if s == nil {
+		generateHtmlFile(testCaseContext, page)
 		return nil, fmt.Errorf("Cannot find element %s", search)
 	}
 	nbElement, errC := s.Count()
 	if errC != nil {
+		generateHtmlFile(testCaseContext, page)
 		return nil, fmt.Errorf("Cannot find element %s: %s", search, errC)
 	}
 	if nbElement != 1 {
+		generateHtmlFile(testCaseContext, page)
 		return nil, fmt.Errorf("Find %d elements", nbElement)
 	}
 	return s, nil
+}
+
+// Generate an HTML file in error case to identify clearly the error
+func generateHtmlFile(context venom.TestCaseContext, page *agouti.Page) {
+	fmt.Printf("GenerateHtmlFile ...\n")
+	html, err := page.HTML()
+	if err == nil {
+		fileName := context.GetName() + ".html"
+		fmt.Printf("Error during an element selection, the content of the HTML page is saved in %s\n", fileName)
+		ioutil.WriteFile(fileName, []byte(html), 0644)
+	}
 }


### PR DESCRIPTION
In some case, it's complexe to understand why some web test failed, especially with phantomjs which not use the last version of javascript. This PR save the HTML of the  current page in a file if an error occurred during the element selection.