### PR TITLE
Fix (cli): don't iterate over empty varFiles

### DIFF
--- a/cli/venom/run/cmd.go
+++ b/cli/venom/run/cmd.go
@@ -141,6 +141,9 @@ var Cmd = &cobra.Command{
 		}
 
 		for _, f := range varFiles {
+			if f == "" {
+				continue
+			}
 			varFileMap := make(map[string]string)
 			bytes, err := ioutil.ReadFile(f)
 			if err != nil {


### PR DESCRIPTION
With current behaviour `for _, f := range varFiles {}` loop will try to open a file named `""` is no file names are given with `--var-from-file=`. 

This should skip it.