### PR TITLE
Save multiple set-cookie headers when returned by the server

### DIFF
--- a/executors/http/executor.go
+++ b/executors/http/executor.go
@@ -175,7 +175,11 @@ func (Executor) Run(testCaseContext venom.TestCaseContext, l venom.Logger, step 
 	if !e.SkipHeaders {
 		r.Headers = make(map[string]string)
 		for k, v := range resp.Header {
-			r.Headers[k] = v[0]
+			if strings.ToLower(k) == "set-cookie" {
+				r.Headers[k] = strings.Join(v[:], "; ")
+			} else {
+				r.Headers[k] = v[0]
+			}
 		}
 		l.Debugf("http.Response.Headers (%q)", r.Headers)
 	}


### PR DESCRIPTION
In case the server returns multiple set-cookie headers, only the first returned set-cookie is being saved in the response headers. The others set-cookies are discarded. This can make tests fail, in case we need to reuse a previous returned set-cookie as a new cookie on a following test.