### PR TITLE
Update link to Submitting-Patches on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,12 @@ pay attention to a few things:
 The contributions should be GitHub Pull Requests. The guidelines are the same
 as the patch submission for the Linux kernel except for the DCO which
 is defined below. The guidelines are defined in the
-'SubmittingPatches' file, available in the directory 'Documentation'
+'submitting-patches' file, available in the directory path 'Documentation/process'
 of the Linux kernel source tree.
 
 It can be accessed online too:
 
-https://www.kernel.org/doc/Documentation/SubmittingPatches
+https://www.kernel.org/doc/Documentation/process/submitting-patches.rst
 
 You can submit your patches via GitHub
 


### PR DESCRIPTION
The link https://www.kernel.org/doc/Documentation/SubmittingPatches has been moved to https://www.kernel.org/doc/Documentation/process/submitting-patches.rst