### PR TITLE
fix: don't ignore invalid yml files

### DIFF
--- a/process_files.go
+++ b/process_files.go
@@ -99,11 +99,7 @@ func (v *Venom) readFiles(filesPath []string) (err error) {
 			return fmt.Errorf("unsupported test suite file extension: %q", ext)
 		}
 		if err != nil {
-			if len(filesPath) == 1 {
-				return err
-			}
-			log.Infof("skipping invalid venom testsuite %s: %v", f, err)
-			continue
+			return fmt.Errorf("Error while unmarshal file %s err: %v", f, err)
 		}
 
 		ts.ShortName = ts.Name


### PR DESCRIPTION
Users have to filter the yml files given to venom if needed

close #234
close #235

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>