### PR TITLE
fix(executor/http): default assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ type Result struct {
 
 // GetDefaultAssertions return default assertions for this executor
 // Optional
-func (Executor) GetDefaultAssertions() venom.StepAssertions {
+func (Executor) GetDefaultAssertions() *venom.StepAssertions {
 	return venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}
 }
 

--- a/executors/http/executor.go
+++ b/executors/http/executor.go
@@ -71,9 +71,8 @@ func (Executor) ZeroValueResult() venom.ExecutorResult {
 }
 
 // GetDefaultAssertions return default assertions for this executor
-// Optional
-func (Executor) GetDefaultAssertions() venom.StepAssertions {
-	return venom.StepAssertions{Assertions: []string{"result.statuscode ShouldEqual 200"}}
+func (Executor) GetDefaultAssertions() *venom.StepAssertions {
+	return &venom.StepAssertions{Assertions: []string{"result.statuscode ShouldEqual 200"}}
 }
 
 // Run execute TestStep

--- a/executors/ovhapi/executor.go
+++ b/executors/ovhapi/executor.go
@@ -59,9 +59,8 @@ func (Executor) ZeroValueResult() venom.ExecutorResult {
 }
 
 // GetDefaultAssertions return default assertions for this executor
-// Optional
-func (Executor) GetDefaultAssertions() venom.StepAssertions {
-	return venom.StepAssertions{Assertions: []string{"result.statuscode ShouldEqual 200"}}
+func (Executor) GetDefaultAssertions() *venom.StepAssertions {
+	return &venom.StepAssertions{Assertions: []string{"result.statuscode ShouldEqual 200"}}
 }
 
 // Run execute TestStep

--- a/executors/rabbitmq/executor.go
+++ b/executors/rabbitmq/executor.go
@@ -78,8 +78,8 @@ func (Executor) ZeroValueResult() venom.ExecutorResult {
 }
 
 // GetDefaultAssertions return default assertions for type exec
-func (Executor) GetDefaultAssertions() venom.StepAssertions {
-	return venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}
+func (Executor) GetDefaultAssertions() *venom.StepAssertions {
+	return &venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}
 }
 
 // Run execute TestStep of type exec


### PR DESCRIPTION
executors rabbit/ovhapi fixed too

close #249

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>