### PR TITLE
Feat/makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,76 @@
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 2m
+
+  # modules-download-mode: vendor
+
+# all available settings of specific linters
+linters-settings:
+  exclude: vendor # skip vendor folder
+
+  errcheck:
+    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    check-type-assertions: true
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    check-blank: true
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 15
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 200
+  unused:
+    # treat code as a program (not a library) and report unused exported identifiers
+    check-exported: false
+  unparam:
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    check-exported: true
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns
+    max-func-lines: 60
+  prealloc:
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops
+    for-loops: false # Report preallocation suggestions on for loops
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - errcheck
+    - gocyclo
+    - structcheck
+    - varcheck
+    - ineffassign
+    - deadcode
+    - golint
+    - interfacer
+    - unconvert
+    - goconst
+    - gocyclo
+    - staticcheck
+    - unused
+    - gosimple
+    - dupl
+    - gofmt
+    - gosec
+    - lll
+    - megacheck
+    - gocritic
+  fast: false
+
+issues:
+  # Independently from option `exclude` we use default exclude patterns,
+  # it can be disabled by this option. To list all
+  # excluded by default patterns execute `golangci-lint run --help`.
+  # Default value for this option is true.
+  exclude-use-default: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ pay attention to a few things:
 
 ## Coding and documentation Style:
 
-- Code must be formated with `go fmt`
+- Code must be formatted with `go fmt`
 - Code must pass `go vet`
 - Code must pass `golint`
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: all
+all: deps lint build test
+
+.PHONY: tidy
+tidy:
+	go mod tidy
+
+.PHONY: download
+download:
+	go mod download
+
+.PHONY: deps
+deps: tidy download
+
+.PHONY: verify
+verify:
+	go mod verify
+
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: test
+test:
+	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+include linting.mk
+
 .PHONY: all
 all: deps lint build test
 

--- a/cli/venom/update/cmd.go
+++ b/cli/venom/update/cmd.go
@@ -34,7 +34,7 @@ func getURLArtifactFromGithub() string {
 	}
 
 	if *release.TagName == venom.Version {
-		cli.Exit("you already have the latest release:", *release.TagName)
+		cli.Exit(fmt.Sprintf("you already have the latest release: %s", *release.TagName))
 	}
 
 	if len(release.Assets) > 0 {

--- a/linting.mk
+++ b/linting.mk
@@ -1,0 +1,27 @@
+TMP_DIR = /tmp/ovh/venom
+
+OSNAME=$(shell go env GOOS)
+CUR_PATH = $(notdir $(shell pwd))
+
+GOLANGCI_DIR = $(TMP_DIR)/$(CUR_PATH)/golangci-lint
+GOLANGCI_TMP_BIN = $(GOLANGCI_DIR)/golangci-lint
+
+GOLANGCI_LINT_VERSION=1.31.0
+GOLANGCI_CMD = golangci-lint run --allow-parallel-runners -c .golangci.yml
+GOLANGCI_LINT_ARCHIVE = golangci-lint-$(GOLANGCI_LINT_VERSION)-$(OSNAME)-amd64.tar.gz
+
+# Run this on localc machine.
+# It downloads a version of golangci-lint and execute it locally.
+# duration first time ~6s
+# duration second time ~2s
+.PHONY: lint
+lint: $(GOLANGCI_TMP_BIN)
+	$(GOLANGCI_DIR)/$(GOLANGCI_CMD)
+
+# install a local golangci-lint if not found.
+$(GOLANGCI_TMP_BIN):
+	curl -OL https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/$(GOLANGCI_LINT_ARCHIVE)
+	mkdir -p $(GOLANGCI_DIR)/
+	tar -xf $(GOLANGCI_LINT_ARCHIVE) --strip-components=1 -C $(GOLANGCI_DIR)/
+	chmod +x $(GOLANGCI_TMP_BIN)
+	rm -f $(GOLANGCI_LINT_ARCHIVE)


### PR DESCRIPTION
The contribution instruction suggest to specific commands like `vet` and `lint`. Where go vet is standard in go across environment. Linting must be declared in a deterministic way, to ensure that all developers and CI are fixing the same rules.

`make deps` ensures that `go mod tidy` is always run when installing dependencies and it tidy up `go.mod` and `go.sum`, this prevents future contributors to find unrelated changes in their PRs because they base commit had untidy dependencies.