### PR TITLE
fix(executor/sql): removing odbc for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ It can also output xUnit results files.
 
 Download latest binary release from https://github.com/ovh/venom/releases  
 
-If you want to go get it with: ```go get -u github.com/ovh/venom/cli/venom```, please
-check the dependencies in §Hacking section.
-
 ```bash
 $ venom run -h
 Run Tests
@@ -348,8 +345,8 @@ Feel free to open a Pull Request with your executors.
 
 # Hacking
 
-# example on osx with custom user installation of homebrew:
-# $ CGO_CFLAGS="-I$HOME/homebrew/Cellar/unixodbc/2.3.9/include" CGO_LDFLAGS="-L$HOME/homebrew/lib" make build
+```
+$ make build
 ```
 
 # License

--- a/executors/sql/README.md
+++ b/executors/sql/README.md
@@ -4,7 +4,6 @@ Step to execute SQL queries into databases:
 * **MySQL**
 * **PostgreSQL**
 * **Oracle**
-* **SQL Server** or other database compatible with ODBC system
 
 It use the package `sqlx` under the hood: https://github.com/jmoiron/sqlx to retreive rows as a list of map[string]interface{}
 
@@ -48,14 +47,6 @@ testcases:
         dsn: "oracle://system:oracle@localhost:49161/XE"
         commands:
           - select * from v$version
-
-  - name: SQL Server ODBC (ODBC Driver must be install)
-    steps:
-      - type: sql
-        driver: odbc
-        dsn: Driver={SQL Server};Server=localhost,1433;UID=sa;PWD=Example_1234;
-        commands:
-          - SELECT @@VERSION
 ```
 
 Example with a query file:

--- a/executors/sql/sql.go
+++ b/executors/sql/sql.go
@@ -19,7 +19,7 @@ import (
 	_ "github.com/sijms/go-ora"
 
 	// ODBC
-	_ "github.com/alexbrainman/odbc"
+	//_ "github.com/alexbrainman/odbc"
 
 	"github.com/ovh/venom"
 )

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,12 @@ go 1.13
 
 require (
 	github.com/Shopify/sarama v1.27.2
-	github.com/alexbrainman/odbc v0.0.0-20200426075526-f0492dfa1575
 	github.com/antonfisher/nested-logrus-formatter v1.3.0
 	github.com/fatih/color v1.10.0
 	github.com/fsamin/go-dump v1.1.1
 	github.com/fullstorydev/grpcurl v1.7.0
 	github.com/garyburd/redigo v1.6.2
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/go-testfixtures/testfixtures/v3 v3.4.1
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alexbrainman/odbc v0.0.0-20200426075526-f0492dfa1575 h1:amPgE3QaxNogld1zImkopnrJQkJN51DE7ngVykqVVYE=
-github.com/alexbrainman/odbc v0.0.0-20200426075526-f0492dfa1575/go.mod h1:WEQLoRNIjBhywJqaxe0olilzzBDABc5EVeETiprzR00=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/antonfisher/nested-logrus-formatter v1.3.0 h1:8zixYquU1Odk+vzAaAQPAdRh1ZjmUXNQ1T+dUBvlhVo=
 github.com/antonfisher/nested-logrus-formatter v1.3.0/go.mod h1:6WTfyWFkBc9+zyBaKIqRrg/KwMqBbodBjgbHjDz7zjA=
@@ -186,8 +184,6 @@ github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgO
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
-github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -816,7 +812,6 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
until executor as plugin is available, this will let everybody compile
and run venom without installing unixodbc library.

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>