### PR TITLE
refactor: remove -no-check-variables argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Usage:
 Flags:
       --format string           --format:yaml, json, xml, tap (default "xml")
   -h, --help                    help for run
-      --no-check-variables      Don't check variables before run
       --output-dir string       Output Directory: create tests results file inside this directory
       --stop-on-failure         Stop running Test Suite on first Test Case failure
       --var strings             --var cds='cds -f config.json' --var cds2='cds -f config.json'

--- a/cli/venom/run/cmd.go
+++ b/cli/venom/run/cmd.go
@@ -39,7 +39,6 @@ var (
 	format        string
 	varFiles      []string
 	outputDir     string
-	noCheckVars   bool
 	stopOnFailure bool
 	verbose       *int
 	v             *venom.Venom
@@ -50,7 +49,6 @@ func init() {
 	Cmd.Flags().StringSliceVarP(&varFiles, "var-from-file", "", []string{""}, "--var-from-file filename.yaml --var-from-file filename2.yaml: yaml, must contains a dictionnary")
 	Cmd.Flags().StringVarP(&format, "format", "", "xml", "--format:yaml, json, xml, tap")
 	Cmd.Flags().BoolVarP(&stopOnFailure, "stop-on-failure", "", false, "Stop running Test Suite on first Test Case failure")
-	Cmd.Flags().BoolVarP(&noCheckVars, "no-check-variables", "", false, "Don't check variables before run")
 	Cmd.PersistentFlags().StringVarP(&outputDir, "output-dir", "", "", "Output Directory: create tests results file inside this directory")
 	verbose = Cmd.Flags().CountP("verbose", "v", "verbose. -vv to very verbose and -vvv to very verbose with CPU Profiling")
 }
@@ -130,12 +128,10 @@ Notice that variables initialized with -var-from-file argument can be overrided 
 
 		start := time.Now()
 
-		if !noCheckVars {
-			if err := v.Parse(path); err != nil {
-				fmt.Println(err)
-				os.Exit(2)
-				return err
-			}
+		if err := v.Parse(path); err != nil {
+			fmt.Println(err)
+			os.Exit(2)
+			return err
 		}
 
 		tests, err := v.Process(context.Background(), path)


### PR DESCRIPTION
variables have to be listed on the top of the testsuite

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>