### PR TITLE
fix: reuse vars from testcase

### DIFF
--- a/executors/readfile/README.md
+++ b/executors/readfile/README.md
@@ -25,7 +25,7 @@ testcases:
   - type: readfile
     path: yourfile.txt
     assertions:
-    - result.err ShouldNotExist
+    - result.err ShouldBeEmpty
 ```
 
 ## Output
@@ -52,7 +52,7 @@ testcases:
 ## Default assertion
 
 ```yaml
-result.err ShouldNotExist
+result.err ShouldBeEmpty
 ```
 
 ## Example

--- a/executors/readfile/readfile.go
+++ b/executors/readfile/readfile.go
@@ -57,7 +57,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.err ShouldNotExist"}}
+	return &venom.StepAssertions{Assertions: []string{"result.err ShouldBeEmpty"}}
 }
 
 // Run execute TestStep of type exec

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -157,6 +157,7 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase) {
 
 	for stepNumber, rawStep := range tc.RawTestSteps {
 		stepVars := tc.Vars.Clone()
+		stepVars.AddAllWithPrefix(tc.Name, tc.computedVars)
 		stepVars.Add("venom.teststep.number", stepNumber)
 
 		vars, err := dump.ToStringMap(stepVars)

--- a/tests/readfile.yml
+++ b/tests/readfile.yml
@@ -5,14 +5,30 @@ testcases:
   - type: readfile
     path: readfile/testa.json
     assertions:
-      - result.contentjson.foo ShouldEqual bar
+    - result.contentjson.foo ShouldEqual bar
 
   - type: readfile
     path: readfile/testb.json
     assertions:
-      - result.contentjson.contentjson0.foo2 ShouldEqual bar2
+    - result.contentjson.contentjson0.foo2 ShouldEqual bar2
 
   - type: readfile
     path: readfile/test.txt
     assertions:
-      - result.content ShouldContainSubstring multilines
+    - result.content ShouldContainSubstring multilines
+
+- name: testcase-readfile2
+  steps:
+  - type: readfile
+    path: readfile/testa.json
+    vars:
+      md5sum_foo:
+        from: result.md5sum.readfile_testa.json
+
+  - type: readfile
+    path: readfile/testa.json
+    info: "md5sum_foo: {{.md5sum_foo}}"
+    assertions:
+    - result.err ShouldEqual ""
+    - result.md5sum.readfile_testa.json ShouldEqual "{{.testcase-readfile2.md5sum_foo}}"
+


### PR DESCRIPTION
and fix default assertion on readfile executor

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>