### PR TITLE
fix: take care of venom variables on parse file

### DIFF
--- a/cmd/venom/.gitignore
+++ b/cmd/venom/.gitignore
@@ -1,2 +1,3 @@
 venom
 bin
+*.yml

--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -244,7 +244,7 @@ Notice that variables initialized with -var-from-file argument can be overrided 
 			readers = append(readers, fi)
 		}
 
-		mapvars, err := readInitialVariables(variables, readers, os.Environ())
+		mapvars, err := readInitialVariables(context.Background(), variables, readers, os.Environ())
 		if err != nil {
 			return err
 		}
@@ -279,7 +279,7 @@ Notice that variables initialized with -var-from-file argument can be overrided 
 	},
 }
 
-func readInitialVariables(argsVars []string, argVarsFiles []io.Reader, environ []string) (map[string]interface{}, error) {
+func readInitialVariables(ctx context.Context, argsVars []string, argVarsFiles []io.Reader, environ []string) (map[string]interface{}, error) {
 	var cast = func(vS string) interface{} {
 		var v interface{}
 		_ = yml.Unmarshal([]byte(vS), &v) //nolint
@@ -292,6 +292,7 @@ func readInitialVariables(argsVars []string, argVarsFiles []io.Reader, environ [
 			tuple := strings.Split(env, "=")
 			k := strings.TrimPrefix(tuple[0], "VENOM_VAR_")
 			result[k] = cast(tuple[1])
+			venom.Debug(ctx, "Adding variable from environment variable %s=%s", k, result[k])
 		}
 	}
 
@@ -306,6 +307,7 @@ func readInitialVariables(argsVars []string, argVarsFiles []io.Reader, environ [
 		}
 		for k, v := range tmpResult {
 			result[k] = v
+			venom.Debug(ctx, "Adding variable from vars-files %s=%s", k, v)
 		}
 	}
 
@@ -318,6 +320,7 @@ func readInitialVariables(argsVars []string, argVarsFiles []io.Reader, environ [
 			return nil, fmt.Errorf("invalid variable declaration: %v", arg)
 		}
 		result[tuple[0]] = cast(tuple[1])
+		venom.Debug(ctx, "Adding variable from vars arg %s=%s", tuple[0], result[tuple[0]])
 	}
 
 	return result, nil

--- a/cmd/venom/run/cmd_test.go
+++ b/cmd/venom/run/cmd_test.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ovh/venom"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func Test_readInitialVariables(t *testing.T) {
+	venom.InitTestLogger(t)
 	type args struct {
 		argsVars     []string
 		argVarsFiles []io.Reader
@@ -64,7 +67,7 @@ c:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := readInitialVariables(tt.args.argsVars, tt.args.argVarsFiles, tt.args.env)
+			got, err := readInitialVariables(context.TODO(), tt.args.argsVars, tt.args.argVarsFiles, tt.args.env)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("readInitialVariables() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/log.go
+++ b/log.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func initTestLogger(t *testing.T) {
+func InitTestLogger(t *testing.T) {
 	l := logrus.New()
 	logger = logrus.NewEntry(l)
 }

--- a/process.go
+++ b/process.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	nested "github.com/antonfisher/nested-logrus-formatter"
+	"github.com/fsamin/go-dump"
 	"github.com/gosimple/slug"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -109,12 +110,24 @@ func (v *Venom) Parse(path []string) error {
 		}
 	}
 
+	vars, err := dump.ToStringMap(v.variables)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse variables")
+	}
+
 	reallyMissingVars := []string{}
 	for _, k := range missingVars {
 		var varExtracted bool
 		for _, e := range extractedVars {
 			if strings.HasPrefix(k, e) {
 				varExtracted = true
+				break
+			}
+		}
+		for t := range vars {
+			if t == k {
+				varExtracted = true
+				break
 			}
 		}
 		if !varExtracted {

--- a/process_files_test.go
+++ b/process_files_test.go
@@ -32,7 +32,7 @@ func randomString(n int) string {
 }
 
 func Test_getFilesPath(t *testing.T) {
-	initTestLogger(t)
+	InitTestLogger(t)
 	rand.Seed(time.Now().UnixNano())
 	log.SetLevel(log.DebugLevel)
 

--- a/process_testcase_test.go
+++ b/process_testcase_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestProcessVariableAssigments(t *testing.T) {
-	initTestLogger(t)
+	InitTestLogger(t)
 	assign := AssignStep{}
 	assign.Assignments = make(map[string]Assignment)
 	assign.Assignments["assignVar"] = Assignment{

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,7 +42,7 @@ stop-test-stack:
 	@for f in `ls -1 *.cid`; do docker stop `cat $${f}`; docker rm `cat $${f}`; done; rm -f *.cid; docker network rm $(docker-network)
 
 run-test: wait-for-kafka
-	@(cd ../cmd/venom; go build && ./venom run --stop-on-failure -vv --var-from-file ../../tests/kafka/testVariables.yml ../../tests/*.yml)
+	@(cd ../cmd/venom; go build && VENOM_VAR_MY_ENVAR=foo ./venom run --stop-on-failure -vv --var-from-file ../../tests/kafka/testVariables.yml --var-from-file ../../tests/vars/vars.yml ../../tests/*.yml)
 
 .PHONY: wait-for-kafka
 wait-for-kafka:

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -25,3 +25,11 @@ testcases:
     - result.code ShouldEqual 0
     - result.systemout ShouldContainSubstring bar
 
+- name: echo_myvar
+  steps:
+  - type: exec
+    script: "echo {{.myvar}}"
+    info: "{{.myvar}}"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring foo

--- a/tests/vars/vars.yml
+++ b/tests/vars/vars.yml
@@ -1,0 +1,2 @@
+---
+myvar: "{{.MY_ENVAR}}"


### PR DESCRIPTION
```
❯ cat vars.yml
---
timezone: "{{.TIMEZONE}}"
❯ cat env_vars.yml
name: Environment variables
version: 2
testcases:
- name: echo_timezone
  steps:
  - type: exec
    script: "echo {{.timezone}}"
    info: "{{.timezone}}"

❯ VENOM_VAR_TIMEZONE=UTC ./venom run env_vars.yml --var-from-file vars.yml -vv
	  [trac] writing venom.log
 • Environment variables (env_vars.yml)
 	• echo_timezone SUCCESS
	  [info] UTC (env_vars.yml:0)
	  [trac] writing Environment-variables.echo_timezone.step.0.dump.json
```

close #350

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>