### PR TITLE
Add wait_for attribute to consume messages for X seconds in kafka consumer executor

### DIFF
--- a/executors/kafka/README.md
+++ b/executors/kafka/README.md
@@ -25,6 +25,8 @@ In your yaml file, you can use:
   - message_limit optional
   - initial_offset optional - Sarama default is newest
   - mark_offset optional
+  - wait_for optional - Wait X seconds before returning the consumed
+  messages from the topic.
 
   # for producer client type:
   - messages

--- a/tests/kafka.yml
+++ b/tests/kafka.yml
@@ -32,5 +32,22 @@ testcases:
     assertions:
     - result.messagesjson.messagesjson0.value.hello ShouldEqual bar
     - result.messages.__len__ ShouldEqual 1
+  - type: kafka
+    clientType: consumer
+    withTLS: false
+    withSASL: false
+    user: "{{.kafkaUser}}"
+    password: "{{.kafkaPwd}}"
+    markOffset: false
+    initialOffset: oldest
+    waitFor: 1
+    groupID: venom-wait-for
+    addrs:
+      - "{{.kafkaHost}}:{{.kafkaPort}}"
+    topics:
+      - test-topic
+    assertions:
+    - result.messages.__len__ ShouldBeGreaterThanOrEqualTo 1
+    - result.messagesjson.messagesjson0.value.hello ShouldEqual bar
   - type: exec
-    script: command -v kt && KT_BROKER=localhost:9092 kt admin --deletetopic test-topic || true
+    script: command -v kt && KT_BROKER="{{.kafkaHost}}:{{.kafkaPort}}" kt admin --deletetopic test-topic || true


### PR DESCRIPTION
Firstly, thanks for this amazing project.

This allows test to consume as an unknown number of messages during a period time. This is a way to solve the issue when you don't know the number of messages the test suite will have to consume, eg when running same test suite against the same topic more than once. This is specially useful when consuming topics from the `oldest` offset.

`Timeout` is left untouched to mark test as failed when a maximum number of messages are expected and timeout is reached. This way this change is backwards compatible.

Example of usage of `waitFor` attribute:
```yaml
- type: kafka
  clientType: consumer
  initialOffset: "oldest"
  groupID: "{{ randAlpha 6 }}"
  markOffset: false
  waitFor: 5  # This consumes messages for 5 seconds
  addrs:
    - "localhost:9092"
  topics:
    - "my_topic"
```

That's my first venom PR. Reviews and feedback are welcome :)