### PR TITLE
Add key_filter attribute to kafka consumer executor

### DIFF
--- a/executors/kafka/README.md
+++ b/executors/kafka/README.md
@@ -27,6 +27,7 @@ In your yaml file, you can use:
   - mark_offset optional
   - wait_for optional - Wait X seconds before returning the consumed
   messages from the topic.
+  - key_filter optional - perform filtering per key
 
   # for producer client type:
   - messages


### PR DESCRIPTION
This way the number of results to do assertions on are much lower and ease the reproducibility and reliability of test suites.

This is an improvement over using `jq` as `exec` executor in the next step / test.

Here `string` is expected to use as key_filter because `Message` struct uses string as `Key` attribute.

Example of usage:
```yaml
- type: kafka
  clientType: consumer
  initialOffset: "oldest"
  groupID: "{{ randAlpha 6 }}"
  keyFilter: "my_key"
  addrs:
    - "localhost:9092"
  topics:
    - "my_topic"
```

Any review or feedback is more than welcome :hugs: 