### PR TITLE
Improvements over kafka consumer executor

### DIFF
--- a/executors/kafka/kafka.go
+++ b/executors/kafka/kafka.go
@@ -374,6 +374,7 @@ func (h *handler) Cleanup(sarama.ConsumerGroupSession) error {
 
 // ConsumeClaim must start a consumer loop of ConsumerGroupClaim's Messages().
 func (h *handler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+	ctx := session.Context()
 	for message := range claim.Messages() {
 		consumeFunction := h.consumeJSON
 		if h.withAVRO {
@@ -385,7 +386,7 @@ func (h *handler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama
 		}
 		// Pass filter
 		if h.keyFilter != "" && msg.Key != h.keyFilter {
-			venom.Info(context.TODO(), "ignore message with key: %s", msg.Key)
+			venom.Info(ctx, "ignore message with key: %s", msg.Key)
 			continue
 		}
 		h.mutex.Lock()
@@ -398,7 +399,7 @@ func (h *handler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama
 			session.MarkMessage(message, "")
 		}
 		if h.messageLimit > 0 && messagesLen >= h.messageLimit {
-			venom.Info(context.Background(), "message limit reached")
+			venom.Info(ctx, "message limit reached")
 			return nil
 		}
 		session.MarkMessage(message, "delivered")


### PR DESCRIPTION
:wave: again !

This is based on #394 to avoid conflicts so it may be better to read two last commmits.

Two minor improvements:

1. Introduce a mutex to share access to `messages` and `messagesJSON` between goroutines when more than 1 partition per topic is added.
2. Use `sarama.ConsumerGroupSession` context in `ConsumeClaim` for logging avoiding creating a new context when the parent one is already available.

Any review or feedback is more than welcome :hugs: 