### PR TITLE
Small improvement to assertions

### DIFF
--- a/assertion.go
+++ b/assertion.go
@@ -85,7 +85,10 @@ func parseAssertions(ctx context.Context, s string, input interface{}) (*asserti
 	if len(assert) < 2 {
 		return nil, errors.New("assertion syntax error")
 	}
-	actual := dump[assert[0]]
+	actual, ok := dump[assert[0]]
+	if !ok {
+		actual = assert[0]
+	}
 
 	f, ok := assertions.Get(assert[1])
 	if !ok {
@@ -95,10 +98,15 @@ func parseAssertions(ctx context.Context, s string, input interface{}) (*asserti
 	args := make([]interface{}, len(assert[2:]))
 	for i, v := range assert[2:] {
 		var err error
-		args[i], err = stringToType(v, actual)
-		if err != nil {
-			return nil, fmt.Errorf("mismatched type between '%v' and '%v': %v", assert[0], v, err)
+
+		arg, ok := dump[v]
+		if !ok {
+			arg, err = stringToType(v, actual)
+			if err != nil {
+				return nil, fmt.Errorf("mismatched type between '%v' and '%v': %v", assert[0], v, err)
+			}
 		}
+		args[i] = arg
 	}
 	return &assertion{
 		Actual: actual,

--- a/tests/assertions.yml
+++ b/tests/assertions.yml
@@ -5,3 +5,10 @@ testcases:
     - script: echo 1
       assertions:
       - result.systemoutjson ShouldBeIn 1 2
+  - name: ShouldBeLessThan
+    steps:
+    - script: echo '{"zero":0, "two":2, "five":5}'
+      assertions:
+      - 0 ShouldBeLessThan 5
+      - result.systemoutjson.zero ShouldBeLessThan "1"
+      - result.systemoutjson.zero ShouldBeLessThan result.systemoutjson.two


### PR DESCRIPTION
👋🏻  2 small improvements regarding assertions, with the following example on master:

```
name: Assertions testsuite
testcases:
  - name: ShouldBeLessThan
    steps:
    - script: echo '{"zero":0, "two":2, "five":5}'
      assertions:
      - 0 ShouldBeLessThan 5
      - result.systemoutjson.zero ShouldBeLessThan "1"
      - result.systemoutjson.zero ShouldBeLessThan result.systemoutjson.two
 ```

### `- 0 ShouldBeLessThan 5`:

This assertion would panic because we are only checking inside the `dump` var.
solution: if cannot be found in `dump` var we can just use the actual value. (changes L89)

### `- result.systemoutjson.zero ShouldBeLessThan result.systemoutjson.two`: 

This assertion would fail because as opposed to above we don't check in the `dump` for the expected value, and we are trying to parse `result.systemoutjson.two`.

```
Testcase "test assertion", step #0: Assertion "result.systemoutjson.zero ShouldBeLessThan result.systemoutjson.two" failed. mismatched type between 'result.systemoutjson.zero' and 'result.systemoutjson.two': strconv.ParseFloat: parsing "result.systemoutjson.two": invalid syntax (test.yml:9)
```

Solution: So, in this case, we can just check in the `dump` var, and if doesn't exist use the original way. (changes L102) 

--- 

A better way might be possible in order to get these assertions above work so feel free to let me know and I update if needed :) 