### PR TITLE
💡  Proposal: Add testsuite labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Flags:
       --format string           --format:yaml, json, xml, tap (default "xml")
   -h, --help                    help for run
       --lib-dir string          Lib Directory: this directory can contain user executors. This overrides the default lib folder directory
+      --label strings           --label critical --label ci-only: only
+      run testsuites with specified labels.
       --output-dir string       Output Directory: create tests results file inside this directory
       --stop-on-failure         Stop running Test Suite on first Test Case failure
       --var stringArray         --var cds='cds -f config.json' --var cds2='cds -f config.json'
@@ -65,6 +67,7 @@ VENOM_FORMAT=json venom run my-test-suite.yml
       --format           -  example: VENOM_FORMAT=json
       --output-dir       -  example: VENOM_OUTPUT_DIR=.
       --lib-dir          -  example: VENOM_LIB_DIR=/etc/venom/lib:$HOME/venom.d/lib
+      --label            -  example: VENOM_LABEL="critical ci-only"
       --stop-on-failure  -  example: VENOM_STOP_ON_FAILURE=true
       --var              -  example: VENOM_VAR="foo=bar"
       --var-from-file    -  example: VENOM_VAR_FROM_FILE="fileA.yml fileB.yml"
@@ -74,7 +77,7 @@ VENOM_FORMAT=json venom run my-test-suite.yml
 You can define the venom settings using a configuration file `.venomrc`. This configuration file should be placed in the current directory or in the home directory.
 
 ```yml
-variables: 
+variables:
   - foo=bar
 variables_files:
   - my_var_file.yaml
@@ -82,6 +85,9 @@ stop_on_failure: true
 format: xml
 output_dir: output
 lib_dir: lib
+label:
+  - critical
+  - ci-only
 verbosity: 3
 ```
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -50,11 +50,12 @@ build-test-binary:
 	CGO_ENABLED=1 go test -coverpkg $$TEMP -c . -o ../../tests/venom.test -tags testbincover;
 
 build-test-binary-docker:
-	docker run -v `pwd`/..:/workspace golang:1.16 sh -c "cd /workspace/tests && make build-test-binary"	
+	docker run -v `pwd`/..:/workspace golang:1.16 sh -c "cd /workspace/tests && make build-test-binary"
 
 run-test: wait-for-kafka
 	VENOM_VAR_MY_ENVAR=foo ./venom_wrapper.sh run -vv --format=xml --lib-dir=./lib_custom --var='array_from_var=["biz","buz"]' --var-from-file ./kafka/testVariables.yml  --var-from-file ./vars/vars.yml ./*.yml ./assertions/*.yml;
 	(cd ./vars_override && VENOM_VAR_foo=from-env VENOM_VAR_FOO2=from-env2 VENOM_VAR_FOO3=from-env3 ../venom_wrapper.sh run -vv --var foo='from-cmd-arg' --var='array_from_var=["biz","buz"]' ./mytc.yml);
+	./venom_wrapper.sh run --label critical -vv --format=xml --lib-dir=./lib_custom ./*.yml;
 
 .PHONY: wait-for-kafka
 wait-for-kafka:

--- a/tests/label.yml
+++ b/tests/label.yml
@@ -1,0 +1,18 @@
+name: Exec testsuite
+labels:
+  - critical
+testcases:
+- name: testA
+  steps:
+  - type: exec
+    script: echo 'foo with a bar here'
+    info:
+      - this a first info
+      - and a second...
+    assertions:
+    - result.code ShouldEqual 0
+    - result.timeseconds ShouldBeLessThan 1
+    vars:
+      myvariable:
+        from: result.systemout
+        regex: foo with a ([a-z]+) here

--- a/types.go
+++ b/types.go
@@ -87,6 +87,7 @@ type TestSuite struct {
 	Vars         H          `xml:"-" json:"-" yaml:"vars"`
 	ComputedVars H          `xml:"-" json:"-" yaml:"-"`
 	WorkDir      string     `xml:"-" json:"-" yaml:"-"`
+	Labels       []string   `xml:"-" json:"labels" yaml:"labels"`
 }
 
 // Property represents a key/value pair used to define properties.

--- a/venom.go
+++ b/venom.go
@@ -53,6 +53,7 @@ type Venom struct {
 	testsuites []TestSuite
 	variables  H
 
+	Labels        []string
 	LibDir        string
 	OutputFormat  string
 	OutputDir     string


### PR DESCRIPTION
⚠️  Feel free to discard the PR if you think it should not be included. 

💡  So the idea is that we want to easily differentiate test suites, some could run in CI while some others could be run manually, some are critical while others are not. 

**Proposal: we would like to be able to via a command or env var to be able to specify these `labels`** 

This way we can specify which test suite can be run or not, if no labels pass as option everything is run :) 

so with the following testsuites: 

```
# testsuite1.yml
name: a_critical_scenario
labels:
 - critical
vars: 
 ...
testcases:
- name: test_case1
- name: test_case2

# testsuite2.yml
name: a_non_critical_scenario_with_label
labels:
 - legacy
vars: 
 ...
testcases:
- name: test_case1
- name: test_case2

# testsuite3.yml
name: a_non_critical_scenario
vars: 
 ...
testcases:
- name: test_case1
- name: test_case2
```

- `venom run *.yml` would run them all
- `venom run *.yml --label critical` would only run the first one
- `venom run *.yml --label critical --label legacy` would only run the first two 

---

ℹ️  If you're happy with adding this feature, I can finish up PR
❓ One thing I'm unsure is how to handle the `computeStats` part as there is already a `Skipped` for `Testsuite` but that seems to be incremented when testcase steps are skipped. 