### PR TITLE
Fix panic pointer and map are both nil

### DIFF
--- a/types.go
+++ b/types.go
@@ -20,9 +20,8 @@ func (h H) Clone() H {
 }
 
 func (h *H) Add(k string, v interface{}) {
-	if h == nil {
-		var _h = H{}
-		*h = _h
+	if h == nil || *h == nil {
+		*h = make(map[string]interface{})
 	}
 	(*h)[k] = v
 }


### PR DESCRIPTION
The following example causes a panic:

test.yaml

```yaml
name: Testy test

testcases:
- name: Testy test part 1
  steps:
  - type: test_part_1
```

lib/test_part_1.yaml

```yaml
executor: test_part_1

steps:
- type: http
  method: PUT
  url: http://localhost/v1/something/something/1234

```

backtrace:

```
venom run test.yaml
	  [trac] writing venom.log
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/ovh/venom.(*H).Add(...)
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/types.go:27
github.com/ovh/venom.(*Venom).registerUserExecutors(0xc000356a20, 0x140fb40, 0xc0003cc7b0, 0xc00044e4e0, 0xb, 0xc0003cc480, 0xc0003cc4e0, 0xc0003cc7b0, 0x16)
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/venom.go:228 +0x4c5
github.com/ovh/venom.(*Venom).GetExecutorRunner(0xc000356a20, 0x140fb40, 0xc0003cc7b0, 0xc0003cc480, 0xc0003cc000, 0x0, 0x0, 0xc000042550, 0x43, 0x120, ...)
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/venom.go:135 +0x746
github.com/ovh/venom.(*Venom).parseTestCase(0xc000356a20, 0xc0003c8900, 0xc00017ec00, 0xe, 0xc0003b60a8, 0x11, 0x0, 0x0, 0x0, 0x0, ...)
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/process_testcase.go:44 +0xe08
github.com/ovh/venom.(*Venom).parseTestCases(0xc000356a20, 0xc0003c8900, 0x12b179b, 0x1a, 0xc0001c19c0, 0x2, 0x2, 0x0, 0x8aa465, 0xc0003a93b0)
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/process_testsuite.go:145 +0x349
github.com/ovh/venom.(*Venom).parseTestSuite(...)
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/process_testsuite.go:130
github.com/ovh/venom.(*Venom).Parse(0xc000356a20, 0x140fad0, 0xc00003c0f8, 0xc0003785c0, 0x1, 0x4, 0x1, 0x1)
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/process.go:77 +0x765
github.com/ovh/venom/cmd/venom/run.glob..func2(0x19e9800, 0xc0003785c0, 0x1, 0x4, 0x0, 0x0)
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/cmd/venom/run/cmd.go:387 +0x2f7
github.com/spf13/cobra.(*Command).execute(0x19e9800, 0xc000378580, 0x4, 0x4, 0x19e9800, 0xc000378580)
	...go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x19e9fe0, 0x7719c5, 0xc0000440b8, 0x1085e60)
	...go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	...go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
main.main()
	...go/pkg/mod/github.com/ovh/venom@v1.0.0-rc.4/cmd/venom/main.go:20 +0x36
```

This PR fixes this panic. I don't know if this is the correct fix however.