### PR TITLE
Parse Redis responses containing nested arrays

### DIFF
--- a/executors/redis/redis.go
+++ b/executors/redis/redis.go
@@ -129,10 +129,10 @@ func sliceStringToSliceInterface(args []string) []interface{} {
 func handleRedisResponse(res interface{}, err error) interface{} {
 	switch p := res.(type) {
 	case []interface{}:
-		var result = []string{}
+		var result []interface{}
 		for i := range p {
 			u := p[i]
-			k, _ := redis.String(u, err) //nolint
+			k := handleRedisResponse(u, err)
 			result = append(result, k)
 		}
 		return result

--- a/tests/redis.yml
+++ b/tests/redis.yml
@@ -11,6 +11,7 @@ testcases:
   - type: redis
     commands:
         - FLUSHALL
+
   - type: redis
     commands:
         - SET foo bar
@@ -27,6 +28,7 @@ testcases:
     redis.dialURL: "redis://{{.redisHost}}:{{.redisPort}}/0"
     commands:
         - FLUSHALL
+
   - type: redis
     path: redis/testredis/commands.txt
     redis.dialURL: "redis://{{.redisHost}}:{{.redisPort}}/0"
@@ -36,3 +38,53 @@ testcases:
         - result.commands.commands2.response.response0 ShouldEqual foo
         - result.commands.commands3.response ShouldEqual OK
         - result.commands.commands4.response ShouldEqual {"test":"go o"}
+
+- name: Commands_Nested_Array_Response_Test_Case
+  steps:
+  - type: redis
+    commands:
+        - FLUSHALL
+
+  - type: redis
+    commands:
+        - XADD testStream * field1 value1 field2 value2
+        - XADD testStream * field3 value3 field4 value4
+    vars:
+      streamEntry1ID:
+        from: result.commands.commands0.response
+      streamEntry2ID:
+        from: result.commands.commands1.response
+    info:
+        - "streamEntry1ID: {{.result.commands.commands0.response}}"
+        - "streamEntry2ID: {{.result.commands.commands1.response}}"
+
+  - type: redis
+    commands:
+        - XREAD COUNT 2 STREAMS testStream 0-0
+    assertions:
+        - result.commands.commands0.response.response0.response00 ShouldEqual testStream
+        - "result.commands.commands0.response.response0.response01.response010.response0100 ShouldEqual {{.Commands_Nested_Array_Response_Test_Case.streamEntry1ID}}"
+        - result.commands.commands0.response.response0.response01.response010.response0101.response01010 ShouldEqual field1
+        - result.commands.commands0.response.response0.response01.response010.response0101.response01011 ShouldEqual value1
+        - result.commands.commands0.response.response0.response01.response010.response0101.response01012 ShouldEqual field2
+        - result.commands.commands0.response.response0.response01.response010.response0101.response01013 ShouldEqual value2
+        - "result.commands.commands0.response.response0.response01.response011.response0110 ShouldEqual {{.Commands_Nested_Array_Response_Test_Case.streamEntry2ID}}"
+        - result.commands.commands0.response.response0.response01.response011.response0111.response01110 ShouldEqual field3
+        - result.commands.commands0.response.response0.response01.response011.response0111.response01111 ShouldEqual value3
+        - result.commands.commands0.response.response0.response01.response011.response0111.response01112 ShouldEqual field4
+        - result.commands.commands0.response.response0.response01.response011.response0111.response01113 ShouldEqual value4
+
+  - type: redis
+    commands:
+        - XRANGE testStream - +
+    assertions:
+        - "result.commands.commands0.response.response0.response00 ShouldEqual {{.Commands_Nested_Array_Response_Test_Case.streamEntry1ID}}"
+        - result.commands.commands0.response.response0.response01.response010 ShouldEqual field1
+        - result.commands.commands0.response.response0.response01.response011 ShouldEqual value1
+        - result.commands.commands0.response.response0.response01.response012 ShouldEqual field2
+        - result.commands.commands0.response.response0.response01.response013 ShouldEqual value2
+        - "result.commands.commands0.response.response1.response10 ShouldEqual {{.Commands_Nested_Array_Response_Test_Case.streamEntry2ID}}"
+        - result.commands.commands0.response.response1.response11.response110 ShouldEqual field3
+        - result.commands.commands0.response.response1.response11.response111 ShouldEqual value3
+        - result.commands.commands0.response.response1.response11.response112 ShouldEqual field4
+        - result.commands.commands0.response.response1.response11.response113 ShouldEqual value4


### PR DESCRIPTION
The Redis executor makes the assumption that if Redis returns an array as a response, this array will be flat, and there will be no arrays nested within it. This is not always the case (for example, **XREAD** and **XRANGE** return nested arrays).

This PR amends the Redis executor to parse Redis responses containing nested arrays, and includes a test-case to demonstrate how this functionality can be used with Redis steams.

Signed-off-by: chris1786 <22242927+chris1786@users.noreply.github.com>