### PR TITLE
Add AMQP executor

### DIFF
--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/ovh/venom"
+	"github.com/ovh/venom/executors/amqp"
 	"github.com/ovh/venom/executors/dbfixtures"
 	"github.com/ovh/venom/executors/exec"
 	"github.com/ovh/venom/executors/grpc"
@@ -327,6 +328,7 @@ Notice that variables initialized with -var-from-file argument can be overrided 
 		v.RegisterExecutorBuiltin(grpc.Name, grpc.New())
 		v.RegisterExecutorBuiltin(rabbitmq.Name, rabbitmq.New())
 		v.RegisterExecutorBuiltin(sql.Name, sql.New())
+		v.RegisterExecutorBuiltin(amqp.Name, amqp.New())
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		initArgs(cmd)

--- a/executors/amqp/README.md
+++ b/executors/amqp/README.md
@@ -1,0 +1,72 @@
+# Venom - Executor AMQP
+
+Step to publish / subscribe to AMQP 1.0 compatible broker (currently implemented by QPID and ActiveMQ, among others)
+
+## Input
+
+```yaml
+- Addr         (address of the amqp broker to connect to, in the format "amqp://<host>:<port>")
+- ClientType   (consumer or producer)
+
+# Consumer Parameters
+- SourceAddr   (source topic/queue to consume messages from)
+- MessageLimit (number of messages to read from the broker before returning result)
+
+# Producer Parameters
+- TargetAddr   (topic/queue to which messages should be published)
+- Messages     (array of message bodies to send to the broker)
+```
+
+## Output
+
+*Populated when ClientType is consumer*
+
+```yaml
+- result.messages     (array of strings, each containing the body of a response message)
+- result.messagesJSON (if response is JSON, corresponding index will be populated with the navigable body of a response)
+```
+## Examples
+
+### Publisher
+```yaml
+name: AMQP
+testcases:
+  - name: Producer
+    steps:
+      - type: amqp
+        addr: amqp://localhost:5673
+        clientType: producer
+        targetAddr: amqp-test
+        messages:
+          - '{"key1":"value1","key2":"value2"}'
+          - '{"key3":"value3","key4":"value4"}'
+          - 'not json'
+          - '["value5","value6"]'
+```
+
+### Consumer
+```yaml
+name: AMQP
+testcases:
+  - name: Consumer
+    steps:
+     - type: amqp
+        addr: amqp://localhost:5673
+        clientType: consumer
+        sourceAddr: amqp-test
+        messageLimit: 4
+        assertions:
+          - result.messages.__len__ ShouldEqual 4
+          - result.messages.messages0 ShouldEqual '{"key1":"value1","key2":"value2"}'
+          - result.messages.messages1 ShouldEqual '{"key3":"value3","key4":"value4"}'
+          - result.messages.messages2 ShouldEqual 'not json'
+          - result.messages.messages3 ShouldEqual '["value5","value6"]'
+          - result.messagesjson.__len__ ShouldEqual 4
+          - result.messagesjson.messagesjson0.key1 ShouldEqual value1
+          - result.messagesjson.messagesjson0.key2 ShouldEqual value2
+          - result.messagesjson.messagesjson1.key3 ShouldEqual value3
+          - result.messagesjson.messagesjson1.key4 ShouldEqual value4
+          - result.messagesjson.messagesjson3.messagesjson30 ShouldEqual value5
+          - result.messagesjson.messagesjson3.messagesjson31 ShouldEqual value6
+```
+

--- a/executors/amqp/README.md
+++ b/executors/amqp/README.md
@@ -5,16 +5,16 @@ Step to publish / subscribe to AMQP 1.0 compatible broker (currently implemented
 ## Input
 
 ```yaml
-- Addr         (address of the amqp broker to connect to, in the format "amqp://<host>:<port>")
-- ClientType   (consumer or producer)
+- addr         (address of the amqp broker to connect to, in the format "amqp://<host>:<port>")
+- clientType   (consumer or producer)
 
 # Consumer Parameters
-- SourceAddr   (source topic/queue to consume messages from)
-- MessageLimit (number of messages to read from the broker before returning result)
+- sourceAddr   (source topic/queue to consume messages from)
+- messageLimit (number of messages to read from the broker before returning result)
 
 # Producer Parameters
-- TargetAddr   (topic/queue to which messages should be published)
-- Messages     (array of message bodies to send to the broker)
+- targetAddr   (topic/queue to which messages should be published)
+- messages     (array of message bodies to send to the broker)
 ```
 
 ## Output
@@ -69,4 +69,3 @@ testcases:
           - result.messagesjson.messagesjson3.messagesjson30 ShouldEqual value5
           - result.messagesjson.messagesjson3.messagesjson31 ShouldEqual value6
 ```
-

--- a/executors/amqp/amqp.go
+++ b/executors/amqp/amqp.go
@@ -1,0 +1,165 @@
+package amqp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	amqp "github.com/Azure/go-amqp"
+	"github.com/mitchellh/mapstructure"
+	"github.com/ovh/venom"
+)
+
+// Name of executor
+const Name = "amqp"
+
+// New returns a new Executor
+func New() venom.Executor {
+	return &Executor{}
+}
+
+// Executor represents a Test Exec
+type Executor struct {
+	Addr string `json:"addr" yaml:"addr"`
+
+	// ClientType must be "consumer" or "producer"
+	ClientType string `json:"clientType" yaml:"clientType"`
+
+	// Used when ClientType is consumer
+	// SourceAddr represents the source address from which to read incoming messages
+	SourceAddr string `json:"sourceAddr" yaml:"sourceAddr"`
+	// MessageLimit represents the limit of message will be read. After limit, consumer will stop reading
+	MessageLimit uint `json:"messageLimit" yaml:"messageLimit"`
+
+	// Used when ClientType is producer
+	// TargetAddr represents the target address to which outgoing messages should be published
+	TargetAddr string `json:"targetAddr" yaml:"targetAddr"`
+	// Messages represents the messages to be sent by producer
+	Messages []string `json:"messages" yaml:"messages"`
+}
+
+// Result represents a step result
+type Result struct {
+	Messages     []string      `json:"messages" yaml:"messages"`
+	MessagesJSON []interface{} `json:"messagesJSON" yaml:"messagesJSON"`
+}
+
+// ZeroValueResult returns an empty implementation of this executor result
+func (Executor) ZeroValueResult() interface{} {
+	return Result{}
+}
+
+// Run execute TestStep
+func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, error) {
+	var e Executor
+	if err := mapstructure.Decode(step, &e); err != nil {
+		return nil, err
+	}
+
+	client, session, err := e.createAMQPSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+	defer session.Close(ctx)
+
+	switch e.ClientType {
+	case "producer":
+		return e.publishMessages(ctx, session)
+	case "consumer":
+		return e.consumeMessages(ctx, session)
+	default:
+		return nil, fmt.Errorf("clientType %q must be producer or consumer", e.ClientType)
+	}
+}
+
+func (e Executor) createAMQPSession(ctx context.Context) (*amqp.Client, *amqp.Session, error) {
+	if e.Addr == "" {
+		return nil, nil, errors.New("creating session: addr is mandatory")
+	}
+
+	client, err := amqp.Dial(e.Addr, amqp.ConnSASLAnonymous())
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating session: %w", err)
+	}
+
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating session: %w", err)
+	}
+
+	return client, session, nil
+}
+
+func (e Executor) publishMessages(ctx context.Context, session *amqp.Session) (interface{}, error) {
+	if e.TargetAddr == "" {
+		return nil, errors.New("publishing messages: targetAddr is manatory when clientType is producer")
+	}
+
+	if len(e.Messages) < 1 {
+		return nil, errors.New("publishing messages: messages length must be > 0 when clientType is producer")
+	}
+
+	sender, err := session.NewSender(amqp.LinkTargetAddress(e.TargetAddr))
+	if err != nil {
+		return nil, fmt.Errorf("publishing messages: %w", err)
+	}
+
+	for _, m := range e.Messages {
+		if err := sender.Send(ctx, amqp.NewMessage([]byte(m))); err != nil {
+			return nil, fmt.Errorf("publishing messages: %w", err)
+		}
+	}
+
+	return nil, nil
+}
+
+func (e Executor) consumeMessages(ctx context.Context, session *amqp.Session) (interface{}, error) {
+	if e.SourceAddr == "" {
+		return nil, errors.New("consuming messages: sourceAddr is manatory when clientType is consumer")
+	}
+
+	if e.MessageLimit < 1 {
+		return nil, errors.New("consuming messages: messageLimit must be > 0 when clientType is consumer")
+	}
+
+	recv, err := session.NewReceiver(amqp.LinkSourceAddress(e.SourceAddr))
+	if err != nil {
+		return nil, fmt.Errorf("consuming messages: %w", err)
+	}
+
+	output := Result{
+		Messages:     make([]string, 0, e.MessageLimit),
+		MessagesJSON: make([]interface{}, 0, e.MessageLimit),
+	}
+
+	for i := uint(0); i < e.MessageLimit; i++ {
+		msgString, msgJSON, err := consumeMessage(ctx, recv)
+		if err != nil {
+			return nil, fmt.Errorf("consuming message %d: %w", i, err)
+		}
+
+		output.Messages = append(output.Messages, msgString)
+		output.MessagesJSON = append(output.MessagesJSON, msgJSON)
+	}
+
+	return output, nil
+}
+
+func consumeMessage(ctx context.Context, recv *amqp.Receiver) (msgString string, msgJSON interface{}, err error) {
+	msg, err := recv.Receive(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("consuming message: %w", err)
+	}
+
+	if err := msg.Accept(ctx); err != nil {
+		return "", nil, fmt.Errorf("consuming message: %w", err)
+	}
+
+	if err := json.Unmarshal(msg.GetData(), &msgJSON); err != nil {
+		return string(msg.GetData()), nil, nil
+	}
+
+	return string(msg.GetData()), msgJSON, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ovh/venom
 go 1.16
 
 require (
+	github.com/Azure/go-amqp v0.13.7
 	github.com/Shopify/sarama v1.27.2
 	github.com/alexbrainman/odbc v0.0.0-20200426075526-f0492dfa1575
 	github.com/antonfisher/nested-logrus-formatter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -35,9 +35,21 @@ github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuE
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-sdk-for-go v29.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v30.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v51.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-service-bus-go v0.9.1/go.mod h1:yzBx6/BUGfjfeqbRZny9AQIbIe3AcV9WZbAdpkoXOa0=
 github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxwl2B6teiRqI0deQUvsw0=
+github.com/Azure/go-amqp v0.13.7 h1:ukcCtx138ZmOfHbdALuh9yoJhGtOY3+yaKApfzNvhSk=
+github.com/Azure/go-amqp v0.13.7/go.mod h1:wbpCKA8tR5MLgRyIu+bb+S6ECdIDdYJ0NlpFE9xsBPI=
 github.com/Azure/go-autorest v12.0.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
+github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
+github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
+github.com/Azure/go-autorest/autorest/validation v0.3.1/go.mod h1:yhLgjC0Wda5DYXl6JAsWyUe4KVNffhoDhG0zVzUMo3E=
+github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
+github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae/go.mod h1:mjwGPas4yKduTyubHvD1Atl9r1rUq8DfVy+gkVvZ+oo=
@@ -156,6 +168,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -244,6 +257,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -703,6 +717,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 h1:umElSU9WZirRdgu2yFHY0ayQkEnKiOC1TtM3fWXFnoU=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,8 +38,11 @@ venom-rabbit.cid:
 	$(call docker_run,rabbitmq,rabbitmq,-p 5672:5672 -p 15672:15672)
 venom-sshd.cid:
 	$(call docker_run,ghcr.io/linuxserver/openssh-server,sshd,-p 2222:2222 -e PUID=1000 -e PGID=1000 -e TZ=Europe/London -e PUBLIC_KEY="$(shell cat ~/.ssh/id_rsa.pub)" -e USER_NAME=venom )
+venom-qpid.cid:
+	$(call docker_run,scholzj/qpid-cpp:1.39.0,qpid,-p 5673:5672)
+	docker exec venom-qpid qpid-config add queue amqp-test
 
-start-test-stack: venom-postgres.cid venom-mysql.cid venom-redis.cid venom-imap.cid venom-kafka.cid venom-rabbit.cid venom-sshd.cid
+start-test-stack: venom-postgres.cid venom-mysql.cid venom-redis.cid venom-imap.cid venom-kafka.cid venom-rabbit.cid venom-sshd.cid venom-qpid.cid
 
 stop-test-stack:
 	@for f in `ls -1 *.cid`; do docker stop `cat $${f}`; docker rm `cat $${f}`; done; rm -f *.cid; docker network rm $(docker-network)

--- a/tests/amqp.yml
+++ b/tests/amqp.yml
@@ -1,0 +1,32 @@
+name: AMQP testsuite
+testcases:
+  - name: QPID testcase
+    steps:
+      - type: amqp
+        addr: amqp://localhost:5673
+        clientType: producer
+        targetAddr: amqp-test
+        messages:
+          - '{"key1":"value1","key2":"value2"}'
+          - '{"key3":"value3","key4":"value4"}'
+          - 'not json'
+          - '["value5","value6"]'
+
+      - type: amqp
+        addr: amqp://localhost:5673
+        clientType: consumer
+        sourceAddr: amqp-test
+        messageLimit: 4
+        assertions:
+          - result.messages.__len__ ShouldEqual 4
+          - result.messages.messages0 ShouldEqual '{"key1":"value1","key2":"value2"}'
+          - result.messages.messages1 ShouldEqual '{"key3":"value3","key4":"value4"}'
+          - result.messages.messages2 ShouldEqual 'not json'
+          - result.messages.messages3 ShouldEqual '["value5","value6"]'
+          - result.messagesjson.__len__ ShouldEqual 4
+          - result.messagesjson.messagesjson0.key1 ShouldEqual value1
+          - result.messagesjson.messagesjson0.key2 ShouldEqual value2
+          - result.messagesjson.messagesjson1.key3 ShouldEqual value3
+          - result.messagesjson.messagesjson1.key4 ShouldEqual value4
+          - result.messagesjson.messagesjson3.messagesjson30 ShouldEqual value5
+          - result.messagesjson.messagesjson3.messagesjson31 ShouldEqual value6


### PR DESCRIPTION
Add AMQP executor

This is primarily designed to support recent versions of QPID, but should also be compatible with ActiveMQ, and other brokers which implement the AMQP 1.0 specification.

Signed-off-by: chris1786 <22242927+chris1786@users.noreply.github.com>