### PR TITLE
add globstars ** support

### DIFF
--- a/process_files.go
+++ b/process_files.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/ghodss/yaml"
 
+	"github.com/mattn/go-zglob"
+
 	"github.com/ovh/cds/sdk/interpolate"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -28,7 +30,7 @@ func getFilesPath(path []string) (filePaths []string, err error) {
 			p = p + string(os.PathSeparator) + "*.yml"
 		}
 
-		fpaths, err := filepath.Glob(p)
+		fpaths, err := zglob.Glob(p)
 		if err != nil {
 			log.Errorf("error reading files on path %q err:%v", path, err)
 			return nil, errors.Wrapf(err, "error reading files on path %q", path)
@@ -46,7 +48,19 @@ func getFilesPath(path []string) (filePaths []string, err error) {
 	if len(filePaths) == 0 {
 		return nil, fmt.Errorf("no yml file selected")
 	}
-	return filePaths, nil
+	return uniq(filePaths), nil
+}
+
+func uniq(stringSlice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range stringSlice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
 }
 
 type partialTestSuite struct {

--- a/process_files_test.go
+++ b/process_files_test.go
@@ -1,6 +1,7 @@
 package venom
 
 import (
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -93,6 +94,114 @@ func Test_getFilesPath(t *testing.T) {
 				return []string{dir1, dir2}, err
 			},
 			want:    []string{"d1.yml", "d2.yml"},
+			wantErr: false,
+		},
+		{
+			name: "Check globstars",
+			init: func(t *testing.T) ([]string, error) {
+				dir1, err := tempDir(t)
+				if err != nil {
+					return nil, err
+				}
+
+				d1 := []byte("hello")
+				if err = ioutil.WriteFile(path.Join(dir1, "d1.yml"), d1, 0644); err != nil {
+					return nil, err
+				}
+
+				dir2 := path.Join(dir1, randomString(10))
+				t.Logf("Creating directory %s", dir2)
+
+				if err := os.Mkdir(dir2, 0744); err != nil {
+					return nil, err
+				}
+
+				d2 := []byte("hello")
+				if err = ioutil.WriteFile(path.Join(dir2, "d2.yml"), d2, 0644); err != nil {
+					return nil, err
+				}
+
+				dir3 := path.Join(dir2, randomString(10))
+				t.Logf("Creating directory %s", dir3)
+
+				if err := os.Mkdir(dir3, 0744); err != nil {
+					return nil, err
+				}
+
+				d3 := []byte("hello")
+				if err = ioutil.WriteFile(path.Join(dir2, "d3.yml"), d3, 0644); err != nil {
+					return nil, err
+				}
+
+				dir4 := path.Join(dir3, randomString(10))
+				t.Logf("Creating directory %s", dir3)
+
+				if err := os.Mkdir(dir4, 0744); err != nil {
+					return nil, err
+				}
+
+				d4 := []byte("hello")
+				if err = ioutil.WriteFile(path.Join(dir4, "d4.yml"), d4, 0644); err != nil {
+					return nil, err
+				}
+
+				return []string{fmt.Sprintf("%s/**/*.yml", dir1)}, err
+			},
+			want:    []string{"d1.yml", "d2.yml", "d3.yml", "d4.yml"},
+			wantErr: false,
+		},
+		{
+			name: "Check globstars with duplicate files",
+			init: func(t *testing.T) ([]string, error) {
+				dir1, err := tempDir(t)
+				if err != nil {
+					return nil, err
+				}
+
+				d1 := []byte("hello")
+				if err = ioutil.WriteFile(path.Join(dir1, "d1.yml"), d1, 0644); err != nil {
+					return nil, err
+				}
+
+				dir2 := path.Join(dir1, randomString(10))
+				t.Logf("Creating directory %s", dir2)
+
+				if err := os.Mkdir(dir2, 0744); err != nil {
+					return nil, err
+				}
+
+				d2 := []byte("hello")
+				if err = ioutil.WriteFile(path.Join(dir2, "d2.yml"), d2, 0644); err != nil {
+					return nil, err
+				}
+
+				dir3 := path.Join(dir2, randomString(10))
+				t.Logf("Creating directory %s", dir3)
+
+				if err := os.Mkdir(dir3, 0744); err != nil {
+					return nil, err
+				}
+
+				d3 := []byte("hello")
+				if err = ioutil.WriteFile(path.Join(dir2, "d3.yml"), d3, 0644); err != nil {
+					return nil, err
+				}
+
+				dir4 := path.Join(dir3, randomString(10))
+				t.Logf("Creating directory %s", dir3)
+
+				if err := os.Mkdir(dir4, 0744); err != nil {
+					return nil, err
+				}
+
+				d4 := []byte("hello")
+				if err = ioutil.WriteFile(path.Join(dir4, "d4.yml"), d4, 0644); err != nil {
+					return nil, err
+				}
+
+				return []string{dir2, dir3, fmt.Sprintf("%s/**/*.yml", dir1)}, err
+			},
+			want:    []string{"d1.yml", "d2.yml", "d3.yml", "d4.yml"},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: marc audefroy <marc.audefroy@corp.ovh.com>

Feature: Handle globstars ** for suite parameter.

## Context

Given this folder testsuites structure
```
MyApp/
  testA/
     test_a.yml 
     testB/
        test_b.yml 
        testC/
          test_c.yml 
```


## Issues 

If we ask MyApp/**/*.yml to venom. The getFilesPath method will returns

[testA/test_a.yml]

## Resolutions

By using github.com/mattn/go-zglob, we can handle globstars. 

After modifications, getFilesPath method returns : 

[testA/testB/testC/test_c.yml testA/testB/test_b.yml testA/test_a.yml]

## Unit tests

Before process_files modification, execute unit tests :

```
--- FAIL: Test_getFilesPath (0.00s)
    --- FAIL: Test_getFilesPath/Check_globstars (0.00s)
        process_files_test.go:22: Creating directory /var/folders/gd/g3_lfygs2r5_4x921ccgzmm80000gn/T/BTV27
        process_files_test.go:113: Creating directory /var/folders/gd/g3_lfygs2r5_4x921ccgzmm80000gn/T/BTV27/nfSQJjQh6K
        process_files_test.go:125: Creating directory /var/folders/gd/g3_lfygs2r5_4x921ccgzmm80000gn/T/BTV27/nfSQJjQh6K/tKJqFFAKzY
        process_files_test.go:137: Creating directory /var/folders/gd/g3_lfygs2r5_4x921ccgzmm80000gn/T/BTV27/nfSQJjQh6K/tKJqFFAKzY
        process_files_test.go:177: getFilesPath() error want d1.yml got [/var/folders/gd/g3_lfygs2r5_4x921ccgzmm80000gn/T/BTV27/nfSQJjQh6K/d2.yml /var/folders/gd/g3_lfygs2r5_4x921ccgzmm80000gn/T/BTV27/nfSQJjQh6K/d3.yml]
        process_files_test.go:177: getFilesPath() error want d4.yml got [/var/folders/gd/g3_lfygs2r5_4x921ccgzmm80000gn/T/BTV27/nfSQJjQh6K/d2.yml /var/folders/gd/g3_lfygs2r5_4x921ccgzmm80000gn/T/BTV27/nfSQJjQh6K/d3.yml]
INFO[0000] Assign 'assignVar' value 'this is the 
value' 
INFO[0000] Assign "assignVarWithRegex" from regexp "this is (?s:(.*))", values ["this is the \nvalue" "the \nvalue"] 
FAIL
exit status 1
FAIL    github.com/ovh/venom    0.630s
```

After process_files modification, execute unit tests :

```
INFO[0000] Assign 'assignVar' value 'this is the 
value' 
INFO[0000] Assign "assignVarWithRegex" from regexp "this is (?s:(.*))", values ["this is the \nvalue" "the \nvalue"] 
PASS
ok      github.com/ovh/venom    0.629s
```
