### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
@@ -171,7 +170,7 @@ type ConfigFileData struct {
 
 // Configuration file overrides the environment variables.
 func initFromReaderConfigFile(reader io.Reader) error {
-	btes, err := ioutil.ReadAll(reader)
+	btes, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}
@@ -425,7 +424,7 @@ func readInitialVariables(ctx context.Context, argsVars []string, argVarsFiles [
 
 	for _, r := range argVarsFiles {
 		var tmpResult = map[string]interface{}{}
-		btes, err := ioutil.ReadAll(r)
+		btes, err := io.ReadAll(r)
 		if err != nil {
 			return nil, err
 		}

--- a/executors/dbfixtures/dbfixtures.go
+++ b/executors/dbfixtures/dbfixtures.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	fixtures "github.com/go-testfixtures/testfixtures/v3"
@@ -73,7 +73,7 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, er
 		for _, s := range e.Schemas {
 			venom.Debug(ctx, "loading schema from file %s\n", s)
 			s = path.Join(workdir, s)
-			sbytes, errs := ioutil.ReadFile(s)
+			sbytes, errs := os.ReadFile(s)
 			if errs != nil {
 				return nil, errs
 			}

--- a/executors/exec/exec.go
+++ b/executors/exec/exec.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -84,7 +83,7 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 	}
 
 	// Create a tmp file
-	tmpscript, err := ioutil.TempFile(os.TempDir(), "venom-")
+	tmpscript, err := os.CreateTemp(os.TempDir(), "venom-")
 	if err != nil {
 		return nil, fmt.Errorf("cannot create tmp file: %s", err)
 	}

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -192,7 +191,7 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 		if err != nil {
 			return nil, err
 		}
-		btes, err := ioutil.ReadAll(body)
+		btes, err := io.ReadAll(body)
 		if err != nil {
 			return nil, err
 		}
@@ -217,7 +216,7 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 
 		if !e.SkipBody {
 			var errr error
-			bb, errr = ioutil.ReadAll(resp.Body)
+			bb, errr = io.ReadAll(resp.Body)
 			if errr != nil {
 				return nil, errr
 			}
@@ -264,7 +263,7 @@ func (e Executor) getRequest(ctx context.Context, workdir string) (*http.Request
 	} else if e.BodyFile != "" {
 		path := filepath.Join(workdir, e.BodyFile)
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			temp, err := ioutil.ReadFile(path)
+			temp, err := os.ReadFile(path)
 			if err != nil {
 				return nil, err
 			}

--- a/executors/imap/decode.go
+++ b/executors/imap/decode.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"mime/quotedprintable"
@@ -77,7 +76,7 @@ func extract(ctx context.Context, rsp imap.Response) (*Mail, error) {
 					venom.Debug(ctx, "Error while read Part:%s", err)
 					break
 				}
-				slurp, errm := ioutil.ReadAll(p)
+				slurp, errm := io.ReadAll(p)
 				if errm != nil {
 					venom.Debug(ctx, "Error while ReadAll Part:%s", err)
 					continue
@@ -87,7 +86,7 @@ func extract(ctx context.Context, rsp imap.Response) (*Mail, error) {
 			}
 		}
 	} else {
-		body, err = ioutil.ReadAll(r)
+		body, err = io.ReadAll(r)
 		if err != nil {
 			return nil, err
 		}

--- a/executors/kafka/kafka.go
+++ b/executors/kafka/kafka.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -187,7 +186,7 @@ func (e Executor) produceMessages(workdir string) error {
 	if e.MessagesFile != "" {
 		path := filepath.Join(workdir, e.MessagesFile)
 		if _, err = os.Stat(path); err == nil {
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
@@ -234,7 +233,7 @@ func (e Executor) getMessageValue(m *Message, workdir string) ([]byte, error) {
 		return nil, fmt.Errorf("no AVRO schema file specified")
 	}
 	shemaPath := path.Join(workdir, m.AvroSchemaFile)
-	schema, err := ioutil.ReadFile(shemaPath)
+	schema, err := os.ReadFile(shemaPath)
 	if err != nil {
 		return nil, fmt.Errorf("can't read from %s: %w", shemaPath, err)
 	}
@@ -264,7 +263,7 @@ func (e Executor) getRAWMessageValue(m *Message, workdir string) ([]byte, error)
 	}
 	// Read from file
 	s := path.Join(workdir, m.ValueFile)
-	value, err := ioutil.ReadFile(s)
+	value, err := os.ReadFile(s)
 	if err != nil {
 		return nil, fmt.Errorf("can't read from %s: %w", s, err)
 	}

--- a/executors/ovhapi/ovhapi.go
+++ b/executors/ovhapi/ovhapi.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -268,7 +267,7 @@ func (e Executor) getRequestBody(workdir string) (res interface{}, err error) {
 	} else if e.BodyFile != "" {
 		path := filepath.Join(workdir, e.BodyFile)
 		if _, err = os.Stat(path); !os.IsNotExist(err) {
-			bytes, err = ioutil.ReadFile(path)
+			bytes, err = os.ReadFile(path)
 			if err != nil {
 				return nil, err
 			}

--- a/executors/plugins/odbc/odbc.go
+++ b/executors/plugins/odbc/odbc.go
@@ -3,7 +3,7 @@ package main
 import (
 	"C"
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/jmoiron/sqlx"
@@ -79,7 +79,7 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, er
 		workdir := venom.StringVarFromCtx(ctx, "venom.testsuite.workdir")
 		file := path.Join(workdir, e.File)
 		venom.Debug(ctx, "loading SQL file from %s\n", file)
-		sbytes, errs := ioutil.ReadFile(file)
+		sbytes, errs := os.ReadFile(file)
 		if errs != nil {
 			return nil, errs
 		}

--- a/executors/readfile/readfile.go
+++ b/executors/readfile/readfile.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,7 +127,7 @@ func (e *Executor) readfile(workdir string) (Result, error) {
 		h := md5.New()
 		tee := io.TeeReader(f, h)
 
-		b, errr := ioutil.ReadAll(tee)
+		b, errr := io.ReadAll(tee)
 		if errr != nil {
 			return result, fmt.Errorf("Error while reading file: %s", errr)
 		}

--- a/executors/sql/sql.go
+++ b/executors/sql/sql.go
@@ -2,7 +2,7 @@ package sql
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/mitchellh/mapstructure"
@@ -87,7 +87,7 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, er
 		workdir := venom.StringVarFromCtx(ctx, "venom.testsuite.workdir")
 		file := path.Join(workdir, e.File)
 		venom.Debug(ctx, "loading SQL file from %s\n", file)
-		sbytes, errs := ioutil.ReadFile(file)
+		sbytes, errs := os.ReadFile(file)
 		if errs != nil {
 			return nil, errs
 		}

--- a/executors/ssh/ssh.go
+++ b/executors/ssh/ssh.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -166,7 +165,7 @@ func privateKey(file string) (key ssh.Signer, err error) {
 	}
 
 	//Read the file
-	buf, err := ioutil.ReadFile(file)
+	buf, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/executors/web/web.go
+++ b/executors/web/web.go
@@ -3,7 +3,7 @@ package web
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -351,5 +351,5 @@ func generateErrorHTMLFile(ctx context.Context, page *agouti.Page, name string) 
 	}
 	filename := name + ".dump.html"
 	venom.Info(ctx, "Content of the HTML page is saved in %s", filename)
-	return ioutil.WriteFile(filename, []byte(html), 0644)
+	return os.WriteFile(filename, []byte(html), 0644)
 }

--- a/process.go
+++ b/process.go
@@ -3,7 +3,7 @@ package venom
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +42,7 @@ func (v *Venom) InitLogger() error {
 
 		logrus.SetOutput(v.LogOutput)
 	} else {
-		logrus.SetOutput(ioutil.Discard)
+		logrus.SetOutput(io.Discard)
 	}
 
 	logrus.SetFormatter(&nested.Formatter{

--- a/process_files.go
+++ b/process_files.go
@@ -3,7 +3,6 @@ package venom
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +68,7 @@ type partialTestSuite struct {
 func (v *Venom) readFiles(ctx context.Context, filesPath []string) (err error) {
 	for _, f := range filesPath {
 		log.Info("Reading ", f)
-		btes, err := ioutil.ReadFile(f)
+		btes, err := os.ReadFile(f)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read file %q", f)
 		}

--- a/process_files_test.go
+++ b/process_files_test.go
@@ -2,7 +2,6 @@ package venom
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -61,7 +60,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d1 := []byte("hello")
-				err = ioutil.WriteFile(path.Join(dir, "d1.yml"), d1, 0644)
+				err = os.WriteFile(path.Join(dir, "d1.yml"), d1, 0644)
 				return []string{dir}, err
 			},
 			want:    []string{"d1.yml"},
@@ -76,7 +75,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d1 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir1, "d1.yml"), d1, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir1, "d1.yml"), d1, 0644); err != nil {
 					return nil, err
 				}
 
@@ -88,7 +87,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d2 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir2, "d2.yml"), d2, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir2, "d2.yml"), d2, 0644); err != nil {
 					return nil, err
 				}
 
@@ -106,7 +105,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d1 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir1, "d1.yml"), d1, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir1, "d1.yml"), d1, 0644); err != nil {
 					return nil, err
 				}
 
@@ -118,7 +117,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d2 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir2, "d2.yml"), d2, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir2, "d2.yml"), d2, 0644); err != nil {
 					return nil, err
 				}
 
@@ -130,7 +129,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d3 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir2, "d3.yml"), d3, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir2, "d3.yml"), d3, 0644); err != nil {
 					return nil, err
 				}
 
@@ -142,7 +141,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d4 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir4, "d4.yml"), d4, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir4, "d4.yml"), d4, 0644); err != nil {
 					return nil, err
 				}
 
@@ -160,7 +159,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d1 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir1, "d1.yml"), d1, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir1, "d1.yml"), d1, 0644); err != nil {
 					return nil, err
 				}
 
@@ -172,7 +171,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d2 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir2, "d2.yml"), d2, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir2, "d2.yml"), d2, 0644); err != nil {
 					return nil, err
 				}
 
@@ -184,7 +183,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d3 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir2, "d3.yml"), d3, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir2, "d3.yml"), d3, 0644); err != nil {
 					return nil, err
 				}
 
@@ -196,7 +195,7 @@ func Test_getFilesPath(t *testing.T) {
 				}
 
 				d4 := []byte("hello")
-				if err = ioutil.WriteFile(path.Join(dir4, "d4.yml"), d4, 0644); err != nil {
+				if err = os.WriteFile(path.Join(dir4, "d4.yml"), d4, 0644); err != nil {
 					return nil, err
 				}
 
@@ -240,10 +239,10 @@ func Test_getFilesPath_files_order(t *testing.T) {
 	dir1, _ := tempDir(t)
 
 	d1 := []byte("hello")
-	ioutil.WriteFile(path.Join(dir1, "a.yml"), d1, 0644)
+	os.WriteFile(path.Join(dir1, "a.yml"), d1, 0644)
 
 	d2 := []byte("hello")
-	ioutil.WriteFile(path.Join(dir1, "A.yml"), d2, 0644)
+	os.WriteFile(path.Join(dir1, "A.yml"), d2, 0644)
 
 	input := []string{dir1 + "/a.yml", dir1 + "/A.yml"}
 

--- a/process_teststep.go
+++ b/process_teststep.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"time"
 
@@ -64,7 +64,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 			}
 			filename := path.Join(oDir, fmt.Sprintf("%s.%s.step.%d.dump.json", slug.Make(StringVarFromCtx(ctx, "venom.testsuite.shortName")), slug.Make(tc.Name), stepNumber))
 
-			if err := ioutil.WriteFile(filename, []byte(output), 0644); err != nil {
+			if err := os.WriteFile(filename, []byte(output), 0644); err != nil {
 				return fmt.Errorf("Error while creating file %s: %v", filename, err)
 			}
 			tc.computedVerbose = append(tc.computedVerbose, fmt.Sprintf("writing %s", filename))

--- a/venom.go
+++ b/venom.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -189,7 +188,7 @@ func (v *Venom) registerUserExecutors(ctx context.Context, name string, ts TestS
 
 	for _, f := range executorsPath {
 		log.Info("Reading ", f)
-		btes, err := ioutil.ReadFile(f)
+		btes, err := os.ReadFile(f)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read file %q", f)
 		}

--- a/venom_output.go
+++ b/venom_output.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -55,7 +54,7 @@ func (v *Venom) OutputResult(tests Tests, elapsed time.Duration) error {
 	}
 
 	filename := path.Join(v.OutputDir, "test_results."+v.OutputFormat)
-	if err := ioutil.WriteFile(filename, data, 0600); err != nil {
+	if err := os.WriteFile(filename, data, 0600); err != nil {
 		return fmt.Errorf("Error while creating file %s: %v", filename, err)
 	}
 	v.PrintFunc("Writing file %s\n", filename)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since venom has been upgraded to Go 1.17 (#438), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.