### PR TITLE
Improve Kafka executor

### DIFF
--- a/executors/kafka/kafka.go
+++ b/executors/kafka/kafka.go
@@ -315,6 +315,7 @@ func (e Executor) consumeMessages(ctx context.Context) ([]Message, []interface{}
 		messageLimit: e.MessageLimit,
 		schemaReg:    e.schemaReg,
 		keyFilter:    e.KeyFilter,
+		done:         make(chan struct{}),
 	}
 	if err := consumerGroup.Consume(ctx, e.Topics, h); err != nil {
 		if e.WaitFor > 0 && errors.Is(err, context.DeadlineExceeded) {
@@ -358,6 +359,8 @@ type handler struct {
 	schemaReg    SchemaRegistry
 	keyFilter    string
 	mutex        sync.Mutex
+	done         chan struct{}
+	once         sync.Once
 }
 
 // Setup is run at the beginning of a new session, before ConsumeClaim
@@ -374,6 +377,12 @@ func (h *handler) Cleanup(sarama.ConsumerGroupSession) error {
 func (h *handler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	ctx := session.Context()
 	for message := range claim.Messages() {
+		// Stop consuming if one of the other handler goroutines already hit the message limit
+		select {
+		case <-h.done:
+			return nil
+		default:
+		}
 		consumeFunction := h.consumeJSON
 		if h.withAVRO {
 			consumeFunction = h.consumeAVRO
@@ -393,6 +402,10 @@ func (h *handler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama
 		messagesLen := len(h.messages)
 		if h.messageLimit > 0 && messagesLen >= h.messageLimit {
 			venom.Info(ctx, "message limit reached")
+			// Signal to other handler goroutines that they should stop consuming messages.
+			// Only checking the message length isn't enough in case of filtering by key and never reaching the check.
+			// Using sync.Once to prevent panics from multiple channel closings.
+			h.once.Do(func() { close(h.done) })
 			h.mutex.Unlock()
 			return nil
 		}


### PR DESCRIPTION
Hello 👋 ,

I think I found one potential issue and one improvement for the Kafka executor:

I checked with a topic that has multiple partitions, and Sarama starts multiple goroutines in which the `handler` is used, so `ConsumeClaim` is called from and running in multiple goroutines concurrently. With that:

1. It can happen that despite a `messageLimit` of 1, after one goroutine added a message to `h.messages` and unlocks the mutex, another goroutine could enter and add another message.
    - => Checking the message length _before_ adding another one should fix this
2. Let's say we use a key for filtering, and one goroutine found a matching msg and hits the `messageLimit` and returns. But other goroutines still continue running, because with the `continue` in the key filter condition it never reaches the limit check. I'm not sure if Sarama notices that one goroutine returned and eventually closes the `claim.Messages()` channel itself, because at least the other goroutines don't seem to continue their full `timeout`/`waitTime` duration, but when adding some logs I definitely saw them continue to consume some msgs after one goroutine hit the `messageLimit`.
    - => Using a channel for signaling that the limit has been met should fix this
 
I can split this into two PRs if you prefer that.