### PR TITLE
feat(executors): expose previous steps result

### DIFF
--- a/process_testcase.go
+++ b/process_testcase.go
@@ -270,6 +270,7 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase) {
 		}
 
 		tc.computedVars.AddAll(assign)
+		tc.Vars.AddAll(tc.computedVars)
 	}
 }
 

--- a/tests/lib_custom/foobar_custom_multisteps.yml
+++ b/tests/lib_custom/foobar_custom_multisteps.yml
@@ -1,0 +1,10 @@
+executor: foobarcustommultisteps
+input: {}
+steps:
+- script: echo "hello"
+  vars:
+    content:
+      from: result.systemout
+- script: echo "{{.content}} world"
+output:
+  foobar: "{{.result.systemout}}"

--- a/tests/user_executor_custom_multisteps.yml
+++ b/tests/user_executor_custom_multisteps.yml
@@ -1,0 +1,8 @@
+name: testsuite with a user executor in custom dir which has multiple steps
+testcases:
+- name: testfoobar multisteps custom
+  steps:
+  - type: foobarcustommultisteps
+    assertions:
+    - result.foobar ShouldEqual "hello world"
+


### PR DESCRIPTION
Closes #451

```
@lowlighter ➜ /workspaces/venom (feat-multistep) $ go run cmd/venom/main.go run tests/user_executor_custom_multisteps.yml --lib-dir tests/lib_custom/
 • testsuite with a user executor in custom dir which has multiple steps (tests/user_executor_custom_multisteps.yml)
        • testfoobar-multisteps-custom SUCCESS
```