### PR TITLE
feat(tests): add `range` supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,8 +527,6 @@ The following data types are supported, each exposing contexted variables `.inde
 - A templated string which results in one of the above typing (`string`)
   - It can be either inherited from vars file, or interpolated from a previous step result
 
-Within a range context, `.range` contexted variable will be set to `true` (while it'll be `false` in regular contexts)
-
 For instance, the following example will iterate over an array of two items containing maps:
 ```yaml
 - name: range with harcoded array
@@ -537,14 +535,12 @@ For instance, the following example will iterate over an array of two items cont
     range:
       - actual: hello
         expected: hello
-        index: 0
       - actual: world
         expected: world
-        index: 1
-    script: echo "{{.range}} {{.index}} {{.value.actual}}"
+    script: echo "{{.value.actual}}"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
+    - result.systemout ShouldEqual "{{.value.expected}}"
 ```
 
 More examples are available in [`tests/ranged.yml`](/tests/ranged.yml).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It can also generate xUnit result files.
 * [Advanced usage](#advanced-usage)
   * [Debug your testsuites](#debug-your-testsuites)
   * [Skip testcase](#skip-testcase)
+  * [Iterating over data](#iterating-over-data)
 * [Use venom in CI](#use-venom-in-ci)
 * [Hacking](#hacking)
 * [License](#license)
@@ -507,6 +508,46 @@ testcases:
     - result.code ShouldEqual 0
 
 ```
+
+## Iterating over data
+
+It is possible to iterate over data using `range` attribute.
+
+The following data types are supported, each exposing contexted variables `.index`, `.key` and `.value`:
+
+- An array where each value will be iterated over (`[]interface{}`)
+  - `.index`/`.key`: current iteration index
+  - `.value`: current iteration item value
+- A map where each key will be iterated over (`map[string]interface{}`)
+  - `.index`: current iteration index
+  - `.key`: current iteration item key
+  - `.value`: current iteration item value
+- An integer to perform target step `n` times (`int`)
+  - `.index`/`.key`/`.value`: current iteration index
+- A templated string which results in one of the above typing (`string`)
+  - It can be either inherited from vars file, or interpolated from a previous step result
+
+Within a range context, `.range` contexted variable will be set to `true` (while it'll be `false` in regular contexts)
+
+For instance, the following example will iterate over an array of two items containing maps:
+```yaml
+- name: range with harcoded array
+  steps:
+  - type: exec
+    range:
+      - actual: hello
+        expected: hello
+        index: 0
+      - actual: world
+        expected: world
+        index: 1
+    script: echo "{{.range}} {{.index}} {{.value.actual}}"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
+```
+
+More examples are available in [`tests/ranged.yml`](/tests/ranged.yml).
 
 # FAQ
 

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -173,7 +173,6 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase) {
 		}
 
 		for rangedIndex, rangedData := range ranged.Items {
-			stepVars.Add("range", ranged.Enabled)
 			if ranged.Enabled {
 				Debug(ctx, "processing step %d", rangedIndex)
 				stepVars.Add("index", rangedIndex)

--- a/tests/ranged.yml
+++ b/tests/ranged.yml
@@ -1,0 +1,85 @@
+name: Range testsuite
+vars:
+  rangedata:
+    - actual: foo
+      expected: foo
+      index: 0
+    - actual: bar
+      expected: bar
+      index: 1
+testcases:
+
+- name: range context is not enabled when "range" attribute is not present
+  steps:
+  - type: exec
+    script: echo {{.range}}
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual false
+
+- name: range with harcoded array
+  steps:
+  - type: exec
+    range:
+      - actual: hello
+        expected: hello
+        index: 0
+      - actual: world
+        expected: world
+        index: 1
+    script: echo "{{.range}} {{.index}} {{.value.actual}}"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
+
+- name: range with harcoded map
+  steps:
+  - type: exec
+    range:
+      foo: 
+        actual: hello
+        expected: hello
+        key: foo
+      bar: 
+        actual: world
+        expected: world
+        key: bar
+    script: echo "{{.range}} {{.key}} {{.value.actual}}"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual "true {{.value.key}} {{.value.expected}}"
+
+- name: range with harcoded iterations
+  steps:
+  - type: exec
+    range: 5
+    script: echo "{{.range}} {{.index}}"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual "true {{.value}}"
+
+- name: range with templated items from current context or vars files
+  steps:
+  - type: exec
+    range: '{{.rangedata}}'
+    script: echo "{{.range}} {{.index}} {{.value.actual}}"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
+
+- name: rangeInterpolatedSetup
+  steps:
+  - type: exec
+    script: echo '[{"actual":"hi", "expected":"hi", "index":0}, {"actual":"hey", "expected":"hey", "index":1}]'
+    vars:
+      result:
+        from: result.systemout
+
+- name: range with templated items from a previous test case
+  steps:
+  - type: exec
+    range: '{{.rangeInterpolatedSetup.result}}'
+    script: echo "{{.range}} {{.index}} {{.value.actual}}"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"

--- a/tests/ranged.yml
+++ b/tests/ranged.yml
@@ -9,14 +9,6 @@ vars:
       index: 1
 testcases:
 
-- name: range context is not enabled when "range" attribute is not present
-  steps:
-  - type: exec
-    script: echo {{.range}}
-    assertions:
-    - result.code ShouldEqual 0
-    - result.systemout ShouldEqual false
-
 - name: range with harcoded array
   steps:
   - type: exec
@@ -27,10 +19,10 @@ testcases:
       - actual: world
         expected: world
         index: 1
-    script: echo "{{.range}} {{.index}} {{.value.actual}}"
+    script: echo "{{.index}} {{.value.actual}}"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
+    - result.systemout ShouldEqual "{{.value.index}} {{.value.expected}}"
 
 - name: range with harcoded string map
   steps:
@@ -44,42 +36,39 @@ testcases:
         actual: world
         expected: world
         key: bar
-    script: echo "{{.range}} {{.key}} {{.value.actual}}"
+    script: echo "{{.key}} {{.value.actual}}"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldEqual "true {{.value.key}} {{.value.expected}}"
+    - result.systemout ShouldEqual "{{.value.key}} {{.value.expected}}"
 
 - name: range with harcoded iterations
   steps:
   - type: exec
     range: 5
-    script: echo "{{.range}} {{.index}}"
+    script: echo "{{.index}}"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldEqual "true {{.value}}"
+    - result.systemout ShouldEqual "{{.value}}"
 
 - name: range with templated items from current context or vars files
   steps:
   - type: exec
     range: '{{.rangedata}}'
-    script: echo "{{.range}} {{.index}} {{.value.actual}}"
+    script: echo "{{.index}} {{.value.actual}}"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
-
-- name: rangeInterpolatedSetup
-  steps:
-  - type: exec
-    script: echo '[{"actual":"hi", "expected":"hi", "index":0}, {"actual":"hey", "expected":"hey", "index":1}]'
-    vars:
-      result:
-        from: result.systemout
+    - result.systemout ShouldEqual "{{.value.index}} {{.value.expected}}"
 
 - name: range with templated items from a previous test case
   steps:
   - type: exec
-    range: '{{.rangeInterpolatedSetup.result}}'
-    script: echo "{{.range}} {{.index}} {{.value.actual}}"
+    script: echo '[{"actual":"hi", "expected":"hi", "index":0}, {"actual":"hey", "expected":"hey", "index":1}]'
+    vars:
+      previousResult:
+        from: result.systemout
+  - type: exec
+    range: '{{.previousResult}}'
+    script: echo "{{.index}} {{.value.actual}}"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
+    - result.systemout ShouldEqual "{{.value.index}} {{.value.expected}}"

--- a/tests/ranged.yml
+++ b/tests/ranged.yml
@@ -32,7 +32,7 @@ testcases:
     - result.code ShouldEqual 0
     - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
 
-- name: range with harcoded map
+- name: range with harcoded string map
   steps:
   - type: exec
     range:

--- a/types.go
+++ b/types.go
@@ -151,6 +151,19 @@ func (t TestStep) StringSliceValue(name string) ([]string, error) {
 	return []string{out}, nil
 }
 
+// Range contains data related to iterable user values
+type Range struct {
+	Enabled    bool
+	Items      []RangeData
+	RawContent interface{} `json:"range"`
+}
+
+// RangeData contains a single iterable user value
+type RangeData struct {
+	Key   string
+	Value interface{}
+}
+
 // Skipped contains data related to a skipped test.
 type Skipped struct {
 	Value string `xml:",cdata" json:"value" yaml:"value,omitempty"`

--- a/types.go
+++ b/types.go
@@ -160,7 +160,7 @@ type Range struct {
 
 // RangeData contains a single iterable user value
 type RangeData struct {
-	Key   string
+	Key   interface{}
 	Value interface{}
 }
 

--- a/types.go
+++ b/types.go
@@ -160,7 +160,7 @@ type Range struct {
 
 // RangeData contains a single iterable user value
 type RangeData struct {
-	Key   interface{}
+	Key   string
 	Value interface{}
 }
 


### PR DESCRIPTION
May close #263 and close #288

This add support for the `range` attribute that can be passed in a step context.
The following types along their contexted variables are supported:
- `[]interface{}`: an array of values
  - `.index`/`.key`: current iteration index
  - `.value`: current iteration item value
- `map[string]interface{}`: a map of values (each key will be iterated over)
  - `.index`: current iteration index
  - `.key`: current iteration item key
  - `.value`: current iteration item value
- `int`: an integer to perform action `n` times
  - `.index`/`.key`/`.value`: current iteration index
- `string`: a templated string which results in one of the above typing 
  - It can be either inherited from vars file, or interpolated from a previous step result 

Within a range context, `.range` variable will be set to `true` (while it'll be `false` in "regular" contexts)
 
Here's an example (see `tests/ranged.yml` in this PR diff for more examples):
```yaml
- name: range with harcoded array
  steps:
  - type: exec
    range:
      - actual: hello
        expected: hello
        index: 0
      - actual: world
        expected: world
        index: 1
    script: echo "{{.range}} {{.index}} {{.value.actual}}"
    assertions:
    - result.code ShouldEqual 0
    - result.systemout ShouldEqual "true {{.value.index}} {{.value.expected}}"
```
Image below show the content of `Range struct` for each test case:
![image](https://user-images.githubusercontent.com/22963968/143625676-514271e2-5c84-4796-af74-5a713307b130.png)

____

I haven't run `go fmt` yet as it'll enclose the current step processing (L176 to L281) within the `for` which make the diff harder to review. If no further changes are requested, I'll run the formatter and add some documentation in the `README.md` with definitive syntax :slightly_smiling_face: 