### PR TITLE
feat(assertions): add logical operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,30 @@ Available formats: jUnit (xml), json, yaml, tap reports
 * ShouldHappenOnOrAfter - [example](https://github.com/ovh/venom/tree/master/tests/assertions/ShouldHappenOnOrAfter.yml)
 * ShouldHappenBetween - [example](https://github.com/ovh/venom/tree/master/tests/assertions/ShouldHappenBetween.yml)
 
+## Using logical operators
+
+While assertions use `and` operator implicitely, it is possible to use other logical operators to perform complex assertions.
+
+Supported operators are `and`, `or` and `xor`.
+
+```yml
+- name: Assertions operators
+  steps:
+  - script: echo 1
+    assertions:
+      - or:
+        - result.systemoutjson ShouldEqual 1 
+        - result.systemoutjson ShouldEqual 2
+      # Nested operators
+      - or:
+        - result.systemoutjson ShouldBeGreaterThanOrEqualTo 1
+        - result.systemoutjson ShouldBeLessThanOrEqualTo 1
+        - or:
+          - result.systemoutjson ShouldEqual 1
+```
+
+More examples are available in [`tests/assertions_operators.yml`](/tests/assertions_operators.yml).
+
 # Advanced usage
 ## Debug your testsuites
 

--- a/assertion.go
+++ b/assertion.go
@@ -171,18 +171,22 @@ func checkBranch(tc TestCase, stepNumber int, branch map[string]interface{}, r i
 	switch operator {
 	case "and":
 		if assertionsSuccess != assertionsCount {
-			err = fmt.Errorf("%d / %d assertions succeeded:\n%s", assertionsSuccess, assertionsCount, strings.Join(results, "\n"))
+			err = fmt.Errorf("%d/%d assertions succeeded:\n%s\n", assertionsSuccess, assertionsCount, strings.Join(results, "\n"))
 		}
 	case "or":
 		if assertionsSuccess == 0 {
-			err = fmt.Errorf("no assertions succeeded:\n%s", strings.Join(results, "\n"))
+			err = fmt.Errorf("no assertions succeeded:\n%s\n", strings.Join(results, "\n"))
 		}
 	case "xor":
 		if assertionsSuccess == 0 {
-			err = fmt.Errorf("no assertions succeeded:\n%s", strings.Join(results, "\n"))
+			err = fmt.Errorf("no assertions succeeded:\n%s\n", strings.Join(results, "\n"))
 		}
 		if assertionsSuccess > 1 {
-			err = fmt.Errorf("multiple assertions succeeded but expected only one to suceed:\n%s", strings.Join(results, "\n"))
+			err = fmt.Errorf("multiple assertions succeeded but expected only one to suceed:\n%s\n", strings.Join(results, "\n"))
+		}
+	case "not":
+		if assertionsSuccess > 0 {
+			err = fmt.Errorf("some assertions succeeded but expected none to suceed:\n%s\n", strings.Join(results, "\n"))
 		}
 	default:
 		return newFailure(tc, stepNumber, "", fmt.Errorf("unsupported assertion operator %s", operator)), nil

--- a/executors/README.md
+++ b/executors/README.md
@@ -42,7 +42,7 @@ type Result struct {
 // GetDefaultAssertions return default assertions for this executor
 // Optional
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.code ShouldEqual 0"}}
 }
 
 // Run execute TestStep

--- a/executors/dbfixtures/dbfixtures.go
+++ b/executors/dbfixtures/dbfixtures.go
@@ -115,7 +115,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return the default assertions of the executor.
 func (e Executor) GetDefaultAssertions() venom.StepAssertions {
-	return venom.StepAssertions{Assertions: []string{}}
+	return venom.StepAssertions{Assertions: []venom.Assertion{}}
 }
 
 // loadFixtures loads the fixtures in the database.

--- a/executors/exec/exec.go
+++ b/executors/exec/exec.go
@@ -49,7 +49,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.code ShouldEqual 0"}}
 }
 
 // Run execute TestStep of type exec

--- a/executors/grpc/grpc.go
+++ b/executors/grpc/grpc.go
@@ -94,7 +94,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.code ShouldEqual 0"}}
 }
 
 // Run execute TestStep of type exec

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -82,7 +82,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for this executor
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.statuscode ShouldEqual 200"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.statuscode ShouldEqual 200"}}
 }
 
 // Run execute TestStep

--- a/executors/imap/imap.go
+++ b/executors/imap/imap.go
@@ -64,7 +64,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.err ShouldNotExist"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.err ShouldNotExist"}}
 }
 
 // Run execute TestStep of type exec

--- a/executors/kafka/kafka.go
+++ b/executors/kafka/kafka.go
@@ -111,7 +111,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.err ShouldBeEmpty"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.err ShouldBeEmpty"}}
 }
 
 // Run execute TestStep of type exec

--- a/executors/mqtt/mqtt.go
+++ b/executors/mqtt/mqtt.go
@@ -69,7 +69,7 @@ type Result struct {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.error ShouldBeEmpty"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.error ShouldBeEmpty"}}
 }
 
 func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, error) {

--- a/executors/ovhapi/ovhapi.go
+++ b/executors/ovhapi/ovhapi.go
@@ -67,7 +67,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for this executor
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.statuscode ShouldEqual 200"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.statuscode ShouldEqual 200"}}
 }
 
 // Run execute TestStep

--- a/executors/plugins/README.md
+++ b/executors/plugins/README.md
@@ -52,7 +52,7 @@ func (e Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return the default assertions of the executor.
 func (e Executor) GetDefaultAssertions() venom.StepAssertions {
-	return venom.StepAssertions{Assertions: []string{}}
+	return venom.StepAssertions{Assertions: []venom.Assertion{}}
 }
 
 ```

--- a/executors/plugins/hello/hello.go
+++ b/executors/plugins/hello/hello.go
@@ -45,5 +45,5 @@ func (e Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return the default assertions of the executor.
 func (e Executor) GetDefaultAssertions() venom.StepAssertions {
-	return venom.StepAssertions{Assertions: []string{}}
+	return venom.StepAssertions{Assertions: []venom.Assertion{}}
 }

--- a/executors/plugins/odbc/odbc.go
+++ b/executors/plugins/odbc/odbc.go
@@ -104,7 +104,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return the default assertions of the executor.
 func (e Executor) GetDefaultAssertions() venom.StepAssertions {
-	return venom.StepAssertions{Assertions: []string{}}
+	return venom.StepAssertions{Assertions: []venom.Assertion{}}
 }
 
 // handleRows iter on each SQL rows result sets and serialize it into a []Row.

--- a/executors/rabbitmq/rabbitmq.go
+++ b/executors/rabbitmq/rabbitmq.go
@@ -76,7 +76,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.error ShouldBeEmpty"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.error ShouldBeEmpty"}}
 }
 
 // Run execute TestStep of type exec

--- a/executors/readfile/readfile.go
+++ b/executors/readfile/readfile.go
@@ -56,7 +56,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.err ShouldBeEmpty"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.err ShouldBeEmpty"}}
 }
 
 // Run execute TestStep of type exec

--- a/executors/smtp/smtp.go
+++ b/executors/smtp/smtp.go
@@ -49,7 +49,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.err ShouldBeEmpty"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.err ShouldBeEmpty"}}
 }
 
 // Run execute TestStep of type exec

--- a/executors/sql/sql.go
+++ b/executors/sql/sql.go
@@ -112,7 +112,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return the default assertions of the executor.
 func (e Executor) GetDefaultAssertions() venom.StepAssertions {
-	return venom.StepAssertions{Assertions: []string{}}
+	return venom.StepAssertions{Assertions: []venom.Assertion{}}
 }
 
 // handleRows iter on each SQL rows result sets and serialize it into a []Row.

--- a/executors/ssh/ssh.go
+++ b/executors/ssh/ssh.go
@@ -50,7 +50,7 @@ func (Executor) ZeroValueResult() interface{} {
 
 // GetDefaultAssertions return default assertions for type exec
 func (Executor) GetDefaultAssertions() *venom.StepAssertions {
-	return &venom.StepAssertions{Assertions: []string{"result.code ShouldEqual 0"}}
+	return &venom.StepAssertions{Assertions: []venom.Assertion{"result.code ShouldEqual 0"}}
 }
 
 // Run execute TestStep of type exec

--- a/tests/assertions_operators.yml
+++ b/tests/assertions_operators.yml
@@ -36,6 +36,17 @@ testcases:
           - or:
             - result.systemoutjson ShouldEqual 1
 
+  - name: AssertionsOperatorNested2
+    steps:
+    - script: echo 1
+      assertions:
+        - or:
+          - or:
+            - or:
+              - or:
+                - or:
+                  - result.systemoutjson ShouldEqual 1
+
   - name: AssertionsReadmeExample
     steps:
     - script: echo 1

--- a/tests/assertions_operators.yml
+++ b/tests/assertions_operators.yml
@@ -17,14 +17,6 @@ testcases:
           - result.systemoutjson ShouldEqual 1 
           - result.systemoutjson ShouldEqual 2
 
-  - name: AssertionsOperatorOrError
-    steps:
-    - script: echo 1
-      assertions:
-        - or:
-          - result.systemoutjson ShouldEqual 0 
-          - result.systemoutjson ShouldEqual 2
-
   - name: AssertionsOperatorXor
     steps:
     - script: echo 1
@@ -33,25 +25,16 @@ testcases:
           - result.systemoutjson ShouldEqual 1
           - result.systemoutjson ShouldEqual 2
 
-  - name: AssertionsOperatorXorError
-    steps:
-    - script: echo 1
-      assertions:
-        - xor:
-          - result.systemoutjson ShouldEqual 1
-          - result.systemoutjson ShouldContain 1 
-
   - name: AssertionsOperatorNested
     steps:
     - script: echo 1
       assertions:
         - or:
-            - and:
-              - result.systemoutjson ShouldBeGreaterThanOrEqualTo 1
-              - result.systemoutjson ShouldBeLessThanOrEqualTo 1
-            - or:
-              - result.systemoutjson ShouldEqual 1
-
+          - and:
+            - result.systemoutjson ShouldBeGreaterThanOrEqualTo 1
+            - result.systemoutjson ShouldBeLessThanOrEqualTo 1
+          - or:
+            - result.systemoutjson ShouldEqual 1
 
   - name: AssertionsReadmeExample
     steps:
@@ -66,3 +49,46 @@ testcases:
           - result.systemoutjson ShouldBeLessThanOrEqualTo 1
           - or:
             - result.systemoutjson ShouldEqual 1
+
+  - name: AssertionsOperatorNot
+    steps:
+    - script: echo 1
+      assertions:
+        - not: 
+          - result.systemoutjson ShouldEqual 0
+
+  - name: AssertionsOperatorOrError
+    steps:
+    - script: echo 1
+      assertions:
+        - not:
+          - or:
+            - result.systemoutjson ShouldEqual 0
+            - result.systemoutjson ShouldEqual 2
+
+  - name: AssertionsOperatorXorErrorMultiple
+    steps:
+    - script: echo 1
+      assertions:
+        - not:
+          - xor:
+            - result.systemoutjson ShouldEqual 1
+            - result.systemoutjson ShouldContain 1 
+
+  - name: AssertionsOperatorXorErrorNone
+    steps:
+    - script: echo 1
+      assertions:
+        - not:
+          - xor:
+            - result.systemoutjson ShouldEqual 0
+            - result.systemoutjson ShouldContain 0
+
+  - name: AssertionsOperatorAndError
+    steps:
+    - script: echo 1
+      assertions:
+        - not:
+          - and:
+            - result.systemoutjson ShouldEqual 1
+            - result.systemoutjson ShouldContain 0

--- a/tests/assertions_operators.yml
+++ b/tests/assertions_operators.yml
@@ -1,0 +1,68 @@
+name: Assertions testsuite
+testcases:
+
+  - name: AssertionsOperatorAnd
+    steps:
+    - script: echo 1
+      assertions:
+        - and:
+          - result.systemoutjson ShouldEqual 1 
+          - result.systemoutjson ShouldContain 1
+
+  - name: AssertionsOperatorOr
+    steps:
+    - script: echo 1
+      assertions:
+        - or:
+          - result.systemoutjson ShouldEqual 1 
+          - result.systemoutjson ShouldEqual 2
+
+  - name: AssertionsOperatorOrError
+    steps:
+    - script: echo 1
+      assertions:
+        - or:
+          - result.systemoutjson ShouldEqual 0 
+          - result.systemoutjson ShouldEqual 2
+
+  - name: AssertionsOperatorXor
+    steps:
+    - script: echo 1
+      assertions:
+        - xor:
+          - result.systemoutjson ShouldEqual 1
+          - result.systemoutjson ShouldEqual 2
+
+  - name: AssertionsOperatorXorError
+    steps:
+    - script: echo 1
+      assertions:
+        - xor:
+          - result.systemoutjson ShouldEqual 1
+          - result.systemoutjson ShouldContain 1 
+
+  - name: AssertionsOperatorNested
+    steps:
+    - script: echo 1
+      assertions:
+        - or:
+            - and:
+              - result.systemoutjson ShouldBeGreaterThanOrEqualTo 1
+              - result.systemoutjson ShouldBeLessThanOrEqualTo 1
+            - or:
+              - result.systemoutjson ShouldEqual 1
+
+
+  - name: AssertionsReadmeExample
+    steps:
+    - script: echo 1
+      assertions:
+        - or:
+          - result.systemoutjson ShouldEqual 1 
+          - result.systemoutjson ShouldEqual 2
+        # Nested operators
+        - or:
+          - result.systemoutjson ShouldBeGreaterThanOrEqualTo 1
+          - result.systemoutjson ShouldBeLessThanOrEqualTo 1
+          - or:
+            - result.systemoutjson ShouldEqual 1

--- a/types.go
+++ b/types.go
@@ -49,9 +49,12 @@ func (h *H) AddAllWithPrefix(p string, h2 H) {
 	}
 }
 
+// Assertion (usually a string, but could be a dictionary when using logical operators)
+type Assertion interface{}
+
 // StepAssertions contains step assertions
 type StepAssertions struct {
-	Assertions []string `json:"assertions,omitempty" yaml:"assertions,omitempty"`
+	Assertions []Assertion `json:"assertions,omitempty" yaml:"assertions,omitempty"`
 }
 
 // Tests contains all informations about tests in a pipeline build


### PR DESCRIPTION
Closes #312 

This add support for logical operators syntax.
Supported operators are `and`, `or` and `xor`.
Nested operators are also supported.

There's a `not` operator too but it was added mostly to test that operators work correctly in tests case. User should use the respective "Not" assertions functions as a best practice rather than use it, that's why I didn't really document this one.

```yml
- name: Assertions operators
  steps:
  - script: echo 1
    assertions:
      - or:
        - result.systemoutjson ShouldEqual 1 
        - result.systemoutjson ShouldEqual 2
      # Nested operators
      - or:
        - result.systemoutjson ShouldBeGreaterThanOrEqualTo 1
        - result.systemoutjson ShouldBeLessThanOrEqualTo 1
        - or:
          - result.systemoutjson ShouldEqual 1
```

![image](https://user-images.githubusercontent.com/22963968/143942320-45827d55-ba5e-4127-8c84-41d6d5422037.png)