### PR TITLE
Upgrade Kakfa client version to 2.6.0

### DIFF
--- a/executors/kafka/kafka.go
+++ b/executors/kafka/kafka.go
@@ -336,7 +336,7 @@ func (e Executor) getKafkaConfig() (*sarama.Config, error) {
 	config.Net.SASL.Password = e.Password
 	config.Consumer.Return.Errors = true
 	config.Net.DialTimeout = defaultDialTimeout
-	config.Version = sarama.V0_10_2_0
+	config.Version = sarama.V2_6_0_0
 
 	if e.KafkaVersion != "" {
 		kafkaVersion, err := sarama.ParseKafkaVersion(e.KafkaVersion)


### PR DESCRIPTION
Upgrade Kakfa client version to 2.6.0 as older versions do not work correctly with RedPanda, Kafka cluster alternative, written in GO.
We use RedPanda as an alternative to Confluent Kafka, due to fact it takes ~300Mb to download and run single fast GO service, compared to 2.5Gb of download and run 3 slow starting Java services, which are required to run Kafka.