### PR TITLE
Ensure the output file has '.xml' extension

### DIFF
--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -58,6 +58,8 @@ var (
 )
 
 func init() {
+	format = "xml"
+
 	formatFlag = Cmd.Flags().String("format", "xml", "--format:yaml, json, xml, tap")
 	stopOnFailureFlag = Cmd.Flags().Bool("stop-on-failure", false, "Stop running Test Suite on first Test Case failure")
 	verboseFlag = Cmd.Flags().CountP("verbose", "v", "verbose. -vv to very verbose and -vvv to very verbose with CPU Profiling")


### PR DESCRIPTION
fix: when output defaults to XML, the file should have the '.xml' extension (#465)

Signed-off-by: Clement Sciascia <clement.sciascia@ovhcloud.com>

I wasn't sure where to put the default value, feel free to suggest a better way or edit my commit.
The default 'xml' value is already defined in the function that instantiates a Venom struct, but gets overwritten by this 'format' variable after flags parsing