### PR TITLE
feat: detailed steps output

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Flags and their equivalent with environment variables usage:
 - `-v` flag is equivalent to `VENOM_VERBOSE=1` environment variable
 - `-vv` flag is equivalent to `VENOM_VERBOSE=2` environment variable
 
+It is possible to set `NO_COLOR=1` environment variable to disable colors from output.
+
 ## Use a configuration file
 
 You can define the Venom settings using a configuration file `.venomrc`. This configuration file should be placed in the current directory or in the `home` directory.

--- a/tests/failing/verbose_output.yml
+++ b/tests/failing/verbose_output.yml
@@ -1,0 +1,54 @@
+name: Test detailed output
+testcases:
+- name: Test single step 
+  steps:
+    - type: exec
+      script: echo foo
+      assertions:
+        - result.systemout ShouldEqual foo
+- name: Test named step 
+  steps:
+    - name: hello-world
+      type: exec
+      script: echo foo
+      assertions:
+        - result.systemout ShouldEqual foo
+- name: Test multi step
+  steps:
+    - name: step1
+      type: exec
+      script: echo foo
+      assertions:
+        - result.systemout ShouldEqual foo
+    - name: step2
+      type: exec
+      script: echo bar
+      assertions:
+        - result.systemout ShouldEqual foo
+        - result.systemout ShouldEqual baz
+- name: Test ranged steps
+  steps:
+    - type: exec
+      script: echo {{.value.v}}
+      assertions:
+        - result.systemout ShouldEqual foo
+      range:
+        - k: a
+          v: foo
+        - k: b
+          v: bar
+        - k: c
+          v: foo
+- name: Test must assertions
+  steps:
+    - name: must1
+      type: exec
+      script: echo foo
+      assertions:
+        - result.systemout MustEqual bar
+    - name: must2
+      type: exec
+      script: echo foo
+    - name: must3
+      type: exec
+      script: echo bar

--- a/tests/verbose_output.yml
+++ b/tests/verbose_output.yml
@@ -1,0 +1,35 @@
+name: testsuite run in verbose mode
+testcases:
+- name: testsuite run in verbose mode
+  steps:
+  # spawn a venom sub-process and expect it to fail and make assertions on its error messages
+  # ensure no color to avoid annoying checks
+  - type: exec
+    script: NO_COLOR=1 {{.venom.executable}} run failing/verbose_output.yml {{.value.opt}}
+    range:
+      verbose:
+        opt: "-vv"
+        op: Should
+      default:
+        opt: ""
+        op: ShouldNot
+    assertions:
+    - result.code ShouldEqual 2
+    - result.systemerr ShouldBeEmpty
+    # single step
+    - result.systemout {{.value.op}}ContainSubstring 'exec SUCCESS'
+    # named step
+    - result.systemout {{.value.op}}ContainSubstring 'hello-world SUCCESS'
+    # multi steps
+    - result.systemout {{.value.op}}ContainSubstring 'step1 SUCCESS'
+    - result.systemout {{.value.op}}ContainSubstring 'step2 FAILURE'
+    # ranged steps
+    - result.systemout {{.value.op}}ContainSubstring 'exec (range=0) SUCCESS'
+    - result.systemout {{.value.op}}ContainSubstring 'exec (range=1) FAILURE'
+    - result.systemout {{.value.op}}ContainSubstring 'exec (range=2) SUCCESS'
+    # must assertions
+    - result.systemout {{.value.op}}ContainSubstring 'must1 FAILURE'
+    - result.systemout ShouldContainSubstring 'At least one required assertion failed, skipping remaining steps'
+    - result.systemout {{.value.op}}ContainSubstring '2 other steps were skipped'
+    - result.systemout ShouldNotContainSubstring 'must2'
+    - result.systemout ShouldNotContainSubstring 'must3'

--- a/types.go
+++ b/types.go
@@ -113,6 +113,7 @@ type TestCase struct {
 	Time            float64           `xml:"time,attr,omitempty" json:"time" yaml:"time,omitempty"`
 	RawTestSteps    []json.RawMessage `xml:"-" json:"steps" yaml:"steps"`
 	testSteps       []TestStep
+	TestStepResults []TestStepResult
 	TestSuiteVars   H `xml:"-" json:"-" yaml:"-"`
 	Vars            H `xml:"-" json:"-" yaml:"vars"`
 	computedVars    H
@@ -121,6 +122,13 @@ type TestCase struct {
 	Skip            []string `xml:"-" json:"skip" yaml:"skip"`
 	IsExecutor      bool     `xml:"-" json:"-" yaml:"-"`
 	IsEvaluated     bool     `xml:"-" json:"-" yaml:"-"`
+}
+
+type TestStepResult struct {
+	Name     string    `xml:"name,attr" json:"name" yaml:"name"`
+	Skipped  []Skipped `xml:"skipped,omitempty" json:"skipped" yaml:"skipped,omitempty"`
+	Errors   []Failure `xml:"error,omitempty" json:"errors" yaml:"errors,omitempty"`
+	Failures []Failure `xml:"failure,omitempty" json:"failures" yaml:"failures,omitempty"`
 }
 
 // TestStep represents a testStep
@@ -195,22 +203,24 @@ type Failure struct {
 	Message string `xml:"message,attr,omitempty" json:"message" yaml:"message,omitempty"`
 }
 
-func newFailure(tc TestCase, stepNumber int, assertion string, err error) *Failure {
+func newFailure(tc TestCase, stepNumber int, rangedIndex int, assertion string, err error) *Failure {
 	var lineNumber = findLineNumber(tc.Classname, tc.originalName, stepNumber, assertion, -1)
 	var value string
 	if assertion != "" {
-		value = fmt.Sprintf(`Testcase %q, step #%d: Assertion %q failed. %s (%v:%d)`,
+		value = fmt.Sprintf(`Testcase %q, step #%d-%d: Assertion %q failed. %s (%v:%d)`,
 			tc.originalName,
 			stepNumber,
+			rangedIndex,
 			RemoveNotPrintableChar(assertion),
 			RemoveNotPrintableChar(err.Error()),
 			tc.Classname,
 			lineNumber,
 		)
 	} else {
-		value = fmt.Sprintf(`Testcase %q, step #%d: %s (%v:%d)`,
+		value = fmt.Sprintf(`Testcase %q, step #%d-%d: %s (%v:%d)`,
 			tc.originalName,
 			stepNumber,
+			rangedIndex,
 			RemoveNotPrintableChar(err.Error()),
 			tc.Classname,
 			lineNumber,

--- a/types_executor.go
+++ b/types_executor.go
@@ -199,7 +199,7 @@ func (ux UserExecutor) ZeroValueResult() interface{} {
 	return result
 }
 
-func (v *Venom) RunUserExecutor(ctx context.Context, runner ExecutorRunner, tcIn *TestCase, step TestStep) (interface{}, error) {
+func (v *Venom) RunUserExecutor(ctx context.Context, runner ExecutorRunner, tcIn *TestCase, tsIn *TestStepResult, step TestStep) (interface{}, error) {
 	vrs := tcIn.TestSuiteVars.Clone()
 	uxIn := runner.GetExecutor().(UserExecutor)
 
@@ -239,7 +239,7 @@ func (v *Venom) RunUserExecutor(ctx context.Context, runner ExecutorRunner, tcIn
 	Debug(ctx, "running user executor %v", tc.Name)
 	Debug(ctx, "with vars: %v", vrs)
 
-	v.runTestSteps(ctx, tc)
+	v.runTestSteps(ctx, tc, tsIn)
 
 	computedVars, err := DumpString(tc.computedVars)
 	if err != nil {

--- a/venom.go
+++ b/venom.go
@@ -74,7 +74,11 @@ func (v *Venom) Println(format string, a ...interface{}) {
 }
 
 func (v *Venom) PrintlnTrace(s string) {
-	v.Println("\t  %s %s", trace("[trac]"), trace(s)) // nolint
+	v.PrintlnIndentedTrace(s, "")
+}
+
+func (v *Venom) PrintlnIndentedTrace(s string, indent string) {
+	v.Println("\t  %s%s %s", indent, trace("[trac]"), trace(s)) // nolint
 }
 
 func (v *Venom) AddVariables(variables map[string]interface{}) {


### PR DESCRIPTION
Closes #485
This is a followup of #453 

This PR introduces a detailed output:
- each step is logged whether it succeeded or not 
  - failures, trace and info are displayed on associated step with correct indentation
  - `range` are expanded and display current key for easier loop tracking
  - `Must` failed assertions display the number of skipped steps 

Also fix some issues:
- `range` step dump were overwritten because they had the same name
- failures in `range` exited the range loop rather than fallthrough (default behaviour of steps)
- `-v` and `` had actually the same verbosity level

Preview (`-v` output):
![image](https://user-images.githubusercontent.com/22963968/149851265-1034ca3e-a5b1-4d6e-a9c6-8f27459c7154.png)

Preview (default output):
![image](https://user-images.githubusercontent.com/22963968/149852516-585f8016-6cfa-411d-b2c6-4e0d1634aadf.png)
