### PR TITLE
Venom: Support for .yml & .yaml extensions

### DIFF
--- a/process_files.go
+++ b/process_files.go
@@ -25,7 +25,8 @@ func getFilesPath(path []string) (filePaths []string, err error) {
 		// if we put ./test/*.yml, it will fail and it's normal
 		fileInfo, _ := os.Stat(p)
 		if fileInfo != nil && fileInfo.IsDir() {
-			p = p + string(os.PathSeparator) + "*.yml"
+			//check if *.yml or *.yaml files exists in the path
+			p = p + string(os.PathSeparator) + "*.y*ml"
 		}
 
 		fpaths, err := zglob.Glob(p)
@@ -43,7 +44,7 @@ func getFilesPath(path []string) (filePaths []string, err error) {
 	}
 
 	if len(filePaths) == 0 {
-		return nil, fmt.Errorf("no yml file selected")
+		return nil, fmt.Errorf("no YAML (*.yml or *.yaml) file found or defined")
 	}
 	return uniq(filePaths), nil
 }


### PR DESCRIPTION

## Observation 

For this PR I started from an observation:

By default, `venom` CLI take in account *.yml* extension.
If it found .yml file, no need to specify them in the `venom run` command line:
```
$ tree /Users/avache/tmp/venom/2 ; go run main.go run /Users/avache/tmp/venom/2
/Users/avache/tmp/venom/2
└── testsuite.yml

0 directories, 1 file
	  [trac] writing venom.log
 • APIIntegrationTest (/Users/avache/tmp/venom/2/testsuite.yml)
 	• GET-http-testcase-with-5-seconds-timeout SUCCESS
```

But it does not support *.yaml* extension file:
```
$ tree /Users/avache/tmp/venom/1 ; go run main.go run /Users/avache/tmp/venom/1
/Users/avache/tmp/venom/1
└── testsuite.yaml

0 directories, 1 file
	  [trac] writing venom.log
no yml file selected
exit status 2
```

But:
* YAML recommend that we use .yaml extension (https://yaml.org/faq.html)
* We can see people using *.yml* or *.yaml* extension for YAML files, depending all the time

And: « no yaml file selected », the text message is not very true because we have a YAML file but not in the extension it wanted to :) .


Sometimes in the code we supports both:
```
for _, fp := range fpaths {
			switch ext := filepath.Ext(fp); ext {
			case ".yml", ".yaml":
				filePaths = append(filePaths, fp)
			}
		}
```

But not in the example I show previously for the `venom run` command support by default.


## Solution

So I recommend that Venom need to supports both *.yml* and *.yaml* extensions, not only .yml by default, all the time.


## New behavior after the feature coded in the PR

Both .yml and .yaml are now supported by default:

```
$  tree /Users/avache/tmp/venom/1 ; go run main.go run /Users/avache/tmp/venom/1
/Users/avache/tmp/venom/1
└── testsuite.yaml

0 directories, 1 file
	  [trac] writing venom.log
[/Users/avache/tmp/venom/1]
 • APIIntegrationTest (/Users/avache/tmp/venom/1/testsuite.yaml)
 	• GET-http-testcase-with-5-seconds-timeout SUCCESS
```

```
$  tree /Users/avache/tmp/venom/2 ; go run main.go run /Users/avache/tmp/venom/2
/Users/avache/tmp/venom/2
└── testsuite.yml

0 directories, 1 file
	  [trac] writing venom.log
[/Users/avache/tmp/venom/2]
 • APIIntegrationTest (/Users/avache/tmp/venom/2/testsuite.yml)
 	• GET-http-testcase-with-5-seconds-timeout SUCCESS
```