### PR TITLE
Gitpod integration to Venom

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: go get -v -t -d ./...
+    command: go run cmd/venom/main.go -h
+vscode:
+  extensions:
+    - golang.go

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Venom is a CLI (Command Line Interface) that aim to create, manage and run your 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ovh/venom)](https://goreportcard.com/report/github.com/ovh/venom)
 [![Dicussions](https://img.shields.io/badge/Discussions-OVHcloud-brightgreen)](https://github.com/ovh/venom/discussions)
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ovh/venom.git)
-
 # Table of content
 
 * [Overview](#overview)
@@ -72,6 +70,12 @@ Example for Linux:
 $ curl https://github.com/ovh/venom/releases/download/v1.0.1/venom.linux-amd64 -L -o /usr/local/bin/venom && chmod +x /usr/local/bin/venom
 $ venom -h
 ```
+
+## Gitpod
+
+Use Gitpod, everything is preinstalled.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ovh/venom.git)
 
 # Updating
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Venom is a CLI (Command Line Interface) that aim to create, manage and run your 
 [![Go Report Card](https://goreportcard.com/badge/github.com/ovh/venom)](https://goreportcard.com/report/github.com/ovh/venom)
 [![Dicussions](https://img.shields.io/badge/Discussions-OVHcloud-brightgreen)](https://github.com/ovh/venom/discussions)
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ovh/venom.git)
+
 # Table of content
 
 * [Overview](#overview)


### PR DESCRIPTION
In order to facilitate the possibility of contributing to Venom, without having to configure the setup on your computer, with everything ready to use, this PR adds integration to GitPod.

GitPod is an Open Source IDEaaS, surprisingly simple and effective solution The principle? A cloud-based development environment, based on Git, Eclipse Theia and Docker, allowing you to develop, test and deploy your code right from a browser window.

If you want to know more about Gitpod:
https://www.youtube.com/watch?v=pDu_rTh_s-0

With this feature, contributors will no longer need to:
- install Go in their computer
- use a Go correct version or update to a good one
- know the command to start the project

To contribute, they will only need to click on "Open to GitPod"... and start to contribute :).

