### PR TITLE
Fix line numbers being duplicated

### DIFF
--- a/process_teststep.go
+++ b/process_teststep.go
@@ -80,17 +80,16 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 				continue
 			}
 			filename := StringVarFromCtx(ctx, "venom.testsuite.filename")
-			originalName := tc.originalName
 			lineNumber := findLineNumber(filename, tc.originalName, stepNumber, i, ninfo+1)
 			if lineNumber > 0 {
 				info += fmt.Sprintf(" (%s:%d)", filename, lineNumber)
 			} else if tc.IsExecutor {
 				filename = StringVarFromCtx(ctx, "venom.executor.filename")
-				originalName = StringVarFromCtx(ctx, "venom.executor.name")
+				originalName := StringVarFromCtx(ctx, "venom.executor.name")
 				lineNumber = findLineNumber(filename, originalName, stepNumber, i, ninfo+1)
-			}
-			if lineNumber > 0 {
-				info += fmt.Sprintf(" (%s:%d)", filename, lineNumber)
+				if lineNumber > 0 {
+					info += fmt.Sprintf(" (%s:%d)", filename, lineNumber)
+				}
 			}
 			Info(ctx, info)
 			tc.computedInfo = append(tc.computedInfo, info)


### PR DESCRIPTION
Noticed that line numbers appear to be duplicated. I believe it stems from these lines. If `linenumber > 0` then the line number statement will be added twice, at lines 85 and 92 of the previous commit. This moves the second conditional statement into the else-clause of the first conditional statement, so it's only added once.

Signed-off-by: Sean Lane <sean.lane@neighbor.com>