### PR TITLE
Add ShouldTimeEqual assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Builtin variables:
 * ShouldHappenAfter - [example](https://github.com/ovh/venom/tree/master/tests/assertions/ShouldHappenAfter.yml)
 * ShouldHappenOnOrAfter - [example](https://github.com/ovh/venom/tree/master/tests/assertions/ShouldHappenOnOrAfter.yml)
 * ShouldHappenBetween - [example](https://github.com/ovh/venom/tree/master/tests/assertions/ShouldHappenBetween.yml)
+* ShouldTimeEqual - [example](https://github.com/ovh/venom/tree/master/tests/assertions/ShouldTimeEqual.yml)
 
 #### `Must` keywords
 

--- a/assertions/assertions.go
+++ b/assertions/assertions.go
@@ -56,6 +56,7 @@ var assertMap = map[string]AssertFunc{
 	"ShouldHappenAfter":            ShouldHappenAfter,
 	"ShouldHappenOnOrAfter":        ShouldHappenOnOrAfter,
 	"ShouldHappenBetween":          ShouldHappenBetween,
+	"ShouldTimeEqual":              ShouldTimeEqual,
 }
 
 func Get(s string) (AssertFunc, bool) {
@@ -1045,6 +1046,41 @@ func ShouldHappenBetween(actual interface{}, expected ...interface{}) error {
 		return nil
 	}
 	return fmt.Errorf("expected '%v' to be between '%v' and '%v' ", actualTime, min, max)
+}
+
+// ShouldTimeEqual receives exactly 2 time.Time arguments and does a time equality check.
+// The arguments have to respect the date format RFC3339, as 2006-01-02T15:04:00+07:00
+//
+// Example of testsuite file:
+//
+//  name: test ShouldTimeEqual
+//  vars:
+//    time_expected: 2006-01-02T13:04:00Z
+//    time: 2006-01-02T15:04:00+02:00
+//  testcases:
+//  - name: test assertion
+//    steps:
+//    - type: exec
+//      script: "echo {{.time}}"
+//      assertions:
+//        - result.systemout ShouldTimeEqual "{{.time_expected}}"
+func ShouldTimeEqual(actual interface{}, expected ...interface{}) error {
+	if err := need(1, expected); err != nil {
+		return err
+	}
+
+	actualTime, err := getTimeFromString(actual)
+	if err != nil {
+		return err
+	}
+	expectedTime, err := getTimeFromString(expected[0])
+	if err != nil {
+		return err
+	}
+	if actualTime.Equal(expectedTime) {
+		return nil
+	}
+	return fmt.Errorf("expected '%v' to be time equals to '%v' ", actualTime, expectedTime)
 }
 
 func getTimeFromString(in interface{}) (time.Time, error) {

--- a/assertions/assertions_test.go
+++ b/assertions/assertions_test.go
@@ -1344,3 +1344,57 @@ func TestShouldHappenBetween(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldTimeEqual(t *testing.T) {
+	type args struct {
+		actual   interface{}
+		expected []interface{}
+	}
+
+	Parisloc, _ := time.LoadLocation("Europe/Paris")
+
+	now := time.Now()
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			args: args{
+				actual:   now,
+				expected: []interface{}{now.In(Parisloc)},
+			},
+		},
+		{
+			name: "ko",
+			args: args{
+				actual:   now,
+				expected: []interface{}{now.Add(1 * time.Second)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "ok",
+			args: args{
+				actual:   "2006-01-02T15:04:00+02:00",
+				expected: []interface{}{"2006-01-02T13:04:00Z"},
+			},
+		},
+		{
+			name: "ko",
+			args: args{
+				actual:   "2006-01-02T15:04:00+07:00",
+				expected: []interface{}{"2006-01-02T15:04:05Z"},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ShouldTimeEqual(tt.args.actual, tt.args.expected...); (err != nil) != tt.wantErr {
+				t.Errorf("ShouldTimeEqual() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/tests/assertions/ShouldTimeEqual.yml
+++ b/tests/assertions/ShouldTimeEqual.yml
@@ -1,0 +1,11 @@
+name: test ShouldTimeEqual - use RFC3339 format
+vars:
+  time_expected: 2006-01-02T13:04:00Z
+  time: 2006-01-02T15:04:00+02:00
+testcases:
+  - name: test assertion
+    steps:
+      - type: exec
+        script: "echo {{.time}}"
+        assertions:
+          - result.systemout ShouldTimeEqual "{{.time_expected}}"


### PR DESCRIPTION
ShoudlEqual assertion return error when we try to compare time in differents location. 

To resolve this issue, we add ShouldEqualTime assertion to check equality between two time.Time. 


```
// ShouldTimeEqual receives exactly 2 time.Time arguments and does a time equality check.
// The arguments have to respect the date format RFC3339, as 2006-01-02T15:04:00+07:00
//
// Example of testsuite file:
//
//  name: test ShouldTimeEqual
//  vars:
//    time_1: 2006-01-02T13:04:00Z
//    time_2: 2006-01-02T15:04:00+02:00
//  testcases:
//  - name: test assertion
//    steps:
//    - type: exec
//      script: "echo {{.time}}"
//      assertions:
//        - result.systemout ShouldTimeEqual "{{.time_1}}" 
```
