### PR TITLE
Fix absolute file path for gRPC TLS certs

### DIFF
--- a/executors/grpc/grpc.go
+++ b/executors/grpc/grpc.go
@@ -143,7 +143,10 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 
 		// connect to a TLS server
 		if e.TLSRootCA != "" {
-			TLSRootCAFilepath := filepath.Join(workdir, e.TLSRootCA)
+			TLSRootCAFilepath := e.TLSRootCA
+			if !filepath.IsAbs(e.TLSRootCA) {
+				TLSRootCAFilepath = filepath.Join(workdir, e.TLSRootCA)
+			}
 			var TLSRootCA []byte
 			if _, err := os.Stat(TLSRootCAFilepath); err == nil {
 				TLSRootCA, err = os.ReadFile(TLSRootCAFilepath)
@@ -166,7 +169,10 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 			// connect to a mutual TLS server
 			var TLSClientCert, TLSClientKey []byte
 			if e.TLSClientCert != "" {
-				TLSClientCertFilepath := filepath.Join(workdir, e.TLSClientCert)
+				TLSClientCertFilepath := e.TLSClientCert
+				if !filepath.IsAbs(e.TLSClientCert) {
+					TLSClientCertFilepath = filepath.Join(workdir, e.TLSClientCert)
+				}
 				if _, err := os.Stat(TLSClientCertFilepath); err == nil {
 					TLSClientCert, err = os.ReadFile(TLSClientCertFilepath)
 					if err != nil {
@@ -178,7 +184,10 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 			}
 
 			if e.TLSClientKey != "" {
-				TLSClientKeyFilepath := filepath.Join(workdir, e.TLSClientKey)
+				TLSClientKeyFilepath := e.TLSClientKey
+				if !filepath.IsAbs(e.TLSClientKey) {
+					TLSClientKeyFilepath = filepath.Join(workdir, e.TLSClientKey)
+				}
 				if _, err := os.Stat(TLSClientKeyFilepath); err == nil {
 					TLSClientKey, err = os.ReadFile(TLSClientKeyFilepath)
 					if err != nil {


### PR DESCRIPTION
Fix absolute file path for gRPC TLS certs:
Now you can provide absolute path for TLS certs files