### PR TITLE
fix small typo

### DIFF
--- a/executors/rabbitmq/README.md
+++ b/executors/rabbitmq/README.md
@@ -27,7 +27,7 @@ In your yaml file, you can use:
 
   # For publisher only
   - messages
-    - durable optional      (true or false) (default alse)
+    - durable optional      (true or false) (default false)
     - contentType optional  
     - contentEncoding optional
     - persistent optional (default true)


### PR DESCRIPTION
This fix a small typo of a missing `f`