### PR TITLE
Add feature to produce messages using latest schema available version

### DIFF
--- a/executors/kafka/README.md
+++ b/executors/kafka/README.md
@@ -34,7 +34,7 @@ In your yaml file, you can use:
   - messages.topic - Topic where to post message
   - messages.value - Value for message
   - messages.valueFile - Take value for message from file provided here
-  - messages.avroSchemaFile - Specify Avro schema file. messages.valueFile or messages.value should have value, which can be encoded with that schema
+  - messages.avroSchemaFile - Specify Avro schema file. messages.valueFile or messages.value should have value, which can be encoded with that schema. If not provided, then it will retrieve the latest available version from schema registry using Topic Name strategy, that is, ${topicName}-value as subject.
 ```
 
 Example without Avro:
@@ -98,6 +98,8 @@ testcases:
     - topic: test-topic
       valueFile: "kafka/values/message2.json"
       avroSchemaFile: "kafka/schemas/message.avsc"
+    - topic: test-topic
+      valueFile: "kafka/values/message3.json"
   - type: kafka
     clientType: consumer
     withTLS: true
@@ -106,7 +108,7 @@ testcases:
     password: "{{.kafkaPwd}}"
     markOffset: true
     initialOffset: oldest
-    messageLimit: 1
+    messageLimit: 2
     groupID: venom
     addrs:
       - "{{.kafkaHost}}:{{.kafkaPort}}"
@@ -115,5 +117,6 @@ testcases:
     assertions:
     - result.messagesjson.messagesjson0.value.id ShouldEqual 1
     - result.messagesjson.messagesjson0.value.message ShouldEqual "Some test"
-    - result.messages.__len__ ShouldEqual 1
+    - result.messagesjson.messagesjson1.value.id ShouldEqual 2
+    - result.messages.__len__ ShouldEqual 2
 ```

--- a/executors/kafka/schema_registry.go
+++ b/executors/kafka/schema_registry.go
@@ -13,6 +13,7 @@ type (
 	SchemaRegistry interface {
 		GetSchemaByID(id int) (string, error)
 		RegisterNewSchema(subject, schema string) (int, error)
+		GetLatestSchema(subject string) (int, string, error)
 	}
 
 	client struct {
@@ -48,10 +49,20 @@ func (c client) GetSchemaByID(id int) (string, error) {
 }
 
 // RegisterNewSchema either register a new schema and return the ID or get the ID of an already created schema.
-func (c client) RegisterNewSchema(topic, schema string) (int, error) {
-	schemaID, err := c.client.RegisterNewSchema(topic, schema)
+func (c client) RegisterNewSchema(subject, schema string) (int, error) {
+	schemaID, err := c.client.RegisterNewSchema(subject, schema)
 	if err != nil {
 		return 0, fmt.Errorf("failed to register new schema or fetch already created schema ID: %w", err)
 	}
 	return schemaID, nil
+}
+
+// GetLatestSchema gets latest schema identifier from the given subject.
+func (c client) GetLatestSchema(subject string) (int, string, error) {
+	schema, err := c.client.GetLatestSchema(subject)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to get latest schema ID: %w", err)
+	}
+	
+	return schema.ID, schema.Schema, nil
 }

--- a/tests/kafka/values/message3.json
+++ b/tests/kafka/values/message3.json
@@ -1,0 +1,4 @@
+{
+    "id": 3,
+    "message": "Yet another test"
+}

--- a/tests/kafkaAvro.yml
+++ b/tests/kafkaAvro.yml
@@ -24,6 +24,21 @@ testcases:
       valueFile: "kafka/values/message2.json"
       avroSchemaFile: "kafka/schemas/message.avsc"
   - type: kafka
+    clientType: producer
+    withSASL: false
+    withTLS: false
+    withAVRO: true
+    user: "{{.kafkaUser}}"
+    password: "{{.kafkaPwd}}"
+    addrs:
+      - "{{.kafkaHost}}:{{.kafkaPort}}"
+    schemaRegistryAddr: "{{.kafkaSchemaRegistryHost}}"
+    messages:
+    - topic: test-topic-avro
+      key: '{"id":3}'
+      valueFile: "kafka/values/message3.json"
+      # Don't provide avro schema as already registered
+  - type: kafka
     clientType: consumer
     withTLS: false
     withSASL: false
@@ -32,7 +47,7 @@ testcases:
     password: "{{.kafkaPwd}}"
     markOffset: true
     initialOffset: oldest
-    messageLimit: 2
+    messageLimit: 3
     groupID: venom
     addrs:
       - "{{.kafkaHost}}:{{.kafkaPort}}"
@@ -42,4 +57,6 @@ testcases:
     assertions:
     - result.messagesjson.messagesjson0.value.id ShouldEqual 1
     - result.messagesjson.messagesjson0.value.message ShouldEqual "Some test"
-    - result.messages.__len__ ShouldEqual 2
+    - result.messagesjson.messagesjson1.value.id ShouldEqual 2
+    - result.messagesjson.messagesjson2.value.id ShouldEqual 3
+    - result.messages.__len__ ShouldEqual 3


### PR DESCRIPTION
This way there is no need to provide the AVSC file upon every message by retrieving the latest version from the schema registry, if available.

Code is using a [no longer maintained library](https://github.com/lensesio/schema-registry), I'd suggest to move to https://github.com/riferrei/srclient which is actively maintained.

If you agree, I can open a new PR with that change :).

Thanks for this great project!
