### PR TITLE
Fix skip assertions variables case not managed

### DIFF
--- a/assertion.go
+++ b/assertion.go
@@ -78,7 +78,7 @@ type assertion struct {
 }
 
 func parseAssertions(ctx context.Context, s string, input interface{}) (*assertion, error) {
-	dump, err := Dump(input)
+	dump, err := DumpStringPreserveCase(input)
 	if err != nil {
 		return nil, errors.New("assertion syntax error")
 	}

--- a/assertion.go
+++ b/assertion.go
@@ -78,7 +78,7 @@ type assertion struct {
 }
 
 func parseAssertions(ctx context.Context, s string, input interface{}) (*assertion, error) {
-	dump, err := DumpStringPreserveCase(input)
+	dump, err := DumpPreserveCase(input)
 	if err != nil {
 		return nil, errors.New("assertion syntax error")
 	}

--- a/dump.go
+++ b/dump.go
@@ -15,6 +15,17 @@ func Dump(v interface{}) (map[string]interface{}, error) {
 	return e.ToMap(v)
 }
 
+func DumpPreserveCase(v interface{}) (map[string]interface{}, error) {
+	e := dump.NewDefaultEncoder()
+	e.ExtraFields.Len = true
+	e.ExtraFields.Type = true
+	e.ExtraFields.DetailedStruct = true
+	e.ExtraFields.DetailedMap = true
+	e.ExtraFields.DetailedArray = true
+
+	return e.ToMap(v)
+}
+
 // DumpString dumps v as a map[string]string{}, key in lowercase
 func DumpString(v interface{}) (map[string]string, error) {
 	e := dump.NewDefaultEncoder()

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -1,6 +1,7 @@
 name: "Skip testsuite"
 vars:
   foo: bar
+  cmdResult: "ok"
 
 testcases:
 - name: init
@@ -26,3 +27,21 @@ testcases:
     script: command_not_found
     assertions:
     - result.code ShouldEqual 0
+
+- name: do-not-skip-this-case-sensitive
+  skip: 
+    - cmdResult ShouldEqual ok
+  steps:
+  - type: exec
+    script: exit 0
+
+- name: skip-this-case-sensitive
+  skip: 
+    - cmdResult ShouldNotEqual ok
+  steps:
+  - type: exec
+    script: command_not_found
+    assertions:
+    - result.code ShouldEqual 0
+
+


### PR DESCRIPTION
Closes #522 

Variables mentioned in skip assertions are not case sensitive.
Variables defined with uppercase characters can currently only be used by setting them to lowercase in skip assertions.