### PR TITLE
json objects with uppercase were wrongly decoded in assertions

### DIFF
--- a/assertion.go
+++ b/assertion.go
@@ -78,7 +78,7 @@ type assertion struct {
 }
 
 func parseAssertions(ctx context.Context, s string, input interface{}) (*assertion, error) {
-	dump, err := Dump(input)
+	dump, err := DumpPreserveCase(input)
 	if err != nil {
 		return nil, errors.New("assertion syntax error")
 	}

--- a/dump.go
+++ b/dump.go
@@ -2,7 +2,7 @@ package venom
 
 import "github.com/fsamin/go-dump"
 
-// Dump dumps v as a map[string]interface{}.
+// Dump dumps v as a map[string]interface{}, key in lowercase
 func Dump(v interface{}) (map[string]interface{}, error) {
 	e := dump.NewDefaultEncoder()
 	e.ExtraFields.Len = true
@@ -11,6 +11,18 @@ func Dump(v interface{}) (map[string]interface{}, error) {
 	e.ExtraFields.DetailedMap = true
 	e.ExtraFields.DetailedArray = true
 	e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
+
+	return e.ToMap(v)
+}
+
+// DumpPreserveCase dumps v as a map[string]interface{}.
+func DumpPreserveCase(v interface{}) (map[string]interface{}, error) {
+	e := dump.NewDefaultEncoder()
+	e.ExtraFields.Len = true
+	e.ExtraFields.Type = true
+	e.ExtraFields.DetailedStruct = true
+	e.ExtraFields.DetailedMap = true
+	e.ExtraFields.DetailedArray = true
 
 	return e.ToMap(v)
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -44,7 +44,7 @@ venom-rabbit.cid:
 venom-sshd.cid:
 	$(call docker_run,ghcr.io/linuxserver/openssh-server,sshd,-p 2222:2222 -e PUID=1000 -e PGID=1000 -e TZ=Europe/London -e PUBLIC_KEY="$(shell cat ~/.ssh/id_rsa.pub)" -e USER_NAME=venom -e PASSWORD_ACCESS=true -e USER_PASSWORD=testvenom -e SUDO_ACCESS=true)
 venom-mqtt.cid:
-	$(call docker_run,eclipse-mosquitto,mqtt-broker,-p 1883:1883 -p 9001:9001 -v $(shell realpath mqtt/mosquitto.conf):/mosquitto/config/mosquitto.conf:ro)
+	$(call docker_run,eclipse-mosquitto,mqtt-broker,-p 1883:1883 -p 9001:9001 -v "$(shell realpath mqtt/mosquitto.conf):/mosquitto/config/mosquitto.conf:ro")
 venom-qpid.cid:
 	$(call docker_run,scholzj/qpid-cpp:1.39.0,qpid,-p 5673:5672)
 	docker exec venom-qpid qpid-config add queue amqp-test

--- a/tests/exec.yml
+++ b/tests/exec.yml
@@ -34,3 +34,4 @@ testcases:
     info: "the value of result.systemoutjson is {{.result.systemoutjson}}"
     assertions:
     - result.systemoutjson.foo ShouldContainSubstring bar
+    - result.systemoutjson.fooBar ShouldContainSubstring baz

--- a/tests/exec/testa.json
+++ b/tests/exec/testa.json
@@ -1,3 +1,4 @@
 {
-  "foo": "bar"
+  "foo": "bar",
+  "fooBar": "baz"
 }


### PR DESCRIPTION
if an executor returns a json object, navigation inside this object was impossible on keys with uppercase

I also fixed a small issue with the makefile : if the file path where the project is located has a whitespace, command venom-mqtt.cid was failing. Tell me if such fix should be in a separate PR.