### PR TITLE
feat: add default value for var

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Available helpers and some examples:
 To be able to reuse a property from a teststep in a following testcase or step, you have to extract the variable, as the following example. 
 
 After the first step execution, `venom` extracts a value using a regular expression `foo with a ([a-z]+) here` from the content of the `result.systemout` property returned by the `executor`.
-Then this variable can be reused in another test, with the name `testA.myvariable` with `testA` corresponding to the name of the testcase.
+Then this variable can be reused in another test, with the name `testA.myvariable` with `testA` corresponding to the name of the testcase. A default value could also be supplied if the variable can't be extracted from the output, which can commonly happen when parsing json output.
 
 ```yaml
 name: MyTestSuite
@@ -499,6 +499,7 @@ testcases:
       myvariable:
         from: result.systemout
         regex: foo with a ([a-z]+) here
+        default: "somevalue"
 
 - name: testB
   steps:

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -432,9 +432,12 @@ func processVariableAssigments(ctx context.Context, tcName string, tcVars H, raw
 		if !has {
 			varValue, has = tcVars[tcName+"."+assigment.From]
 			if !has {
-				err := fmt.Errorf("%s reference not found in %s", assigment.From, strings.Join(tcVarsKeys, "\n"))
-				Info(ctx, "%v", err)
-				return nil, true, err
+				if assigment.Default == "" {
+					err := fmt.Errorf("%s reference not found in %s", assigment.From, strings.Join(tcVarsKeys, "\n"))
+					Info(ctx, "%v", err)
+					return nil, true, err
+				}
+				varValue = assigment.Default
 			}
 		}
 		if assigment.Regex == "" {

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -432,7 +432,7 @@ func processVariableAssigments(ctx context.Context, tcName string, tcVars H, raw
 		if !has {
 			varValue, has = tcVars[tcName+"."+assigment.From]
 			if !has {
-				if assigment.Default == "" {
+				if assigment.Default == nil {
 					err := fmt.Errorf("%s reference not found in %s", assigment.From, strings.Join(tcVarsKeys, "\n"))
 					Info(ctx, "%v", err)
 					return nil, true, err

--- a/tests/exec.yml
+++ b/tests/exec.yml
@@ -34,3 +34,15 @@ testcases:
     info: "the value of result.systemoutjson is {{.result.systemoutjson}}"
     assertions:
     - result.systemoutjson.foo ShouldContainSubstring bar
+    vars:
+      foo:
+        from: result.systemoutjson.foo
+      bar:
+        from: result.systemoutjson.notexisting
+        default: "test"
+
+- name: verify default
+  steps:
+  - script: echo "{{.cat-json.foo}} {{.cat-json.bar}}"
+    assertions:
+    - result.systemout ShouldEqual "bar test"

--- a/types.go
+++ b/types.go
@@ -250,8 +250,9 @@ type AssignStep struct {
 }
 
 type Assignment struct {
-	From  string `json:"from" yaml:"from"`
-	Regex string `json:"regex" yaml:"regex"`
+	From    string      `json:"from" yaml:"from"`
+	Regex   string      `json:"regex" yaml:"regex"`
+	Default interface{} `json:"default" yaml:"default"`
 }
 
 // RemoveNotPrintableChar removes not printable chararacter from a string


### PR DESCRIPTION
today, if one of the json elements can't be found, none of the resolution works

```yaml
name: Exec testsuite
testcases:
  - name: catjson
    steps:
      - script: cat exec/testa.json
        info: "the value of result.systemoutjson is {{.result.systemoutjson}}"
        assertions:
          - result.systemoutjson.foo ShouldContainSubstring bar
        vars:
          foo:
            from: result.systemoutjson.foo
          bar:
            from: result.systemoutjson.bar
            default: "test"
      - script: echo "{{.catjson.foo}}"
        info: "the value of foo is {{.catjson.foo}} {{.catjson.bar}}"
```
this is the output
```sh
 • Exec testsuite (tests/exec.yml)
 	• catjson FAILURE
	  [info] the value of result.systemoutjson is {"foo":"bar"} (tests/exec.yml:29)
	  [info] the value of foo is {{.catjson.foo}} {{.catjson.bar}} (tests/exec.yml:39)
```

This change allows a `default` value to be specified such that if it's missing from the json, the default value will be used.
