### PR TITLE
Cache executor files

### DIFF
--- a/venom.go
+++ b/venom.go
@@ -181,6 +181,9 @@ func (v *Venom) getUserExecutorFilesPath(vars map[string]string) (filePaths []st
 			}
 			return nil
 		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	sort.Strings(filePaths)

--- a/venom.go
+++ b/venom.go
@@ -144,7 +144,7 @@ func (v *Venom) GetExecutorRunner(ctx context.Context, ts TestStep, h H) (contex
 		return ctx, newExecutorRunner(ex, name, "builtin", retry, retryIf, delay, timeout, info), nil
 	}
 
-	if err := v.registerUserExecutors(ctx, name, ts, vars); err != nil {
+	if err := v.registerUserExecutors(ctx, name, vars); err != nil {
 		Debug(ctx, "executor %q is not implemented as user executor - err:%v", name, err)
 	}
 
@@ -193,7 +193,7 @@ func (v *Venom) getUserExecutorFilesPath(vars map[string]string) (filePaths []st
 	return filePaths, nil
 }
 
-func (v *Venom) registerUserExecutors(ctx context.Context, name string, ts TestStep, vars map[string]string) error {
+func (v *Venom) registerUserExecutors(ctx context.Context, name string, vars map[string]string) error {
 	executorsPath, err := v.getUserExecutorFilesPath(vars)
 	if err != nil {
 		return err

--- a/venom.go
+++ b/venom.go
@@ -166,9 +166,8 @@ func (v *Venom) GetExecutorRunner(ctx context.Context, ts TestStep, h H) (contex
 func (v *Venom) getUserExecutorFilesPath(vars map[string]string) (filePaths []string, err error) {
 	var libpaths []string
 	if v.LibDir != "" {
-		for _, p := range strings.Split(v.LibDir, string(os.PathListSeparator)) {
-			libpaths = append(libpaths, p)
-		}
+		p := strings.Split(v.LibDir, string(os.PathListSeparator))
+		libpaths = append(libpaths, p...)
 	}
 	libpaths = append(libpaths, path.Join(vars["venom.testsuite.workdir"], "lib"))
 


### PR DESCRIPTION
Hello 👋 ,

We're running Venom inside of a Docker container in some cases, while mounting the scenario and custom executor files from the host into the container. Depending on the OS and the Docker config, for example when on macOS and having the "new Virtualization framework" enabled, but "VirtioFS" disabled, file operations can be very slow in Docker. Now with Venom we noticed that custom executors are read dozens of times during scenario execution, adding up to a lot of time.

Here's a screenshot of an example problematic Docker configuration on macOS:
![image](https://user-images.githubusercontent.com/170670/172075270-b5c7c48a-955f-40fb-90d0-3064ab4cb0a7.png)

But even with both of those options disabled, or both enabled, the file I/O is not great. For example we have a scenario that takes 1m, and 10s of that is spent purely on reading custom executor files!

This PR fixes that.

It introduces an executor file cache, and reads each file only _once_.

Cc @christophe-dufour 

PS: Maybe some other operations in the loop don't need to be repeated as well, but of those, they either don't take long (based on my measurements) and an optimization would have little impact, or the interpolation step (where an optimization would be nice) is a bit more complex to optimize, because for each `registerUserExecutors` call there can be new variable values so the interpolated result can't be cached, if my understanding is correct. And I wanted to keep this PR simple.