### PR TITLE
feat: preserve case

### DIFF
--- a/cmd/venom/.gitignore
+++ b/cmd/venom/.gitignore
@@ -1,6 +1,7 @@
 venom
 bin
 *.yml
+*.json
 *.xml
 *.log
 .venomrc

--- a/dump.go
+++ b/dump.go
@@ -25,6 +25,8 @@ func DumpWithPrefix(va interface{}, prefix string) (map[string]interface{}, erro
 
 	// TODO venom >= v1.2 update the PreserveCase behaviour
 	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
+		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
+	} else {
 		e.ExtraFields.UseJSONTag = true
 		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
 	}
@@ -43,6 +45,8 @@ func Dump(va interface{}) (map[string]interface{}, error) {
 
 	// TODO venom >= v1.2 update the PreserveCase behaviour
 	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
+		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
+	} else {
 		e.ExtraFields.UseJSONTag = true
 		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
 	}
@@ -61,6 +65,8 @@ func DumpString(va interface{}) (map[string]string, error) {
 
 	// TODO venom >= v1.2 update the PreserveCase behaviour
 	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
+		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
+	} else {
 		e.ExtraFields.UseJSONTag = true
 		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
 	}

--- a/dump.go
+++ b/dump.go
@@ -1,9 +1,21 @@
 package venom
 
-import "github.com/fsamin/go-dump"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fsamin/go-dump"
+)
+
+var preserveCase string
+
+func init() {
+	preserveCase = os.Getenv("VENOM_PRESERVE_CASE")
+}
 
 // Dump dumps v as a map[string]interface{}.
-func DumpWithPrefix(v interface{}, prefix string) (map[string]interface{}, error) {
+func DumpWithPrefix(va interface{}, prefix string) (map[string]interface{}, error) {
 	e := dump.NewDefaultEncoder()
 	e.ExtraFields.Len = true
 	e.ExtraFields.Type = true
@@ -11,43 +23,73 @@ func DumpWithPrefix(v interface{}, prefix string) (map[string]interface{}, error
 	e.ExtraFields.DetailedMap = true
 	e.ExtraFields.DetailedArray = true
 	e.Prefix = prefix
-	e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
 
-	return e.ToMap(v)
+	// TODO venom >= v1.2 update the PreserveCase behaviour
+	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
+		e.ExtraFields.UseJSONTag = true
+		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
+	}
+
+	return e.ToMap(va)
 }
 
 // Dump dumps v as a map[string]interface{}.
-func Dump(v interface{}) (map[string]interface{}, error) {
+func Dump(va interface{}) (map[string]interface{}, error) {
 	e := dump.NewDefaultEncoder()
 	e.ExtraFields.Len = true
 	e.ExtraFields.Type = true
 	e.ExtraFields.DetailedStruct = true
 	e.ExtraFields.DetailedMap = true
 	e.ExtraFields.DetailedArray = true
-	e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
 
-	return e.ToMap(v)
+	// TODO venom >= v1.2 update the PreserveCase behaviour
+	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
+		e.ExtraFields.UseJSONTag = true
+		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
+	}
+
+	r, _ := e.ToMap(va)
+	fmt.Printf("e.ToMap(va): %v\n", r)
+	return e.ToMap(va)
 }
 
 // DumpString dumps v as a map[string]string{}, key in lowercase
-func DumpString(v interface{}) (map[string]string, error) {
+func DumpString(va interface{}) (map[string]string, error) {
 	e := dump.NewDefaultEncoder()
 	e.ExtraFields.Len = true
 	e.ExtraFields.Type = true
 	e.ExtraFields.DetailedStruct = true
 	e.ExtraFields.DetailedMap = true
 	e.ExtraFields.DetailedArray = true
-	e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
-	return e.ToStringMap(v)
+
+	// TODO venom >= v1.2 update the PreserveCase behaviour
+	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
+		e.ExtraFields.UseJSONTag = true
+		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
+	}
+	return e.ToStringMap(va)
 }
 
 // DumpStringPreserveCase dumps v as a map[string]string{}
-func DumpStringPreserveCase(v interface{}) (map[string]string, error) {
+func DumpStringPreserveCase(va interface{}) (map[string]string, error) {
 	e := dump.NewDefaultEncoder()
 	e.ExtraFields.Len = true
 	e.ExtraFields.Type = true
 	e.ExtraFields.DetailedStruct = true
 	e.ExtraFields.DetailedMap = true
 	e.ExtraFields.DetailedArray = true
-	return e.ToStringMap(v)
+	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
+		e.ExtraFields.UseJSONTag = true
+	}
+	return e.ToStringMap(va)
+}
+
+func WithTitleFormatterFirstKey() dump.KeyFormatterFunc {
+	f := dump.WithDefaultFormatter()
+	return func(s string, level int) string {
+		if level == 0 {
+			return strings.ToLower(f(s, level))
+		}
+		return f(s, level)
+	}
 }

--- a/dump.go
+++ b/dump.go
@@ -1,7 +1,6 @@
 package venom
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -48,8 +47,6 @@ func Dump(va interface{}) (map[string]interface{}, error) {
 		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
 	}
 
-	r, _ := e.ToMap(va)
-	fmt.Printf("e.ToMap(va): %v\n", r)
 	return e.ToMap(va)
 }
 

--- a/dump.go
+++ b/dump.go
@@ -11,6 +11,9 @@ var preserveCase string
 
 func init() {
 	preserveCase = os.Getenv("VENOM_PRESERVE_CASE")
+	if preserveCase == "" || preserveCase == "AUTO" {
+		preserveCase = "OFF"
+	}
 }
 
 // Dump dumps v as a map[string]interface{}.
@@ -24,11 +27,11 @@ func DumpWithPrefix(va interface{}, prefix string) (map[string]interface{}, erro
 	e.Prefix = prefix
 
 	// TODO venom >= v1.2 update the PreserveCase behaviour
-	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
-		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
-	} else {
+	if preserveCase == "ON" {
 		e.ExtraFields.UseJSONTag = true
-		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
+		e.Formatters = []dump.KeyFormatterFunc{WithFormatterLowerFirstKey()}
+	} else {
+		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
 	}
 
 	return e.ToMap(va)
@@ -44,11 +47,11 @@ func Dump(va interface{}) (map[string]interface{}, error) {
 	e.ExtraFields.DetailedArray = true
 
 	// TODO venom >= v1.2 update the PreserveCase behaviour
-	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
-		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
-	} else {
+	if preserveCase == "ON" {
 		e.ExtraFields.UseJSONTag = true
-		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
+		e.Formatters = []dump.KeyFormatterFunc{WithFormatterLowerFirstKey()}
+	} else {
+		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
 	}
 
 	return e.ToMap(va)
@@ -64,11 +67,11 @@ func DumpString(va interface{}) (map[string]string, error) {
 	e.ExtraFields.DetailedArray = true
 
 	// TODO venom >= v1.2 update the PreserveCase behaviour
-	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
-		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
-	} else {
+	if preserveCase == "ON" {
 		e.ExtraFields.UseJSONTag = true
-		e.Formatters = []dump.KeyFormatterFunc{WithTitleFormatterFirstKey()}
+		e.Formatters = []dump.KeyFormatterFunc{WithFormatterLowerFirstKey()}
+	} else {
+		e.Formatters = []dump.KeyFormatterFunc{dump.WithDefaultLowerCaseFormatter()}
 	}
 	return e.ToStringMap(va)
 }
@@ -81,13 +84,13 @@ func DumpStringPreserveCase(va interface{}) (map[string]string, error) {
 	e.ExtraFields.DetailedStruct = true
 	e.ExtraFields.DetailedMap = true
 	e.ExtraFields.DetailedArray = true
-	if preserveCase == "OFF" || preserveCase == "AUTO" || preserveCase == "" {
+	if preserveCase == "ON" {
 		e.ExtraFields.UseJSONTag = true
 	}
 	return e.ToStringMap(va)
 }
 
-func WithTitleFormatterFirstKey() dump.KeyFormatterFunc {
+func WithFormatterLowerFirstKey() dump.KeyFormatterFunc {
 	f := dump.WithDefaultFormatter()
 	return func(s string, level int) string {
 		if level == 0 {

--- a/executors/amqp/amqp.go
+++ b/executors/amqp/amqp.go
@@ -41,7 +41,7 @@ type Executor struct {
 // Result represents a step result
 type Result struct {
 	Messages     []string      `json:"messages" yaml:"messages"`
-	MessagesJSON []interface{} `json:"messagesJSON" yaml:"messagesJSON"`
+	MessagesJSON []interface{} `json:"messagesjson" yaml:"messagesJSON"`
 }
 
 // ZeroValueResult returns an empty implementation of this executor result

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -71,7 +71,7 @@ type Result struct {
 type HTTPRequest struct {
 	Method   string      `json:"method,omitempty"`
 	URL      string      `json:"url,omitempty"`
-	Header   http.Header `json:"headers,omitempty"`
+	Header   http.Header `json:"header,omitempty"`
 	Body     string      `json:"body,omitempty"`
 	Form     url.Values  `json:"form,omitempty"`
 	PostForm url.Values  `json:"post_form,omitempty"`

--- a/executors/imap/imap.go
+++ b/executors/imap/imap.go
@@ -51,10 +51,10 @@ type Mail struct {
 
 // Result represents a step result
 type Result struct {
-	Err         string  `json:"error" yaml:"error"`
+	Err         string  `json:"err" yaml:"error"`
 	Subject     string  `json:"subject,omitempty" yaml:"subject,omitempty"`
 	Body        string  `json:"body,omitempty" yaml:"body,omitempty"`
-	TimeSeconds float64 `json:"timeSeconds,omitempty" yaml:"timeSeconds,omitempty"`
+	TimeSeconds float64 `json:"timeseconds,omitempty" yaml:"timeSeconds,omitempty"`
 }
 
 // ZeroValueResult return an empty implementation of this executor result

--- a/executors/kafka/kafka.go
+++ b/executors/kafka/kafka.go
@@ -96,10 +96,10 @@ type (
 
 	// Result represents a step result.
 	Result struct {
-		TimeSeconds  float64       `json:"timeSeconds,omitempty" yaml:"timeSeconds,omitempty"`
+		TimeSeconds  float64       `json:"timeseconds,omitempty" yaml:"timeSeconds,omitempty"`
 		Messages     []Message     `json:"messages,omitempty" yaml:"messages,omitempty"`
-		MessagesJSON []interface{} `json:"messagesJSON,omitempty" yaml:"messagesJSON,omitempty"`
-		Err          string        `json:"error" yaml:"error"`
+		MessagesJSON []interface{} `json:"messagesjson,omitempty" yaml:"messagesJSON,omitempty"`
+		Err          string        `json:"err" yaml:"error"`
 	}
 	consumeFunc = func(message *sarama.ConsumerMessage) (Message, interface{}, error)
 )
@@ -229,11 +229,11 @@ func (e Executor) getMessageValue(m *Message, workdir string) ([]byte, error) {
 	// This is test with Avro
 	var (
 		schemaID int
-		schema string
+		schema   string
 	)
 	// 1. Get schema with its ID
 	// 1.1 Try with the file, if provided
-	subject := fmt.Sprintf("%s-value", m.Topic)  // Using topic name strategy
+	subject := fmt.Sprintf("%s-value", m.Topic) // Using topic name strategy
 	schemaFile := strings.Trim(m.AvroSchemaFile, " ")
 	if len(schemaFile) != 0 {
 		schemaPath := path.Join(workdir, schemaFile)
@@ -254,7 +254,7 @@ func (e Executor) getMessageValue(m *Message, workdir string) ([]byte, error) {
 			return nil, fmt.Errorf("can't get latest schema for subject %s-value: %w", m.Topic, err)
 		}
 	}
-	
+
 	// 2. Encode Value with schema
 	avroMsg, err := Convert2Avro(value, string(schema))
 	if err != nil {

--- a/executors/mqtt/mqtt.go
+++ b/executors/mqtt/mqtt.go
@@ -60,11 +60,11 @@ type Message struct {
 
 // Result represents a step result.
 type Result struct {
-	TimeSeconds  float64       `json:"timeSeconds" yaml:"timeSeconds"`
+	TimeSeconds  float64       `json:"timeseconds" yaml:"timeSeconds"`
 	Topics       []string      `json:"topics" yaml:"topics"`
 	Messages     []interface{} `json:"messages" yaml:"messages"`
-	MessagesJSON []interface{} `json:"messagesJSON" yaml:"messagesJSON"`
-	Err          string        `json:"error" yaml:"error"`
+	MessagesJSON []interface{} `json:"messagesjson" yaml:"messagesJSON"`
+	Err          string        `json:"err" yaml:"error"`
 }
 
 // GetDefaultAssertions return default assertions for type exec

--- a/executors/rabbitmq/rabbitmq.go
+++ b/executors/rabbitmq/rabbitmq.go
@@ -61,12 +61,12 @@ type Executor struct {
 
 // Result represents a step result.
 type Result struct {
-	TimeSeconds float64       `json:"timeSeconds" yaml:"timeSeconds"`
+	TimeSeconds float64       `json:"timeseconds" yaml:"timeSeconds"`
 	Body        []string      `json:"body" yaml:"body"`
 	Messages    []interface{} `json:"messages" yaml:"messages"`
-	BodyJSON    []interface{} `json:"bodyJSON" yaml:"bodyJSON"`
+	BodyJSON    []interface{} `json:"bodyjson" yaml:"bodyJSON"`
 	Headers     []amqp.Table  `json:"headers" yaml:"headers"`
-	Err         string        `json:"error" yaml:"error"`
+	Err         string        `json:"err" yaml:"error"`
 }
 
 // ZeroValueResult return an empty implementation of this executor result

--- a/executors/readfile/readfile.go
+++ b/executors/readfile/readfile.go
@@ -35,8 +35,8 @@ type Executor struct {
 type Result struct {
 	Content     string            `json:"content,omitempty" yaml:"content,omitempty"`
 	ContentJSON interface{}       `json:"contentjson,omitempty" yaml:"contentjson,omitempty"`
-	Err         string            `json:"error" yaml:"error"`
-	TimeSeconds float64           `json:"timeSeconds,omitempty" yaml:"timeSeconds,omitempty"`
+	Err         string            `json:"err" yaml:"error"`
+	TimeSeconds float64           `json:"timeseconds,omitempty" yaml:"timeSeconds,omitempty"`
 	Md5sum      map[string]string `json:"md5sum,omitempty" yaml:"md5sum,omitempty"`
 	Size        map[string]int64  `json:"size,omitempty" yaml:"size,omitempty"`
 	ModTime     map[string]int64  `json:"modtime,omitempty" yaml:"modtime,omitempty"`

--- a/executors/smtp/smtp.go
+++ b/executors/smtp/smtp.go
@@ -38,8 +38,8 @@ type Executor struct {
 
 // Result represents a step result
 type Result struct {
-	Err         string  `json:"error,omitempty" yaml:"error"`
-	TimeSeconds float64 `json:"timeSeconds,omitempty" yaml:"timeSeconds,omitempty"`
+	Err         string  `json:"err,omitempty" yaml:"error"`
+	TimeSeconds float64 `json:"timeseconds,omitempty" yaml:"timeSeconds,omitempty"`
 }
 
 // ZeroValueResult return an empty implementation of this executor result

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/confluentinc/bincover v0.2.0
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/fatih/color v1.13.0
-	github.com/fsamin/go-dump v1.7.0
+	github.com/fsamin/go-dump v0.0.0-20220811134020-951ca28b6c23
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/garyburd/redigo v1.6.3
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/confluentinc/bincover v0.2.0
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/fatih/color v1.13.0
-	github.com/fsamin/go-dump v0.0.0-20220811151532-e083d29933b0
+	github.com/fsamin/go-dump v1.8.0
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/garyburd/redigo v1.6.3
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/confluentinc/bincover v0.2.0
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/fatih/color v1.13.0
-	github.com/fsamin/go-dump v0.0.0-20220811134020-951ca28b6c23
+	github.com/fsamin/go-dump v0.0.0-20220811151532-e083d29933b0
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/garyburd/redigo v1.6.3
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsamin/go-dump v0.0.0-20220811134020-951ca28b6c23 h1:8EBsFJ40eEsF8M4/0E/Ilxq6GV2PolHzkt/0Or+chJo=
 github.com/fsamin/go-dump v0.0.0-20220811134020-951ca28b6c23/go.mod h1:/xw/mwt7LWFJlTwxTjwKMv1W3gmKJsKD8zHS9+/czFY=
+github.com/fsamin/go-dump v0.0.0-20220811151532-e083d29933b0 h1:D7FFK1RN9JfVhB+LZQ8/Ap1xyzE8LTFDwIWiqAzRAvI=
+github.com/fsamin/go-dump v0.0.0-20220811151532-e083d29933b0/go.mod h1:/xw/mwt7LWFJlTwxTjwKMv1W3gmKJsKD8zHS9+/czFY=
 github.com/fsamin/go-dump v1.7.0 h1:12qptOwAyJ6vuzERrcMhREy1fT3bVmlYhi2CibhdAJM=
 github.com/fsamin/go-dump v1.7.0/go.mod h1:/xw/mwt7LWFJlTwxTjwKMv1W3gmKJsKD8zHS9+/czFY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/fsamin/go-dump v0.0.0-20220811151532-e083d29933b0 h1:D7FFK1RN9JfVhB+L
 github.com/fsamin/go-dump v0.0.0-20220811151532-e083d29933b0/go.mod h1:/xw/mwt7LWFJlTwxTjwKMv1W3gmKJsKD8zHS9+/czFY=
 github.com/fsamin/go-dump v1.7.0 h1:12qptOwAyJ6vuzERrcMhREy1fT3bVmlYhi2CibhdAJM=
 github.com/fsamin/go-dump v1.7.0/go.mod h1:/xw/mwt7LWFJlTwxTjwKMv1W3gmKJsKD8zHS9+/czFY=
+github.com/fsamin/go-dump v1.8.0 h1:jy1qExf8rXFoIc3y9hGuBgk0C+2GqETnusw/uouZlO8=
+github.com/fsamin/go-dump v1.8.0/go.mod h1:/xw/mwt7LWFJlTwxTjwKMv1W3gmKJsKD8zHS9+/czFY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/fsamin/go-dump v0.0.0-20220811134020-951ca28b6c23 h1:8EBsFJ40eEsF8M4/0E/Ilxq6GV2PolHzkt/0Or+chJo=
+github.com/fsamin/go-dump v0.0.0-20220811134020-951ca28b6c23/go.mod h1:/xw/mwt7LWFJlTwxTjwKMv1W3gmKJsKD8zHS9+/czFY=
 github.com/fsamin/go-dump v1.7.0 h1:12qptOwAyJ6vuzERrcMhREy1fT3bVmlYhi2CibhdAJM=
 github.com/fsamin/go-dump v1.7.0/go.mod h1:/xw/mwt7LWFJlTwxTjwKMv1W3gmKJsKD8zHS9+/czFY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/tests/interpolation.yml
+++ b/tests/interpolation.yml
@@ -26,7 +26,7 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.headers.x-cache ShouldEqual "HIT"
       - type: http
-        method: GET
+        method: HEAD
         url: "http://example.com"
         headers:
           test: "{{ .GetVar.accept }}"

--- a/tests/readfile.yml
+++ b/tests/readfile.yml
@@ -29,7 +29,7 @@ testcases:
     path: readfile/testa.json
     info: "md5sum_foo: {{.md5sum_foo}}"
     assertions:
-    - result.err ShouldBeNil
+    - result.err ShouldEqual ""
     - result.md5sum.readfile_testa.json ShouldEqual "{{.testcase-readfile2.md5sum_foo}}"
 
 - name: testcase-readfile-with-integer

--- a/tests/readfile.yml
+++ b/tests/readfile.yml
@@ -29,7 +29,7 @@ testcases:
     path: readfile/testa.json
     info: "md5sum_foo: {{.md5sum_foo}}"
     assertions:
-    - result.err ShouldEqual ""
+    - result.err ShouldBeNil
     - result.md5sum.readfile_testa.json ShouldEqual "{{.testcase-readfile2.md5sum_foo}}"
 
 - name: testcase-readfile-with-integer


### PR DESCRIPTION
It's now possible to read something like that :
```json
{
  "foo": "bar",
  "FOO": "truc",
}
```
and use these variables:

```yml
- type: readfile
    path: the_file.json
    info: "{{.Result.ContentJSON.foo}}-{{.Result.ContentJSON.FOO}}"
```

Environment variable: VENOM_PRESERVE_CASE

venom 1.1.x
  VENOM_PRESERVE_CASE="AUTO" is equals to VENOM_PRESERVE_CASE="OFF"

venom 1.2.x
  VENOM_PRESERVE_CASE="AUTO" is equals to VENOM_PRESERVE_CASE="ON"

venom 1.1 users, you can try:

```sh
> export VENOM_PRESERVE_CASE="ON";
> venom run ...
```

close #522
close #547
close #522

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>