### PR TITLE
feat: VENOM_PRESERVE_CASE default ON

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -12,7 +12,7 @@ var preserveCase string
 func init() {
 	preserveCase = os.Getenv("VENOM_PRESERVE_CASE")
 	if preserveCase == "" || preserveCase == "AUTO" {
-		preserveCase = "OFF"
+		preserveCase = "ON"
 	}
 }
 

--- a/tests/case.yml
+++ b/tests/case.yml
@@ -1,0 +1,10 @@
+name:  Readfile testsuite
+
+testcases:
+- name: testcase-readfile
+  steps:
+  - script: 'echo "{\"foo\": \"foo\", \"FOO\": \"bar\"}"'
+    info: "{{.result.systemoutjson.foo}}-{{.result.systemoutjson.FOO}}"
+    assertions:
+      - result.systemoutjson.foo ShouldEqual foo
+      - result.systemoutjson.FOO ShouldEqual bar

--- a/tests/interpolation.yml
+++ b/tests/interpolation.yml
@@ -13,7 +13,7 @@ testcases:
           - result.statuscode ShouldEqual 200
         vars:
           accept:
-            from: result.headers.content-type
+            from: result.headers.Content-Type
 
   - name: UseVar
     steps:
@@ -24,7 +24,7 @@ testcases:
           test: "{{ .GetVar.accept }}"
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.headers.x-cache ShouldEqual "HIT"
+          - result.headers.X-Cache ShouldEqual "HIT"
       - type: http
         method: HEAD
         url: "http://example.com"
@@ -32,4 +32,4 @@ testcases:
           test: "{{ .GetVar.accept }}"
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.headers.accept-ranges ShouldEqual "bytes"
+          - result.headers.Accept-Ranges ShouldEqual "bytes"


### PR DESCRIPTION
It's now possible to read something like that :

```json
{
  "foo": "bar",
  "FOO": "truc",
}
```
and use these variables:

```yml
- type: readfile
    path: the_file.json
    info: "{{.Result.ContentJSON.foo}}-{{.Result.ContentJSON.FOO}}"
```

Environment variable: VENOM_PRESERVE_CASE

venom 1.1.x
  VENOM_PRESERVE_CASE="AUTO" is equals to VENOM_PRESERVE_CASE="OFF"

venom 1.2.x
  VENOM_PRESERVE_CASE="AUTO" is equals to VENOM_PRESERVE_CASE="ON"

venom 1.1 users, you can try:

```sh
> export VENOM_PRESERVE_CASE="ON";
> venom run ...
```

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>