### PR TITLE
Add a registry variable to source executors from

### DIFF
--- a/cmd/venom/main.go
+++ b/cmd/venom/main.go
@@ -1,30 +1,12 @@
 package main
 
 import (
+	"github.com/ovh/venom/cmd/venom/root"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
-	"github.com/ovh/venom/cmd/venom/run"
-	"github.com/ovh/venom/cmd/venom/update"
-	"github.com/ovh/venom/cmd/venom/version"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "venom",
-	Short: "Venom aim to create, manage and run your integration tests with efficiency",
-}
-
 func main() {
-	addCommands()
-
-	if err := rootCmd.Execute(); err != nil {
+	if err := root.New().Execute(); err != nil {
 		log.Fatalf("Err:%s", err)
 	}
-}
-
-//AddCommands adds child commands to the root command rootCmd.
-func addCommands() {
-	rootCmd.AddCommand(run.Cmd)
-	rootCmd.AddCommand(version.Cmd)
-	rootCmd.AddCommand(update.Cmd)
 }

--- a/cmd/venom/root/root.go
+++ b/cmd/venom/root/root.go
@@ -1,0 +1,26 @@
+package root
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/ovh/venom/cmd/venom/run"
+	"github.com/ovh/venom/cmd/venom/update"
+	"github.com/ovh/venom/cmd/venom/version"
+)
+
+// New creates a venom root command.
+func New() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "venom",
+		Short: "Venom aim to create, manage and run your integration tests with efficiency",
+	}
+	addCommands(rootCmd)
+	return rootCmd
+}
+
+//AddCommands adds child commands to the root command rootCmd.
+func addCommands(cmd *cobra.Command) {
+	cmd.AddCommand(run.Cmd)
+	cmd.AddCommand(version.Cmd)
+	cmd.AddCommand(update.Cmd)
+}

--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -19,22 +19,7 @@ import (
 
 	"github.com/ovh/cds/sdk/interpolate"
 	"github.com/ovh/venom"
-	"github.com/ovh/venom/executors/amqp"
-	"github.com/ovh/venom/executors/dbfixtures"
-	"github.com/ovh/venom/executors/exec"
-	"github.com/ovh/venom/executors/grpc"
-	"github.com/ovh/venom/executors/http"
-	"github.com/ovh/venom/executors/imap"
-	"github.com/ovh/venom/executors/kafka"
-	"github.com/ovh/venom/executors/mqtt"
-	"github.com/ovh/venom/executors/ovhapi"
-	"github.com/ovh/venom/executors/rabbitmq"
-	"github.com/ovh/venom/executors/readfile"
-	"github.com/ovh/venom/executors/redis"
-	"github.com/ovh/venom/executors/smtp"
-	"github.com/ovh/venom/executors/sql"
-	"github.com/ovh/venom/executors/ssh"
-	"github.com/ovh/venom/executors/web"
+	"github.com/ovh/venom/executors"
 )
 
 var (
@@ -321,22 +306,9 @@ var Cmd = &cobra.Command{
 		}
 
 		v = venom.New()
-		v.RegisterExecutorBuiltin(amqp.Name, amqp.New())
-		v.RegisterExecutorBuiltin(dbfixtures.Name, dbfixtures.New())
-		v.RegisterExecutorBuiltin(exec.Name, exec.New())
-		v.RegisterExecutorBuiltin(grpc.Name, grpc.New())
-		v.RegisterExecutorBuiltin(http.Name, http.New())
-		v.RegisterExecutorBuiltin(imap.Name, imap.New())
-		v.RegisterExecutorBuiltin(kafka.Name, kafka.New())
-		v.RegisterExecutorBuiltin(mqtt.Name, mqtt.New())
-		v.RegisterExecutorBuiltin(ovhapi.Name, ovhapi.New())
-		v.RegisterExecutorBuiltin(rabbitmq.Name, rabbitmq.New())
-		v.RegisterExecutorBuiltin(readfile.Name, readfile.New())
-		v.RegisterExecutorBuiltin(redis.Name, redis.New())
-		v.RegisterExecutorBuiltin(smtp.Name, smtp.New())
-		v.RegisterExecutorBuiltin(sql.Name, sql.New())
-		v.RegisterExecutorBuiltin(ssh.Name, ssh.New())
-		v.RegisterExecutorBuiltin(web.Name, web.New())
+		for name, executorFunc := range executors.Registry {
+			v.RegisterExecutorBuiltin(name, executorFunc())
+		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		initArgs(cmd)

--- a/executors/registry.go
+++ b/executors/registry.go
@@ -1,0 +1,43 @@
+package executors
+
+import (
+	"github.com/ovh/venom"
+	"github.com/ovh/venom/executors/amqp"
+	"github.com/ovh/venom/executors/dbfixtures"
+	"github.com/ovh/venom/executors/exec"
+	"github.com/ovh/venom/executors/grpc"
+	"github.com/ovh/venom/executors/http"
+	"github.com/ovh/venom/executors/imap"
+	"github.com/ovh/venom/executors/kafka"
+	"github.com/ovh/venom/executors/mqtt"
+	"github.com/ovh/venom/executors/ovhapi"
+	"github.com/ovh/venom/executors/rabbitmq"
+	"github.com/ovh/venom/executors/readfile"
+	"github.com/ovh/venom/executors/redis"
+	"github.com/ovh/venom/executors/smtp"
+	"github.com/ovh/venom/executors/sql"
+	"github.com/ovh/venom/executors/ssh"
+	"github.com/ovh/venom/executors/web"
+)
+
+type Constructor func() venom.Executor
+
+// Registry is a map of executors to executor constructor functions.
+var Registry map[string]Constructor = map[string]Constructor{
+	amqp.Name:       amqp.New,
+	dbfixtures.Name: dbfixtures.New,
+	exec.Name:       exec.New,
+	grpc.Name:       grpc.New,
+	http.Name:       http.New,
+	imap.Name:       imap.New,
+	kafka.Name:      kafka.New,
+	mqtt.Name:       mqtt.New,
+	ovhapi.Name:     ovhapi.New,
+	rabbitmq.Name:   rabbitmq.New,
+	readfile.Name:   readfile.New,
+	redis.Name:      redis.New,
+	smtp.Name:       smtp.New,
+	sql.Name:        sql.New,
+	ssh.Name:        ssh.New,
+	web.Name:        web.New,
+}


### PR DESCRIPTION
This refactoring allows users to use venom as a library and easily create "venom-like" CLIs with their own custom executors which may not make sense in the main venom repository.

NOTE - this is purely a cosmetic refactoring. This should not affect how venom functions at all.

This is possible through something like - 


```go
package main

import (
	log "github.com/sirupsen/logrus"

	"github.com/ovh/venom/executors"
	"github.com/ovh/venom/cmd/venom/root"
)


func main() {
	addCustomExecutors()
	if err := root.New().Execute(); err != nil {
		log.Fatalf("Err:%s", err)
	}
}

func addCustomExecutors() {
	executors.Registry[myExecutor.Name] = myExecutor.New
}
```
