### PR TITLE
feat: output html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ test_results.xml
 git-template
 tests/grpc/pki
 tests/pki_variables.yml
+*.log
+*.xml
+test_results*.html
+!venom_output.html

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ run: ## build binary for current OS only and run it. For development purpose onl
 lint: mk_go_lint ## install and run golangci-lint on all go files. doc https://github.com/golangci/golangci-lint
 
 clean: mk_go_clean ## delete directories dist and results and all temp files (coverage, tests, reports)
-	@rm -f *.dump.json *_profile.prof test_results.xml venom.log
+	@rm -f *.dump.json *_profile.prof test_results.xml *.log
 	@rm -rf ${DIST_DIR}
 	@rm -rf ${RESULTS_DIR}
 	$(MAKE) clean -C cmd/venom

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Examples:
   Run all testsuites containing in files ending with *.yml or *.yaml: venom run
   Run a single testsuite: venom run mytestfile.yml
   Run a single testsuite and export the result in JSON format in test/ folder: venom run mytestfile.yml --format=json --output-dir=test
+  Run a single testsuite and export the result in XML and HTML formats in test/ folder: venom run mytestfile.yml --format=xml,html --output-dir=test
   Run a single testsuite and specify a variable: venom run mytestfile.yml --var="foo=bar"
   Run a single testsuite and load all variables from a file: venom run mytestfile.yml --var-from-file variables.yaml
   Run all testsuites containing in files ending with *.yml or *.yaml with verbosity: VENOM_VERBOSE=2 venom run
@@ -154,7 +155,7 @@ Examples:
   More info: https://github.com/ovh/venom
 
 Flags:
-      --format string           --format:yaml, json, xml, tap (default "xml")
+      --format string           --format:html, json, tap, xml, yaml (default "xml")
   -h, --help                    help for run
       --lib-dir string          Lib Directory: can contain user executors. example:/etc/venom/lib:$HOME/venom.d/lib
       --output-dir string       Output Directory: create tests results file inside this directory
@@ -228,7 +229,7 @@ List of available flags for `venom run` command:
 
 ```
 Flags:
-      --format string           --format:yaml, json, xml, tap (default "xml")
+      --format string           --format:html, json, tap, xml, yaml (default "xml")
   -h, --help                    help for run
       --lib-dir string          Lib Directory: can contain user executors. example:/etc/venom/lib:$HOME/venom.d/lib
       --output-dir string       Output Directory: create tests results file inside this directory
@@ -716,6 +717,9 @@ You can specify the output directory with the `--output-dir` flag and the format
 
 ```bash
 $ venom run --format=xml --output-dir="."
+
+# xml and html export
+$ venom run --format=xml,html --output-dir="."
 ```
 
 Reports exported in XML can be visualized with a xUnit/jUnit Viewer, directly in your favorite CI/CD stack for example in order to see results run after run.
@@ -724,10 +728,13 @@ Reports exported in XML can be visualized with a xUnit/jUnit Viewer, directly in
 
 ## Debug your testsuites
 
+A *venom.log* file is generated for each `venom run` command.
+
 There are two ways to debug a testsuite:
  - use `-v` flag on venom binary.
-   - `$ venom run -v test.yml` will output a *venom.log* file
-   - `$ venom run -vv test.yml` will output a *venom.log* and *dump.json* files for each teststep.
+   - `$ venom run -v test.yml` will output details for each step
+   - `$ venom run -vv test.yml` will generate *dump.json* files for each teststep.
+   - `$ venom run -vvv test.yml` will generate *pprof* files for CPU profiling.
  - use `info` keyword in your teststep:
 `test.yml` file:
 ```yml

--- a/README.md
+++ b/README.md
@@ -573,7 +573,9 @@ Builtin variables:
 * {{.venom.outputdir}}
 * {{.venom.testcase}}
 * {{.venom.teststep.number}}
+* {{.venom.testsuite.name}}
 * {{.venom.testsuite.filename}}
+* {{.venom.testsuite.filepath}}
 * {{.venom.testsuite.shortName}}
 * {{.venom.testsuite.workdir}}
 * {{.venom.testsuite}}

--- a/assertion.go
+++ b/assertion.go
@@ -16,27 +16,29 @@ import (
 	"github.com/ovh/venom/assertions"
 )
 
-type assertionsApplied struct {
-	ok        bool
-	errors    []Failure
-	failures  []Failure
-	systemout string
-	systemerr string
+type AssertionsApplied struct {
+	OK         bool `json:"ok" yml:"-"`
+	errors     []Failure
+	systemout  string
+	systemerr  string
+	Assertions []AssertionApplied `json:"assertions" yml:"-"`
+}
+type AssertionApplied struct {
+	Assertion Assertion `json:"assertion" yml:"-"`
+	IsOK      bool      `json:"isOK" yml:"-"`
 }
 
-func applyAssertions(r interface{}, tc TestCase, stepNumber int, rangedIndex int, step TestStep, defaultAssertions *StepAssertions) assertionsApplied {
+func applyAssertions(ctx context.Context, r interface{}, tc TestCase, stepNumber int, rangedIndex int, step TestStep, defaultAssertions *StepAssertions) AssertionsApplied {
 	var sa StepAssertions
 	var errors []Failure
-	var failures []Failure
 	var systemerr, systemout string
 
 	if err := mapstructure.Decode(step, &sa); err != nil {
-		return assertionsApplied{
-			false,
-			[]Failure{{Value: RemoveNotPrintableChar(fmt.Sprintf("error decoding assertions: %s", err))}},
-			failures,
-			systemout,
-			systemerr,
+		return AssertionsApplied{
+			OK:        false,
+			errors:    []Failure{{Value: RemoveNotPrintableChar(fmt.Sprintf("error decoding assertions: %s", err))}},
+			systemout: systemout,
+			systemerr: systemerr,
 		}
 	}
 
@@ -47,16 +49,19 @@ func applyAssertions(r interface{}, tc TestCase, stepNumber int, rangedIndex int
 	executorResult := GetExecutorResult(r)
 
 	isOK := true
+	assertions := []AssertionApplied{}
 	for _, assertion := range sa.Assertions {
-		errs, fails := check(tc, stepNumber, rangedIndex, assertion, executorResult)
+		errs := check(ctx, tc, stepNumber, rangedIndex, assertion, executorResult)
+		isAssertionOK := true
 		if errs != nil {
 			errors = append(errors, *errs)
 			isOK = false
+			isAssertionOK = false
 		}
-		if fails != nil {
-			failures = append(failures, *fails)
-			isOK = false
-		}
+		assertions = append(assertions, AssertionApplied{
+			Assertion: assertion,
+			IsOK:      isAssertionOK,
+		})
 	}
 
 	if _, ok := executorResult["result.systemerr"]; ok {
@@ -67,7 +72,13 @@ func applyAssertions(r interface{}, tc TestCase, stepNumber int, rangedIndex int
 		systemout = fmt.Sprintf("%v", executorResult["result.systemout"])
 	}
 
-	return assertionsApplied{isOK, errors, failures, systemout, systemerr}
+	return AssertionsApplied{
+		OK:         isOK,
+		errors:     errors,
+		systemerr:  systemerr,
+		systemout:  systemout,
+		Assertions: assertions,
+	}
 }
 
 type assertion struct {
@@ -116,26 +127,25 @@ func parseAssertions(ctx context.Context, s string, input interface{}) (*asserti
 }
 
 // check selects the correct assertion function to call depending on typing provided by user
-func check(tc TestCase, stepNumber int, rangedIndex int, assertion Assertion, r interface{}) (*Failure, *Failure) {
+func check(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertion Assertion, r interface{}) *Failure {
 	var errs *Failure
-	var fails *Failure
 	switch t := assertion.(type) {
 	case string:
-		errs, fails = checkString(tc, stepNumber, rangedIndex, assertion.(string), r)
+		errs = checkString(ctx, tc, stepNumber, rangedIndex, assertion.(string), r)
 	case map[string]interface{}:
-		errs, fails = checkBranch(tc, stepNumber, rangedIndex, assertion.(map[string]interface{}), r)
+		errs = checkBranch(ctx, tc, stepNumber, rangedIndex, assertion.(map[string]interface{}), r)
 	default:
-		errs = newFailure(tc, stepNumber, rangedIndex, "", fmt.Errorf("unsupported assertion format: %v", t))
+		errs = newFailure(ctx, tc, stepNumber, rangedIndex, "", fmt.Errorf("unsupported assertion format: %v", t))
 	}
-	return errs, fails
+	return errs
 }
 
 // checkString evaluate a complex assertion containing logical operators
 // it recursively calls checkAssertion for each operand
-func checkBranch(tc TestCase, stepNumber int, rangedIndex int, branch map[string]interface{}, r interface{}) (*Failure, *Failure) {
+func checkBranch(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, branch map[string]interface{}, r interface{}) *Failure {
 	// Extract logical operator
 	if len(branch) != 1 {
-		return newFailure(tc, stepNumber, rangedIndex, "", fmt.Errorf("expected exactly 1 logical operator but %d were provided", len(branch))), nil
+		return newFailure(ctx, tc, stepNumber, rangedIndex, "", fmt.Errorf("expected exactly 1 logical operator but %d were provided", len(branch)))
 	}
 	var operator string
 	for k := range branch {
@@ -148,28 +158,22 @@ func checkBranch(tc TestCase, stepNumber int, rangedIndex int, branch map[string
 	case []interface{}:
 		operands = branch[operator].([]interface{})
 	default:
-		return newFailure(tc, stepNumber, rangedIndex, "", fmt.Errorf("expected %s operands to be an []interface{}, got %v", operator, t)), nil
+		return newFailure(ctx, tc, stepNumber, rangedIndex, "", fmt.Errorf("expected %s operands to be an []interface{}, got %v", operator, t))
 	}
 	if len(operands) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// Evaluate assertions (operands)
-	var errsBuf []Failure
-	var failsBuf []Failure
 	var results []string
 	assertionsCount := len(operands)
 	assertionsSuccess := 0
 	for _, assertion := range operands {
-		errs, fails := check(tc, stepNumber, rangedIndex, assertion, r)
+		errs := check(ctx, tc, stepNumber, rangedIndex, assertion, r)
 		if errs != nil {
-			errsBuf = append(errsBuf, *errs)
-		}
-		if fails != nil {
-			failsBuf = append(failsBuf, *fails)
 			results = append(results, fmt.Sprintf("  - fail: %s", assertion))
 		}
-		if (errs == nil) && (fails == nil) {
+		if errs == nil {
 			assertionsSuccess++
 			results = append(results, fmt.Sprintf("  - pass: %s", assertion))
 		}
@@ -198,27 +202,27 @@ func checkBranch(tc TestCase, stepNumber int, rangedIndex int, branch map[string
 			err = fmt.Errorf("some assertions succeeded but expected none to suceed:\n%s\n", strings.Join(results, "\n"))
 		}
 	default:
-		return newFailure(tc, stepNumber, rangedIndex, "", fmt.Errorf("unsupported assertion operator %s", operator)), nil
+		return newFailure(ctx, tc, stepNumber, rangedIndex, "", fmt.Errorf("unsupported assertion operator %s", operator))
 	}
 	if err != nil {
-		return nil, newFailure(tc, stepNumber, rangedIndex, "", err)
+		return newFailure(ctx, tc, stepNumber, rangedIndex, "", err)
 	}
-	return nil, nil
+	return nil
 }
 
 // checkString evaluate a single string assertion
-func checkString(tc TestCase, stepNumber int, rangedIndex int, assertion string, r interface{}) (*Failure, *Failure) {
+func checkString(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertion string, r interface{}) *Failure {
 	assert, err := parseAssertions(context.Background(), assertion, r)
 	if err != nil {
-		return nil, newFailure(tc, stepNumber, rangedIndex, assertion, err)
+		return newFailure(ctx, tc, stepNumber, rangedIndex, assertion, err)
 	}
 
 	if err := assert.Func(assert.Actual, assert.Args...); err != nil {
-		failure := newFailure(tc, stepNumber, rangedIndex, assertion, err)
+		failure := newFailure(ctx, tc, stepNumber, rangedIndex, assertion, err)
 		failure.AssertionRequired = assert.Required
-		return nil, failure
+		return failure
 	}
-	return nil, nil
+	return nil
 }
 
 // splitAssertion splits the assertion string a, with support
@@ -354,7 +358,7 @@ func findLineNumber(filename, testcase string, stepNumber int, assertion string,
 	return countLine
 }
 
-//This evaluates a string of assertions with a given vars scope, and returns a slice of failures (i.e. empty slice = all pass)
+// This evaluates a string of assertions with a given vars scope, and returns a slice of failures (i.e. empty slice = all pass)
 func testConditionalStatement(ctx context.Context, tc *TestCase, assertions []string, vars H, text string) ([]string, error) {
 	var failures []string
 	for _, assertion := range assertions {
@@ -362,7 +366,6 @@ func testConditionalStatement(ctx context.Context, tc *TestCase, assertions []st
 		assert, err := parseAssertions(ctx, assertion, vars)
 		if err != nil {
 			Error(ctx, "unable to parse assertion: %v", err)
-			tc.AppendError(err)
 			return failures, err
 		}
 		if err := assert.Func(assert.Actual, assert.Args...); err != nil {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"fmt"
 	"os"
+
+	"github.com/ovh/venom"
 )
 
 // Exit func display an error message on stderr and exit 1
 func Exit(format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, args...)
-	os.Exit(1)
+	venom.OSExit(1)
 }

--- a/cmd/venom/.gitignore
+++ b/cmd/venom/.gitignore
@@ -4,4 +4,5 @@ bin
 *.json
 *.xml
 *.log
+*.html
 .venomrc

--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -322,7 +322,6 @@ var Cmd = &cobra.Command{
 		if err := v.InitLogger(); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			venom.OSExit(2)
-			return err
 		}
 
 		if v.Verbose == 3 {
@@ -360,7 +359,8 @@ var Cmd = &cobra.Command{
 
 		mapvars, err := readInitialVariables(context.Background(), variables, readers, os.Environ())
 		if err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			venom.OSExit(2)
 		}
 		v.AddVariables(mapvars)
 

--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -57,12 +57,12 @@ func initArgs(cmd *cobra.Command) {
 	// Configuration file overrides the environment variables.
 	if _, err := initFromEnv(os.Environ()); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(2)
+		venom.OSExit(2)
 	}
 
 	if err := initFromConfigFile(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(2)
+		venom.OSExit(2)
 	}
 	cmd.LocalFlags().VisitAll(initFromCommandArguments)
 }
@@ -321,7 +321,7 @@ var Cmd = &cobra.Command{
 
 		if err := v.InitLogger(); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(2)
+			venom.OSExit(2)
 			return err
 		}
 
@@ -366,28 +366,25 @@ var Cmd = &cobra.Command{
 
 		if err := v.Parse(context.Background(), path); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(2)
-			return err
+			venom.OSExit(2)
 		}
 
 		if err := v.Process(context.Background(), path); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(2)
-			return err
+			venom.OSExit(2)
 		}
 
 		if err := v.OutputResult(); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(2)
-			return err
+			venom.OSExit(2)
 		}
 
 		if v.Tests.Status == venom.StatusPass {
 			fmt.Fprintf(os.Stdout, "final status: %v\n", venom.Green(v.Tests.Status))
-			os.Exit(0)
+			venom.OSExit(0)
 		}
 		fmt.Fprintf(os.Stdout, "final status: %v\n", venom.Red(v.Tests.Status))
-		os.Exit(2)
+		venom.OSExit(2)
 
 		return nil
 	},

--- a/process.go
+++ b/process.go
@@ -3,10 +3,10 @@ package venom
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	nested "github.com/antonfisher/nested-logrus-formatter"
 	"github.com/gosimple/slug"
@@ -16,12 +16,8 @@ import (
 
 // InitLogger initializes venom logger
 func (v *Venom) InitLogger() error {
-	v.testsuites = []TestSuite{}
-	if v.Verbose == 0 {
-		logrus.SetLevel(logrus.WarnLevel)
-	} else {
-		logrus.SetLevel(logrus.DebugLevel)
-	}
+	v.Tests.TestSuites = []TestSuite{}
+	logrus.SetLevel(logrus.DebugLevel)
 
 	if v.OutputDir != "" {
 		if err := os.MkdirAll(v.OutputDir, os.FileMode(0755)); err != nil {
@@ -29,20 +25,14 @@ func (v *Venom) InitLogger() error {
 		}
 	}
 
-	if v.Verbose > 0 {
-		var err error
-		var logFile = filepath.Join(v.OutputDir, computeVenomLogFilename())
-		v.LogOutput, err = os.OpenFile(logFile, os.O_CREATE|os.O_RDWR, os.FileMode(0644))
-		if err != nil {
-			return errors.Wrapf(err, "unable to write log file")
-		}
-
-		v.PrintlnTrace("writing " + logFile)
-
-		logrus.SetOutput(v.LogOutput)
-	} else {
-		logrus.SetOutput(io.Discard)
+	var err error
+	var logFile = filepath.Join(v.OutputDir, computeOutputFilename("venom.log"))
+	v.LogOutput, err = os.OpenFile(logFile, os.O_CREATE|os.O_RDWR, os.FileMode(0644))
+	if err != nil {
+		return errors.Wrapf(err, "unable to write log file")
 	}
+	v.PrintlnTrace("writing " + logFile)
+	logrus.SetOutput(v.LogOutput)
 
 	logrus.SetFormatter(&nested.Formatter{
 		HideKeys:       true,
@@ -57,12 +47,15 @@ func (v *Venom) InitLogger() error {
 	return nil
 }
 
-func computeVenomLogFilename() string {
-	if !fileExists("venom.log") {
-		return "venom.log"
+func computeOutputFilename(filename string) string {
+	// example of filename: venom.log
+	t := strings.Split(filename, ".")
+
+	if !fileExists(filename) {
+		return filename
 	}
 	for i := 0; ; i++ {
-		filename := fmt.Sprintf("venom.%d.log", i)
+		filename := fmt.Sprintf("%s.%d.%s", t[0], i, t[1])
 		if !fileExists(filename) {
 			return filename
 		}
@@ -90,17 +83,17 @@ func (v *Venom) Parse(ctx context.Context, path []string) error {
 
 	missingVars := []string{}
 	extractedVars := []string{}
-	for i := range v.testsuites {
-		ts := &v.testsuites[i]
+	for i := range v.Tests.TestSuites {
+		ts := &v.Tests.TestSuites[i]
 		ts.Vars.Add("venom.testsuite", ts.Name)
 
-		Info(ctx, "Parsing testsuite %s : %+v", ts.Package, ts.Vars)
+		Info(ctx, "Parsing testsuite %s : %+v", ts.Filepath, ts.Vars)
 		tvars, textractedVars, err := v.parseTestSuite(ts)
 		if err != nil {
 			return err
 		}
 
-		Debug(ctx, "Testsuite (%s) variables: %+v", ts.Package, ts.Vars)
+		Debug(ctx, "Testsuite (%s) variables: %+v", ts.Filepath, ts.Vars)
 		for k := range ts.Vars {
 			textractedVars = append(textractedVars, k)
 		}
@@ -171,13 +164,41 @@ func (v *Venom) Parse(ctx context.Context, path []string) error {
 }
 
 // Process runs tests suite and return a Tests result
-func (v *Venom) Process(ctx context.Context, path []string) (*Tests, error) {
-	testsResult := &Tests{}
-	Debug(ctx, "nb testsuites: %d", len(v.testsuites))
-	for i := range v.testsuites {
-		v.runTestSuite(ctx, &v.testsuites[i])
-		computeStats(testsResult, &v.testsuites[i])
+func (v *Venom) Process(ctx context.Context, path []string) error {
+	v.Tests.Status = StatusRun
+	v.Tests.Start = time.Now()
+	Debug(ctx, "nb testsuites: %d", len(v.Tests.TestSuites))
+	for i := range v.Tests.TestSuites {
+
+		v.Tests.TestSuites[i].Start = time.Now()
+		// ##### RUN Test Suite Here
+		v.runTestSuite(ctx, &v.Tests.TestSuites[i])
+
+		v.Tests.TestSuites[i].End = time.Now()
+		v.Tests.TestSuites[i].Duration = v.Tests.TestSuites[i].End.Sub(v.Tests.TestSuites[i].Start).Seconds()
+	}
+	v.Tests.End = time.Now()
+	v.Tests.Duration = v.Tests.End.Sub(v.Tests.Start).Seconds()
+
+	var isFailed bool
+	var nSkip int
+	for i := range v.Tests.TestSuites {
+		if v.Tests.TestSuites[i].Status == StatusFail {
+			isFailed = true
+			break
+		} else if v.Tests.TestSuites[i].Status == StatusSkip {
+			nSkip++
+		}
+	}
+	if isFailed {
+		v.Tests.Status = StatusFail
+	} else if nSkip > 0 && nSkip == len(v.Tests.TestSuites) {
+		v.Tests.Status = StatusSkip
+	} else {
+		v.Tests.Status = StatusPass
 	}
 
-	return testsResult, nil
+	Debug(ctx, "final status: %s", v.Tests.Status)
+
+	return nil
 }

--- a/process_files.go
+++ b/process_files.go
@@ -140,13 +140,19 @@ func (v *Venom) readFiles(ctx context.Context, filesPath []string) (err error) {
 			return errors.Wrapf(err, "Unable to get testsuite's working directory")
 		}
 
+		// ../foo/a.yml
 		ts.Filepath = f
-		ts.Filename = strings.TrimSuffix(filepath.Base(f), filepath.Ext(f))
+		// a
+		ts.ShortName = strings.TrimSuffix(filepath.Base(f), filepath.Ext(f))
+		// a.yml
+		ts.Filename = filepath.Base(f)
 		ts.Vars = varCloned
 
 		ts.Vars.Add("venom.testsuite.workdir", ts.WorkDir)
-		ts.Vars.Add("venom.testsuite.shortName", ts.Name)
+		ts.Vars.Add("venom.testsuite.name", ts.Name)
+		ts.Vars.Add("venom.testsuite.shortName", ts.ShortName)
 		ts.Vars.Add("venom.testsuite.filename", ts.Filename)
+		ts.Vars.Add("venom.testsuite.filepath", ts.Filepath)
 		ts.Vars.Add("venom.datetime", time.Now().Format(time.RFC3339))
 		ts.Vars.Add("venom.timestamp", fmt.Sprintf("%d", time.Now().Unix()))
 

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -179,10 +179,6 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 		stepVars.AddAllWithPrefix(tc.Name, tc.computedVars)
 		stepVars.Add("venom.teststep.number", stepNumber)
 
-		//testStepResult := TestStepResult{}
-		//tc.TestStepResults = append(tc.TestStepResults, testStepResult)
-		//tsIn := &tc.TestStepResults[len(tc.TestStepResults)-1]
-
 		ranged, err := parseRanged(ctx, rawStep, stepVars)
 		if err != nil {
 			Error(ctx, "unable to parse \"range\" attribute: %v", err)

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
-	"github.com/fatih/color"
 	"github.com/ghodss/yaml"
 	"github.com/ovh/cds/sdk/interpolate"
 	"github.com/pkg/errors"
@@ -16,7 +16,7 @@ import (
 
 var varRegEx = regexp.MustCompile("{{.*}}")
 
-//Parse the testcase to find unreplaced and extracted variables
+// Parse the testcase to find unreplaced and extracted variables
 func (v *Venom) parseTestCase(ts *TestSuite, tc *TestCase) ([]string, []string, error) {
 	dvars, err := DumpStringPreserveCase(tc.Vars)
 	if err != nil {
@@ -147,18 +147,21 @@ func (v *Venom) runTestCase(ctx context.Context, ts *TestSuite, tc *TestCase) {
 	}
 
 	defer Info(ctx, "Ending testcase")
+	// ##### RUN Test Steps Here
 	v.runTestSteps(ctx, tc, nil)
 }
 
 func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepResult) {
-
 	results, err := testConditionalStatement(ctx, tc, tc.Skip, tc.Vars, "skipping testcase %q: %v")
 	if err != nil {
 		Error(ctx, "unable to evaluate \"skip\" assertions: %v", err)
-		tc.AppendError(err)
+		testStepResult := TestStepResult{}
+		testStepResult.appendError(err)
+		tc.TestStepResults = append(tc.TestStepResults, testStepResult)
 		return
 	}
 	if len(results) > 0 {
+		tc.Status = StatusSkip
 		for _, s := range results {
 			tc.Skipped = append(tc.Skipped, Skipped{Value: s})
 			Warn(ctx, s)
@@ -176,16 +179,21 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 		stepVars.AddAllWithPrefix(tc.Name, tc.computedVars)
 		stepVars.Add("venom.teststep.number", stepNumber)
 
+		//testStepResult := TestStepResult{}
+		//tc.TestStepResults = append(tc.TestStepResults, testStepResult)
+		//tsIn := &tc.TestStepResults[len(tc.TestStepResults)-1]
+
 		ranged, err := parseRanged(ctx, rawStep, stepVars)
 		if err != nil {
 			Error(ctx, "unable to parse \"range\" attribute: %v", err)
-			tc.AppendError(err)
+			tsIn.appendError(err)
 			return
 		}
 
 		for rangedIndex, rangedData := range ranged.Items {
 			tc.TestStepResults = append(tc.TestStepResults, TestStepResult{})
-			ts := &tc.TestStepResults[len(tc.TestStepResults)-1]
+			tsResult := &tc.TestStepResults[len(tc.TestStepResults)-1]
+
 			if ranged.Enabled {
 				Debug(ctx, "processing range index: %d", rangedIndex)
 				stepVars.Add("index", rangedIndex)
@@ -196,14 +204,14 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 			vars, err := DumpStringPreserveCase(stepVars)
 			if err != nil {
 				Error(ctx, "unable to dump testcase vars: %v", err)
-				tc.AppendError(err)
+				tsResult.appendError(err)
 				return
 			}
 
 			for k, v := range vars {
 				content, err := interpolate.Do(v, vars)
 				if err != nil {
-					tc.AppendError(err)
+					tsResult.appendError(err)
 					Error(ctx, "unable to interpolate variable %q: %v", k, err)
 					return
 				}
@@ -221,7 +229,7 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 			for i := 0; i < 10; i++ {
 				content, err = interpolate.Do(string(rawStep), vars)
 				if err != nil {
-					tc.AppendError(err)
+					tsResult.appendError(err)
 					Error(ctx, "unable to interpolate step: %v", err)
 					return
 				}
@@ -231,9 +239,27 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 			}
 
 			Info(ctx, "Step #%d-%d content is: %q", stepNumber, rangedIndex, content)
+
+			data, err := yaml.Marshal(rawStep)
+			if err != nil {
+				tsResult.appendError(err)
+				Error(ctx, "unable to marshal raw: %v", err)
+			}
+			tsResult.Raw = data
+
+			data2, err := yaml.JSONToYAML([]byte(content))
+			if err != nil {
+				tsResult.appendError(err)
+				Error(ctx, "unable to marshal interpolated: %v", err)
+			}
+			tsResult.Interpolated = data2
+
+			tsResult.Number = stepNumber
+			tsResult.RangedIndex = rangedIndex
+			tsResult.InputVars = vars
 			var step TestStep
 			if err := yaml.Unmarshal([]byte(content), &step); err != nil {
-				tc.AppendError(err)
+				tsResult.appendError(err)
 				Error(ctx, "unable to unmarshal step: %v", err)
 				return
 			}
@@ -242,7 +268,7 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 			var e ExecutorRunner
 			ctx, e, err = v.GetExecutorRunner(ctx, step, tc.Vars)
 			if err != nil {
-				tc.AppendError(err)
+				tsResult.appendError(err)
 				Error(ctx, "unable to get executor: %v", err)
 				break
 			}
@@ -252,65 +278,69 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 				if !known {
 					ctx, err = e.Setup(ctx, tc.Vars)
 					if err != nil {
-						tc.AppendError(err)
+						tsResult.appendError(err)
 						Error(ctx, "unable to setup executor: %v", err)
 						break
 					}
 					knowExecutors[e.Name()] = struct{}{}
 					defer func(ctx context.Context) {
 						if err := e.TearDown(ctx); err != nil {
-							tc.AppendError(err)
+							tsResult.appendError(err)
 							Error(ctx, "unable to teardown executor: %v", err)
 						}
 					}(ctx)
 				}
 			}
 
-			printStepName := v.Verbose >= 2 && !fromUserExecutor
-			v.setTestStepName(ts, e, step, &ranged, &rangedData, printStepName)
+			printStepName := v.Verbose >= 1 && !fromUserExecutor
+			v.setTestStepName(tsResult, e, step, &ranged, &rangedData, printStepName)
 
-			result := v.RunTestStep(ctx, e, tc, ts, stepNumber, rangedIndex, step)
+			tsResult.Start = time.Now()
+
+			// ##### RUN Test Step Here
+			tsResult.Status = StatusRun
+			result := v.RunTestStep(ctx, e, tc, tsResult, stepNumber, rangedIndex, step)
+			if len(tsResult.Errors) > 0 || !tsResult.AssertionsApplied.OK {
+				tsResult.Status = StatusFail
+			} else {
+				tsResult.Status = StatusPass
+			}
+
+			tsResult.End = time.Now()
+			tsResult.Duration = tsResult.End.Sub(tsResult.Start).Seconds()
+
 			mapResult := GetExecutorResult(result)
 			previousStepVars.AddAll(H(mapResult))
 
 			tc.testSteps = append(tc.testSteps, step)
 
-			var hasFailed bool
 			var isRequired bool
-			if len(ts.Failures) > 0 {
-				for _, f := range ts.Failures {
-					Warning(ctx, "%v", f)
-					isRequired = isRequired || f.AssertionRequired
-				}
-				hasFailed = true
-			}
 
-			if len(ts.Errors) > 0 {
+			if tsResult.Status == StatusFail {
 				Error(ctx, "Errors: ")
-				for _, e := range ts.Errors {
+				for _, e := range tsResult.Errors {
 					Error(ctx, "%v", e)
+					isRequired = isRequired || e.AssertionRequired
 				}
-				hasFailed = true
-			}
 
-			if hasFailed {
 				if isRequired {
-					failure := newFailure(*tc, stepNumber, rangedIndex, "", fmt.Errorf("At least one required assertion failed, skipping remaining steps"))
-					ts.appendFailure(tc, *failure)
-					v.printTestStepResult(tc, ts, tsIn, stepNumber, true)
+					failure := newFailure(ctx, *tc, stepNumber, rangedIndex, "", fmt.Errorf("At least one required assertion failed, skipping remaining steps"))
+					tsResult.appendFailure(*failure)
+					v.printTestStepResult(tc, tsResult, tsIn, stepNumber, true)
 					return
 				}
-				v.printTestStepResult(tc, ts, tsIn, stepNumber, false)
+				v.printTestStepResult(tc, tsResult, tsIn, stepNumber, false)
 				continue
 			}
-			v.printTestStepResult(tc, ts, tsIn, stepNumber, false)
+			v.printTestStepResult(tc, tsResult, tsIn, stepNumber, false)
 
 			allVars := tc.Vars.Clone()
 			allVars.AddAll(tc.computedVars.Clone())
+			tsResult.ComputedVars = tc.computedVars.Clone()
 
 			assign, _, err := processVariableAssigments(ctx, tc.Name, allVars, rawStep)
 			if err != nil {
-				tc.AppendError(err)
+				tsResult.appendError(err)
 				Error(ctx, "unable to process variable assignments: %v", err)
 				break
 			}
@@ -321,7 +351,7 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 	}
 }
 
-//Set test step name (defaults to executor name, excepted if it got a "name" attribute. in range, also print key)
+// Set test step name (defaults to executor name, excepted if it got a "name" attribute. in range, also print key)
 func (v *Venom) setTestStepName(ts *TestStepResult, e ExecutorRunner, step TestStep, ranged *Range, rangedData *RangeData, print bool) {
 	name := e.Name()
 	if value, ok := step["name"]; ok {
@@ -340,45 +370,35 @@ func (v *Venom) setTestStepName(ts *TestStepResult, e ExecutorRunner, step TestS
 	}
 }
 
-//Print a single step result (if verbosity is enabled)
+// Print a single step result (if verbosity is enabled)
 func (v *Venom) printTestStepResult(tc *TestCase, ts *TestStepResult, tsIn *TestStepResult, stepNumber int, mustAssertionFailed bool) {
-	if v.Verbose >= 2 {
-		fromUserExecutor := tsIn != nil
-		var red = color.New(color.FgRed).SprintFunc()
-		var green = color.New(color.FgGreen).SprintFunc()
-		var gray = color.New(color.Attribute(90)).SprintFunc()
-
-		//Within an user executor, we instead transfer errors to original test step which will print it for use
-		if fromUserExecutor {
-			tsIn.appendError(tc, ts.Errors...)
-			tsIn.appendFailure(tc, ts.Failures...)
-		} else { //Else print step status
-			if len(ts.Skipped) > 0 {
-				v.Println(" %s", gray("SKIPPED"))
-			} else if len(ts.Failures) > 0 || len(ts.Errors) > 0 {
-				v.Println(" %s", red("FAILURE"))
-				for _, f := range ts.Failures {
-					v.Println(" \t\t  %s", red(f))
-				}
+	fromUserExecutor := tsIn != nil
+	if fromUserExecutor {
+		tsIn.appendFailure(ts.Errors...)
+	}
+	if v.Verbose >= 1 {
+		if !fromUserExecutor { //Else print step status
+			if len(ts.Errors) > 0 {
+				v.Println(" %s", Red(StatusFail))
 				for _, f := range ts.Errors {
-					v.Println(" \t\t  %s", red(f.Value))
+					v.Println(" \t\t  %s", Yellow(f.Value))
 				}
 				if mustAssertionFailed {
 					skipped := len(tc.RawTestSteps) - stepNumber - 1
 					if skipped == 1 {
-						v.Println(" \t\t  %s", gray(fmt.Sprintf("%d other step was skipped", skipped)))
+						v.Println(" \t\t  %s", Gray(fmt.Sprintf("%d other step was skipped", skipped)))
 					} else {
-						v.Println(" \t\t  %s", gray(fmt.Sprintf("%d other steps were skipped", skipped)))
+						v.Println(" \t\t  %s", Gray(fmt.Sprintf("%d other steps were skipped", skipped)))
 					}
 				}
 			} else {
-				v.Println(" %s", green("SUCCESS"))
+				v.Println(" %s", Green(StatusPass))
 			}
 		}
 	}
 }
 
-//Parse and format range data to allow iterations over user data
+// Parse and format range data to allow iterations over user data
 func parseRanged(ctx context.Context, rawStep []byte, stepVars H) (Range, error) {
 
 	//Load "range" attribute and perform actions depending on its typing

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -7,3 +7,4 @@ venom.test
 *.coverprofile
 *.out
 *.test.out
+test_results.*

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -77,7 +77,7 @@ build-test-binary-docker:
 
 run-test: generate-venom-pki
 	VENOM_VAR_MY_ENVAR=foo  ./venom_wrapper.sh run \
-	-vv --format=xml --output-dir=. --lib-dir=./lib_custom --var='array_from_var=["biz","buz"]' --var-from-file ./kafka/testVariables.yml --var-from-file=$(PKI_VAR_FILE) --var-from-file ./vars/vars.yml ./*.yml ./assertions/*.yml && \
+	-vv --format=html,xml --output-dir=. --lib-dir=./lib_custom --var='array_from_var=["biz","buz"]' --var-from-file ./kafka/testVariables.yml --var-from-file=$(PKI_VAR_FILE) --var-from-file ./vars/vars.yml ./*.yml ./assertions/*.yml && \
 	(cd ./vars_override && VENOM_VAR_foo=from-env VENOM_VAR_FOO2=from-env2 VENOM_VAR_FOO3=from-env3 ../venom_wrapper.sh run -vv --format=xml --output-dir=. --var foo='from-cmd-arg' --var='array_from_var=["biz","buz"]' ./mytc.yml);
 
 .PHONY: wait-for-kafka
@@ -87,7 +87,7 @@ wait-for-kafka:
 	echo "\n\033[0;32mdone\033[0m"
 
 clean:
-	@rm -f *.prof *.log *.dump.json *.args.file *.error.out *.out *.test.out *.coverprofile
+	@rm -f *.prof *.html *.xml *.log *.dump.json *.args.file *.error.out *.out *.test.out *.coverprofile
 
 merge-coverage:
 	@docker run -v `pwd`:/workspace golang:1.17 sh -c "\

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -70,7 +70,7 @@ stop-test-stack:
 build-test-binary:
 	cd ../cmd/venom; \
 	TEMP=`$(PKGS_COMMA_SEP)`; \
-	CGO_ENABLED=1 go test -coverpkg $$TEMP -c . -o ../../tests/venom.test -ldflags "-X github.com/ovh/venom.IsTest=true" -tags testbincover;
+	CGO_ENABLED=1 go test -coverpkg $$TEMP -c . -o ../../tests/venom.test -tags testbincover;
 
 build-test-binary-docker:
 	docker run -v `pwd`/..:/workspace golang:1.17 sh -c "cd /workspace/tests && make build-test-binary"	

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -70,7 +70,7 @@ stop-test-stack:
 build-test-binary:
 	cd ../cmd/venom; \
 	TEMP=`$(PKGS_COMMA_SEP)`; \
-	CGO_ENABLED=1 go test -coverpkg $$TEMP -c . -o ../../tests/venom.test -tags testbincover;
+	CGO_ENABLED=1 go test -coverpkg $$TEMP -c . -o ../../tests/venom.test -ldflags "-X github.com/ovh/venom.IsTest=true" -tags testbincover;
 
 build-test-binary-docker:
 	docker run -v `pwd`/..:/workspace golang:1.17 sh -c "cd /workspace/tests && make build-test-binary"	

--- a/tests/retry_if.yml
+++ b/tests/retry_if.yml
@@ -19,7 +19,7 @@ testcases:
   steps:
   # spawn a venom sub-process and expect it to fail 
   - type: exec
-    script: '{{.venom.executable}} run failing/retry_if.yml'
+    script: './venom run failing/retry_if.yml'
     assertions:
       - result.code ShouldEqual 2
       - result.systemerr ShouldBeEmpty

--- a/tests/user_executor_custom_must_assertion.yml
+++ b/tests/user_executor_custom_must_assertion.yml
@@ -4,7 +4,7 @@ testcases:
   steps:
   # spawn a venom sub-process and expect it to fail and make assertions on its error messages
   - type: exec
-    script: '{{.venom.executable}} run failing/must_assertion.yml --lib-dir {{.venom.libdir}}'
+    script: './venom run failing/must_assertion.yml --lib-dir {{.venom.libdir}}'
     assertions:
       - result.code ShouldEqual 2
       - result.systemout ShouldContainSubstring 'At least one required assertion failed, skipping remaining steps'

--- a/tests/verbose_output.yml
+++ b/tests/verbose_output.yml
@@ -6,6 +6,7 @@ testcases:
   # ensure no color to avoid annoying checks
   - type: exec
     script: NO_COLOR=1 {{.venom.executable}} run failing/verbose_output.yml {{.value.opt}}
+    info: NO_COLOR=1 {{.venom.executable}} run failing/verbose_output.yml {{.value.opt}}
     range:
       verbose:
         opt: "-vv"
@@ -17,18 +18,18 @@ testcases:
     - result.code ShouldEqual 2
     - result.systemerr ShouldBeEmpty
     # single step
-    - result.systemout {{.value.op}}ContainSubstring 'exec SUCCESS'
+    - result.systemout {{.value.op}}ContainSubstring 'exec PASS'
     # named step
-    - result.systemout {{.value.op}}ContainSubstring 'hello-world SUCCESS'
+    - result.systemout {{.value.op}}ContainSubstring 'hello-world PASS'
     # multi steps
-    - result.systemout {{.value.op}}ContainSubstring 'step1 SUCCESS'
-    - result.systemout {{.value.op}}ContainSubstring 'step2 FAILURE'
+    - result.systemout {{.value.op}}ContainSubstring 'step1 PASS'
+    - result.systemout {{.value.op}}ContainSubstring 'step2 FAIL'
     # ranged steps
-    - result.systemout {{.value.op}}ContainSubstring 'exec (range=0) SUCCESS'
-    - result.systemout {{.value.op}}ContainSubstring 'exec (range=1) FAILURE'
-    - result.systemout {{.value.op}}ContainSubstring 'exec (range=2) SUCCESS'
+    - result.systemout {{.value.op}}ContainSubstring 'exec (range=0) PASS'
+    - result.systemout {{.value.op}}ContainSubstring 'exec (range=1) FAIL'
+    - result.systemout {{.value.op}}ContainSubstring 'exec (range=2) PASS'
     # must assertions
-    - result.systemout {{.value.op}}ContainSubstring 'must1 FAILURE'
+    - result.systemout {{.value.op}}ContainSubstring 'must1 FAIL'
     - result.systemout ShouldContainSubstring 'At least one required assertion failed, skipping remaining steps'
     - result.systemout {{.value.op}}ContainSubstring '2 other steps were skipped'
     - result.systemout ShouldNotContainSubstring 'must2'

--- a/tests/verbose_output.yml
+++ b/tests/verbose_output.yml
@@ -5,8 +5,8 @@ testcases:
   # spawn a venom sub-process and expect it to fail and make assertions on its error messages
   # ensure no color to avoid annoying checks
   - type: exec
-    script: NO_COLOR=1 {{.venom.executable}} run failing/verbose_output.yml {{.value.opt}}
-    info: NO_COLOR=1 {{.venom.executable}} run failing/verbose_output.yml {{.value.opt}}
+    script: NO_COLOR=1 ./venom run failing/verbose_output.yml {{.value.opt}}
+    info: NO_COLOR=1 ./venom run failing/verbose_output.yml {{.value.opt}}
     range:
       verbose:
         opt: "-vv"

--- a/types.go
+++ b/types.go
@@ -113,6 +113,7 @@ type TestSuite struct {
 	Vars      H          `json:"vars" yaml:"vars"`
 
 	// computed
+	ShortName    string `json:"shortname" yaml:"-"`
 	Filename     string `json:"filename" yaml:"-"`
 	Filepath     string `json:"filepath" yaml:"-"`
 	ComputedVars H      `json:"computed_vars" yaml:"-"`

--- a/types_executor.go
+++ b/types_executor.go
@@ -220,14 +220,20 @@ func (v *Venom) RunUserExecutor(ctx context.Context, runner ExecutorRunner, tcIn
 	}
 	// reload the user executor with the interpolated vars
 	_, exe, err := v.GetExecutorRunner(ctx, step, vrs)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to reload executor")
+	}
 	ux := exe.GetExecutor().(UserExecutor)
 
 	tc := &TestCase{
-		Name:          ux.Executor,
-		RawTestSteps:  ux.RawTestSteps,
-		Vars:          vrs,
-		TestSuiteVars: tcIn.TestSuiteVars,
-		IsExecutor:    true,
+		TestCaseInput: TestCaseInput{
+			Name:         ux.Executor,
+			RawTestSteps: ux.RawTestSteps,
+			Vars:         vrs,
+		},
+		TestSuiteVars:   tcIn.TestSuiteVars,
+		IsExecutor:      true,
+		TestStepResults: make([]TestStepResult, 0),
 	}
 
 	tc.originalName = tc.Name
@@ -279,9 +285,7 @@ func (v *Venom) RunUserExecutor(ctx context.Context, runner ExecutorRunner, tcIn
 		return nil, errors.Wrapf(err, "unable to unmarshal")
 	}
 
-	tcIn.Errors = tc.Errors
-	tcIn.Failures = tc.Failures
-	if len(tc.Errors) > 0 || len(tc.Failures) > 0 {
+	if len(tsIn.Errors) > 0 {
 		return outputResult, fmt.Errorf("failed")
 	}
 

--- a/venom.go
+++ b/venom.go
@@ -25,11 +25,11 @@ import (
 var (
 	//Version is set with -ldflags "-X github.com/ovh/venom/venom.Version=$(VERSION)"
 	Version = "snapshot"
-	IsTest  = false
+	IsTest  = ""
 )
 
 func OSExit(exitCode int) {
-	if IsTest {
+	if IsTest != "" {
 		bincover.ExitCode = exitCode
 	} else {
 		os.Exit(exitCode)

--- a/venom.go
+++ b/venom.go
@@ -53,8 +53,8 @@ type Venom struct {
 	executorsUser     map[string]Executor
 	executorFileCache map[string][]byte
 
-	testsuites []TestSuite
-	variables  H
+	Tests     Tests
+	variables H
 
 	LibDir        string
 	OutputFormat  string

--- a/venom.go
+++ b/venom.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/confluentinc/bincover"
 	"github.com/fatih/color"
 	"github.com/ghodss/yaml"
 	"github.com/ovh/cds/sdk/interpolate"
@@ -24,7 +25,16 @@ import (
 var (
 	//Version is set with -ldflags "-X github.com/ovh/venom/venom.Version=$(VERSION)"
 	Version = "snapshot"
+	IsTest  = false
 )
+
+func OSExit(exitCode int) {
+	if IsTest {
+		bincover.ExitCode = exitCode
+	} else {
+		os.Exit(exitCode)
+	}
+}
 
 // ContextKey can be added in context to store contextual infos. Also used by logger.
 type ContextKey string

--- a/venom.go
+++ b/venom.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/confluentinc/bincover"
 	"github.com/fatih/color"
 	"github.com/ghodss/yaml"
 	"github.com/ovh/cds/sdk/interpolate"
@@ -28,11 +29,11 @@ var (
 )
 
 func OSExit(exitCode int) {
-	// if IsTest != "" {
-	// 	bincover.ExitCode = exitCode
-	// } else {
-	os.Exit(exitCode)
-	//}
+	if IsTest != "" {
+		bincover.ExitCode = exitCode
+	} else {
+		os.Exit(exitCode)
+	}
 }
 
 // ContextKey can be added in context to store contextual infos. Also used by logger.

--- a/venom.go
+++ b/venom.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/confluentinc/bincover"
 	"github.com/fatih/color"
 	"github.com/ghodss/yaml"
 	"github.com/ovh/cds/sdk/interpolate"
@@ -29,11 +28,11 @@ var (
 )
 
 func OSExit(exitCode int) {
-	if IsTest != "" {
-		bincover.ExitCode = exitCode
-	} else {
-		os.Exit(exitCode)
-	}
+	// if IsTest != "" {
+	// 	bincover.ExitCode = exitCode
+	// } else {
+	os.Exit(exitCode)
+	//}
 }
 
 // ContextKey can be added in context to store contextual infos. Also used by logger.

--- a/venom_output.html
+++ b/venom_output.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Venom Results</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/yamljs/0.3.0/yaml.min.js"></script>
+    <style>
+      
+    @media (min-width: 768px) {
+      .bd-placeholder-img-lg {
+        font-size: 3.5rem;
+      }
+    }
+    
+    .bi {
+      vertical-align: -.125em;
+      fill: currentColor;
+    }
+    .nav-scroller {
+      position: relative;
+      z-index: 2;
+      height: 2.75rem;
+      overflow-y: hidden;
+    }
+    .nav-scroller .nav {
+      display: flex;
+      flex-wrap: nowrap;
+      padding-bottom: 1rem;
+      margin-top: -1px;
+      overflow-x: auto;
+      text-align: center;
+      white-space: nowrap;
+      -webkit-overflow-scrolling: touch;
+    }
+    body {
+      font-size: .875rem;
+    }
+    
+    .feather {
+      width: 16px;
+      height: 16px;
+    }
+    
+    .sidebar {
+      position: fixed;
+      top: 0;
+      /* rtl:raw:
+      right: 0;
+      */
+      bottom: 0;
+      /* rtl:remove */
+      left: 0;
+      z-index: 100; /* Behind the navbar */
+      padding: 48px 0 0; /* Height of navbar */
+    }
+    
+    @media (max-width: 767.98px) {
+      .sidebar {
+        top: 5rem;
+      }
+    }
+    
+    .b-divider {
+      height: 3rem;
+      background-color: rgba(0, 0, 0, .1);
+      border: solid rgba(0, 0, 0, .15);
+      border-width: 1px 0;
+      box-shadow: inset 0 .5em 1.5em rgba(0, 0, 0, .1), inset 0 .125em .5em rgba(0, 0, 0, .15);
+    }
+
+    .b-vr {
+      flex-shrink: 0;
+      width: 1.5rem;
+      height: 100vh;
+    }
+
+    .sidebar-sticky {
+      height: calc(100vh - 48px);
+      overflow-x: hidden;
+      overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
+    }
+    
+    .start-97 {
+      left: 5%!important;
+    }
+
+    .nt {
+      color: rgb(33,37,41);
+    }
+    
+    .navbar-brand {
+      padding-top: .75rem;
+      padding-bottom: .75rem;
+    }
+    
+    .float-right {
+      float: right!important;
+    }
+
+    .testsuites li {
+      cursor:pointer;
+    }
+  </style>
+  </head>
+<body>
+    
+<header class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0 shadow">
+  <a class="navbar-brand col-md-3 col-lg-2 me-0 px-3 fs-6" href="#">🐍 Venom</a>
+  <div class="navbar-nav">
+  </div>
+</header>
+<div class="container-fluid">
+  <div class="row">
+    <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-withe sidebar">
+      <div class="position-sticky pt-3 sidebar-sticky">
+        <div class="align-items-center flex-shrink-0 p-3 link-dark text-decoration-none border-bottom" id="title-nav-testsuites">
+        </div>
+        <ul class="list-group list-group-flush border-bottom scrollarea testsuites" id="testsuites">
+        </ul>
+      </div>
+    </nav>
+
+    <main class="d-flex flex-nowrap col-md-9 ms-sm-auto col-lg-10 px-md-0">
+      <div class="b-divider b-vr"></div>
+      <div class="p-3 col-md-11">
+      <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 id="testsuite" class="h2"></h1>
+      </div>
+      <div id="testsuite_infos"></div>
+      <div id="testcases">        
+      </div>
+      </div>
+    </main>
+  </div>
+</div>
+<script>
+  (() => {
+    'use strict'
+    $(document).ready( function () {
+      var a = {{.JSONValue}};
+      
+      var nb = 0;
+      var testsuites = "";
+      for (var i = 0; i < a.test_suites.length; i++) { 
+        if (a.test_suites[i]) {
+          testsuites += navbartestsuite(i, a.test_suites[i]); 
+        }
+        nb++;
+      }
+
+      var testsuiteDisplay = '<p class="fs-5 fw-semibold" id="title-nav-testsuites">Tests Suites: '+nb+'</p>';
+      testsuiteDisplay += '<ul>';
+      if (a.nbTestsuitesFail > 0) {
+        var badge = '<span class="badge text-bg-danger">'+a.nbTestsuitesFail+' FAIL</span>';
+        testsuiteDisplay += '<li>'+badge+'</li>';
+      }
+      if (a.nbTestsuitesPass > 0) {
+        var badge = '<span class="badge text-bg-success">'+a.nbTestsuitesPass+' PASS</span>';
+        testsuiteDisplay += '<li>'+badge+'</li>';
+      }
+      if (a.nbTestsuitesSkip > 0) {
+        var badge = '<span class="badge text-bg-secondary">'+a.nbTestsuitesSkip+' SKIP</span>';
+        testsuiteDisplay += '<li>'+badge+'</li>';
+      }
+      testsuiteDisplay += '<li>Duration: <code class="nt">'+parseFloat(a.duration).toFixed(2)+'s</code></li>';
+      testsuiteDisplay += '<li>Start: <code class="nt">'+ToLocaleString(a.start)+'</code></li>';
+      testsuiteDisplay += '<li>End: <code class="nt">'+ToLocaleString(a.end)+'</code></li>';
+      testsuiteDisplay += '</ul>';
+
+      $('#title-nav-testsuites').html(testsuiteDisplay);
+      $('#testsuites').html(testsuites)
+      
+      $('#testsuites li').on('click', function () {
+        var data = a.test_suites[this.id];
+
+        var info = "";
+        info += '<ul>'
+        if (data.nbTestcasesFail > 0) {
+          var badge = '<span class="badge text-bg-danger">'+data.nbTestcasesFail+' FAIL</span>';
+          info += '<li>'+badge+'</li>';
+        }
+        if (data.nbTestcasesPass > 0) {
+          var badge = '<span class="badge text-bg-success">'+data.nbTestcasesPass+' PASS</span>';
+          info += '<li>'+badge+'</li>';
+        }
+        if (data.nbTestcasesSkip > 0) {
+          var badge = '<span class="badge text-bg-secondary">'+data.nbTestcasesSkip+' SKIP</span>';
+          info += '<li>'+badge+'</li>';
+        }
+        info += '<li>Filepath: <code class="nt">'+data.filepath+'</code></li>';
+        info += '<li>Workdir: <code class="nt">'+data.workdir+'</code></li>';
+        info += '<li>Duration: <code class="nt">'+parseFloat(data.duration).toFixed(2)+'s</code></li>';
+        info += '<li>Start: <code class="nt">'+ToLocaleString(data.start)+'</code></li>';
+        info += '<li>End: <code class="nt">'+ToLocaleString(data.end)+'</code></li>';
+        if (data.testcases) {
+          info += '<li>Testcases: <code class="nt">'+data.testcases.length+'</code></li>';
+        } else {
+          info += '<li>Testcases: 0</li>';
+        }
+
+        info += '</ul>';
+        $('#testsuite_infos').html(info);
+        $('#testsuite').html("testsuite " + data.name);
+        middletestsuite(i, data);
+      });
+    });
+  })()
+
+  function ToLocaleString(dateTime) {
+    var date = Date.parse(dateTime);
+    var d = new Date(date)
+    return d.toLocaleString();
+  }
+
+  function navbartestsuite(idx, testsuite) {
+    var badges = '<span class="badge rounded-pill float-right text-bg-'+colorStatus(testsuite.status)+'" title="'+colorStatus(testsuite.status)+'">'+testsuite.status+'</span>';
+    var name = testsuite.name;
+    if (name === '') {
+      name = "N/A";
+    }
+    
+    var r = '<li class="list-group-item list-group-item-action py-3 lh-sm" id="'+idx+'">';
+
+    r += '<div class="d-flex w-100 align-items-center justify-content-between">';
+    r += '<strong class="mb-1">'+name+'</strong>';
+    
+    r += '<small>'+badges+'</small>';
+
+    r += '<span class="position-absolute top-0 translate-middle rounded-pill text-bg-light start-97">';
+    r += '<small>'+(idx+1)+'</small>';
+    r += '</span>';
+
+    r += '</div>';
+
+    r += '<div class="col-10 mb-1 small">'+parseFloat(testsuite.duration).toFixed(2)+'s</div>';
+
+    r += '</li>';
+    return r;
+  }
+
+  function colorStatus(status) {
+    switch (status) {
+    case "PASS":
+        return "success";
+        break;
+    case "RUN":
+        return "primary";
+        break;
+    case "FAIL":
+        return "danger";
+        break;
+    case "SKIP":
+        return "secondary";
+        break;
+    }
+  }
+
+  function middletestsuite(idx, testsuite) {
+    $('#testcases').html('');
+    if (testsuite.testcases) {
+      var testcases = "";
+      for (var i = 0; i < testsuite.testcases.length; i++) {
+        var testcase = testsuite.testcases[i];
+       
+        var r = "";
+        var status = colorStatus(testcase.status);
+        var badgeTC = '<span class="badge rounded-pill float-right text-bg-'+colorStatus(testsuite.status)+'" title="'+colorStatus(testsuite.status)+'">'+testsuite.status+'</span>';
+
+        var border = "border-"+status;
+
+        r += '<div class="card bg-light mb-3 w-100 '+border+'" style="width: 18rem;">';
+        r += '  <div class="card-header bg-transparent '+border+' text-'+status+'">';
+        r += '   testcase: '+testcase.name+' '+badgeTC;
+        r += '  </div>';
+        r += '  <ul class="list-group list-group-flush">';
+
+        if (testcase.skipped && testcase.skipped.length > 0) {
+          r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#skipped-'+i+''+j+'">Skipped Info</button>';
+          r += '<div id="skipped-'+i+''+j+'" class="collapse show"><ul>';
+          for (var k = 0; k < testcase.skipped.length; k++) {
+            r += '<li><span class="badge rounded-pill text-bg-info" title="info">Info</span>';
+            r += ' <code class="nt">'+testcase.skipped[k].value+'</code></li>';
+          }
+          r += '</ul></div>';
+        }
+
+        if (testcase.results) {
+          for (var j = 0; j < testcase.results.length; j++) {
+            var result = testcase.results[j];
+            var badgeR = '<span class="badge rounded-pill float-right text-bg-'+colorStatus(result.status)+'" title="'+colorStatus(result.status)+'">'+result.status+'</span>';
+
+            r += '<li class="list-group-item"><p>';
+            r += '<p>step '+(result.number+1)+': '+result.name ;
+            r +=  badgeR;
+            r += '</p>';
+
+            if (result.raw && result.raw !== '') {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#raw-'+i+''+j+'">Raw</button>';
+              r += '<div id="raw-'+i+''+j+'" class="collapse">';
+              r += '  <pre>'+decodeURIComponent(escape(atob(result.raw)))+'</pre>';
+              r += '</div>';
+            }
+            if (result.interpolated && result.interpolated !== '') {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#interpolated-'+i+''+j+'">Raw Interpolated</button>';
+              r += '<div id="interpolated-'+i+''+j+'" class="collapse">';
+              r += '  <pre>'+decodeURIComponent(escape(atob(result.interpolated)))+'</pre>';
+              r += '</div>';
+            }
+            if (result.computedInfos && result.computedInfos !== '') {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#computedInfos-'+i+''+j+'">Computed Infos</button>';
+              r += '<div id="computedInfos-'+i+''+j+'" class="collapse show"><ul>';
+              for (var k = 0; k < result.computedInfos.length; k++) {
+                r += '<li><span class="badge rounded-pill text-bg-info" title="info">Info</span>';
+                r += ' <code class="nt">'+result.computedInfos[k]+'</code></li>';
+              }
+              r += '</ul></div>';
+            }
+            if (result.errors && result.errors !== '') {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#errors-'+i+''+j+'">Errors</button>';
+              r += '<div id="errors-'+i+''+j+'" class="collapse show"><ul>';
+              for (var k = 0; k < result.errors.length; k++) {
+                r += '<li><span class="badge rounded-pill text-bg-danger" title="info">FAIL</span>';
+                r += ' <code class="nt">'+result.errors[k].value+'</code></li>';
+              }
+              r += '</ul></div>';
+            }
+            if (result.systemout && result.systemout !== '') {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#systemout-'+i+''+j+'">System Out</button>';
+              r += '<div id="systemout-'+i+''+j+'" class="collapse">';
+              r += '  <pre>'+YAML.stringify(result.systemout)+'</pre>';
+              r += '</div>';
+            }
+            if (result.systemerr && result.systemerr !== '') {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#systemerr-'+i+''+j+'">System Err</button>';
+              r += '<div id="systemerr-'+i+''+j+'" class="collapse">';
+              r += '  <pre>'+YAML.stringify(result.systemerr)+'</pre>';
+              r += '</div>';
+            }
+            if (result.inputVars && result.inputVars !== '') {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#inputVars-'+i+''+j+'">Input Vars</button>';
+              r += '<div id="inputVars-'+i+''+j+'" class="collapse">';
+              r += '  <pre>'+YAML.stringify(result.inputVars)+'</pre>';
+              r += '</div>';
+            }
+            if (result.computedVars && result.computedVars !== '') {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#computedVars-'+i+''+j+'">Computed Vars</button>';
+              r += '<div id="computedVars-'+i+''+j+'" class="collapse">';
+              r += '  <pre>'+YAML.stringify(result.computedVars)+'</pre>';
+              r += '</div>';
+            }
+            if (result.assertionsApplied && result.assertionsApplied.assertions && result.assertionsApplied.assertions.length > 0) {
+              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#assertionsApplied-'+i+''+j+'">Assertions applied Infos</button>';
+              r += '<div id="assertionsApplied-'+i+''+j+'" class="collapse"><ul>';
+              for (var k = 0; k < result.assertionsApplied.assertions.length; k++) {
+                var assertionStatus = "PASS";
+                if (result.assertionsApplied.assertions[k].isOK !== true) {
+                  assertionStatus = "FAIL";
+                }
+                r += '<li><span class="badge rounded-pill text-bg-'+colorStatus(assertionStatus)+'" title="'+colorStatus(assertionStatus)+'">'+assertionStatus+'</span>';
+
+                r += ' <code class="nt">'+result.assertionsApplied.assertions[k].assertion+'</code></li>'; 
+              }
+              r += '</ul></div>';
+            }
+
+            r += '</p><small class="text-muted">'+parseFloat(result.duration).toFixed(2)+'s';
+            r += ' - start:'+ToLocaleString(result.start);
+            r += ' - end:'+ToLocaleString(result.end);
+            r += '</small>';
+
+            r += '</li>';
+          }
+        }
+        r += '  </ul>';
+
+        r += '  <div class="card-footer '+border+'">';
+        r += '    <small class="text-muted">'+parseFloat(testcase.duration).toFixed(2)+'s';
+        r += ' - start:'+ToLocaleString(testcase.start);
+        r += ' - end:'+ToLocaleString(testcase.end);
+        r += '</small>';
+        r += '  </div>';
+
+        r += '</div>';
+        testcases += r;
+      }
+      var cards = '<div class="">'+testcases+'</div>';
+      $('#testcases').html(cards);
+    }
+  }
+
+  function dis(id, value, sing, plu) {
+    $(id).hide()
+    if (value == 1) {
+      $(id).html(value + " " + sing);
+      $(id).show()
+    } else if (value > 1) {
+        $(id).html(value + " " + plu);
+        $(id).show()
+    }
+  }
+  </script>  
+  </body>
+</html>

--- a/venom_output.html
+++ b/venom_output.html
@@ -127,31 +127,31 @@
     <main class="d-flex flex-nowrap col-md-9 ms-sm-auto col-lg-10 px-md-0">
       <div class="b-divider b-vr"></div>
       <div class="p-3 col-md-11">
-      <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-        <h1 id="testsuite" class="h2"></h1>
-        <div id="testsuite-badges"></div>
-      </div>
-      <div id="testsuite_infos"></div>
+        <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+          <h1 id="testsuite" class="h2"></h1>
+          <div id="testsuite-badges"></div>
+        </div>
+        <div id="testsuite_infos"></div>
 
-      <div id="testcases">        
-      </div>
+        <div id="testcases">        
+        </div>
 
-      <!-- Modal -->
-      <div class="modal fade" id="varsModal" tabindex="-1" aria-labelledby="varsModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="varsModalLabel">Test Suite Variables</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body" id="testsuite-vars">
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <!-- Modal -->
+        <div class="modal fade" id="varsModal" tabindex="-1" aria-labelledby="varsModalLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="varsModalLabel">Test Suite Variables</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              </div>
+              <div class="modal-body" id="testsuite-vars">
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
       
       </div>
     </main>

--- a/venom_output.html
+++ b/venom_output.html
@@ -129,10 +129,30 @@
       <div class="p-3 col-md-11">
       <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
         <h1 id="testsuite" class="h2"></h1>
+        <div id="testsuite-badges"></div>
       </div>
       <div id="testsuite_infos"></div>
+
       <div id="testcases">        
       </div>
+
+      <!-- Modal -->
+      <div class="modal fade" id="varsModal" tabindex="-1" aria-labelledby="varsModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="varsModalLabel">Test Suite Variables</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body" id="testsuite-vars">
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      
       </div>
     </main>
   </div>
@@ -142,7 +162,7 @@
     'use strict'
     $(document).ready( function () {
       var a = {{.JSONValue}};
-      
+
       var nb = 0;
       var testsuites = "";
       for (var i = 0; i < a.test_suites.length; i++) { 
@@ -152,20 +172,33 @@
         nb++;
       }
 
-      var testsuiteDisplay = '<p class="fs-5 fw-semibold" id="title-nav-testsuites">Tests Suites: '+nb+'</p>';
-      testsuiteDisplay += '<ul>';
+      
+
+      var infob = '';
       if (a.nbTestsuitesFail > 0) {
-        var badge = '<span class="badge text-bg-danger">'+a.nbTestsuitesFail+' FAIL</span>';
-        testsuiteDisplay += '<li>'+badge+'</li>';
+        var badge = '<span class="badge text-bg-danger">'+a.nbTestsuitesFail+' FAILED</span>';
+        infob += badge;
       }
       if (a.nbTestsuitesPass > 0) {
-        var badge = '<span class="badge text-bg-success">'+a.nbTestsuitesPass+' PASS</span>';
-        testsuiteDisplay += '<li>'+badge+'</li>';
+        var badge = '<span class="badge text-bg-success">'+a.nbTestsuitesPass+' PASSED</span>';
+        infob += badge;
       }
       if (a.nbTestsuitesSkip > 0) {
-        var badge = '<span class="badge text-bg-secondary">'+a.nbTestsuitesSkip+' SKIP</span>';
-        testsuiteDisplay += '<li>'+badge+'</li>';
+        var badge = '<span class="badge text-bg-secondary">'+a.nbTestsuitesSkip+' SKIPPED</span>';
+        infob += badge;
       }
+      var testsuiteDisplay = '';
+      
+      testsuiteDisplay = '<div class="">';
+      testsuiteDisplay = '<div class="fs-5 fw-semibold">';
+      testsuiteDisplay += 'Tests Suites';
+      testsuiteDisplay += '</div>';
+      testsuiteDisplay += '<small>'+infob+'</small>';
+      testsuiteDisplay += '</div>';
+      
+
+      testsuiteDisplay += '<ul>';
+
       testsuiteDisplay += '<li>Duration: <code class="nt">'+parseFloat(a.duration).toFixed(2)+'s</code></li>';
       testsuiteDisplay += '<li>Start: <code class="nt">'+ToLocaleString(a.start)+'</code></li>';
       testsuiteDisplay += '<li>End: <code class="nt">'+ToLocaleString(a.end)+'</code></li>';
@@ -173,24 +206,13 @@
 
       $('#title-nav-testsuites').html(testsuiteDisplay);
       $('#testsuites').html(testsuites)
-      
+
       $('#testsuites li').on('click', function () {
         var data = a.test_suites[this.id];
 
         var info = "";
         info += '<ul>'
-        if (data.nbTestcasesFail > 0) {
-          var badge = '<span class="badge text-bg-danger">'+data.nbTestcasesFail+' FAIL</span>';
-          info += '<li>'+badge+'</li>';
-        }
-        if (data.nbTestcasesPass > 0) {
-          var badge = '<span class="badge text-bg-success">'+data.nbTestcasesPass+' PASS</span>';
-          info += '<li>'+badge+'</li>';
-        }
-        if (data.nbTestcasesSkip > 0) {
-          var badge = '<span class="badge text-bg-secondary">'+data.nbTestcasesSkip+' SKIP</span>';
-          info += '<li>'+badge+'</li>';
-        }
+        
         info += '<li>Filepath: <code class="nt">'+data.filepath+'</code></li>';
         info += '<li>Workdir: <code class="nt">'+data.workdir+'</code></li>';
         info += '<li>Duration: <code class="nt">'+parseFloat(data.duration).toFixed(2)+'s</code></li>';
@@ -202,9 +224,33 @@
           info += '<li>Testcases: 0</li>';
         }
 
+        if (data.vars) {
+          info += '<li>Variables: ';
+          info += '<a href="#" data-bs-toggle="modal" data-bs-target="#varsModal">';
+          info += Object.keys(data.vars).length;
+          info += '</li>';
+          $('#testsuite-vars').html("<pre>"+YAML.stringify(data.vars)+"</pre>")
+        }
+
         info += '</ul>';
         $('#testsuite_infos').html(info);
-        $('#testsuite').html("testsuite " + data.name);
+
+        var infob = "";
+        if (data.nbTestcasesFail > 0) {
+          var badge = '<span class="badge text-bg-danger">'+data.nbTestcasesFail+' FAILED</span>';
+          infob += badge;
+        }
+        if (data.nbTestcasesPass > 0) {
+          var badge = '<span class="badge text-bg-success">'+data.nbTestcasesPass+' PASSED</span>';
+          infob += badge;
+        }
+        if (data.nbTestcasesSkip > 0) {
+          var badge = '<span class="badge text-bg-secondary">'+data.nbTestcasesSkip+' SKIPPED</span>';
+          infob += badge;
+        }
+
+        $('#testsuite').html(data.name);
+        $('#testsuite-badges').html(infob);
         middletestsuite(i, data);
       });
     });
@@ -291,70 +337,112 @@
         if (testcase.results) {
           for (var j = 0; j < testcase.results.length; j++) {
             var result = testcase.results[j];
-            var badgeR = '<span class="badge rounded-pill float-right text-bg-'+colorStatus(result.status)+'" title="'+colorStatus(result.status)+'">'+result.status+'</span>';
+            var badgeR = '<span class="badge rounded-pill text-bg-'+colorStatus(result.status)+'" title="'+colorStatus(result.status)+'">'+result.status+'</span>';
 
-            r += '<li class="list-group-item"><p>';
-            r += '<p>step '+(result.number+1)+': '+result.name ;
+            r += '<ul class="nav nav-tabs">';
+            r += '<li class="nav-item">';
+            r += '<a class="nav-link disabled">step '+(result.number+1)+': '+result.name + ' <code>'+parseFloat(result.duration).toFixed(2)+'s</code> ';
             r +=  badgeR;
-            r += '</p>';
+            r +=  '</a>';
+            r += '</li>';
 
+            if (result.errors && result.errors !== '') {
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#errors-'+i+''+j+'")>Errors</a>';
+              r += '</li>';
+            }
             if (result.raw && result.raw !== '') {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#raw-'+i+''+j+'">Raw</button>';
-              r += '<div id="raw-'+i+''+j+'" class="collapse">';
-              r += '  <pre>'+decodeURIComponent(escape(atob(result.raw)))+'</pre>';
-              r += '</div>';
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#raw-'+i+''+j+'")>Raw</a>';
+              r += '</li>';
             }
             if (result.interpolated && result.interpolated !== '') {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#interpolated-'+i+''+j+'">Raw Interpolated</button>';
-              r += '<div id="interpolated-'+i+''+j+'" class="collapse">';
-              r += '  <pre>'+decodeURIComponent(escape(atob(result.interpolated)))+'</pre>';
-              r += '</div>';
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#interpolated-'+i+''+j+'")>Raw Interpolated</a>';
+              r += '</li>';
             }
             if (result.computedInfos && result.computedInfos !== '') {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#computedInfos-'+i+''+j+'">Computed Infos</button>';
-              r += '<div id="computedInfos-'+i+''+j+'" class="collapse show"><ul>';
-              for (var k = 0; k < result.computedInfos.length; k++) {
-                r += '<li><span class="badge rounded-pill text-bg-info" title="info">Info</span>';
-                r += ' <code class="nt">'+result.computedInfos[k]+'</code></li>';
-              }
-              r += '</ul></div>';
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#computedInfos-'+i+''+j+'")>Computed Infos</a>';
+              r += '</li>';
             }
-            if (result.errors && result.errors !== '') {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#errors-'+i+''+j+'">Errors</button>';
-              r += '<div id="errors-'+i+''+j+'" class="collapse show"><ul>';
+            if (result.systemout && result.systemout !== '') {
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#systemout-'+i+''+j+'")>System Out</a>';
+              r += '</li>';
+            }
+            if (result.systemerr && result.systemerr !== '') {
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#systemerr-'+i+''+j+'")>System Err</a>';
+              r += '</li>';
+            }
+            if (result.inputVars && result.inputVars !== '') {
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#inputVars-'+i+''+j+'")>Input Vars</a>';
+              r += '</li>';
+            }
+            if (result.computedVars && result.computedVars !== '') {
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#computedVars-'+i+''+j+'")>Computed Vars</a>';
+              r += '</li>';
+            }
+            if (result.assertionsApplied && result.assertionsApplied.assertions && result.assertionsApplied.assertions.length > 0) {
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#assertionsApplied-'+i+''+j+'")>Assertions applied Infos</a>';
+              r += '</li>';
+            }
+
+            r += '</ul>';
+
+            if (result.errors) {
+              r += '<div id="errors-'+i+''+j+'" class="collapse multi-collapse p-3"><ul>';
               for (var k = 0; k < result.errors.length; k++) {
                 r += '<li><span class="badge rounded-pill text-bg-danger" title="info">FAIL</span>';
                 r += ' <code class="nt">'+result.errors[k].value+'</code></li>';
               }
               r += '</ul></div>';
             }
+
+            if (result.raw && result.raw !== '') {
+              r += '<div id="raw-'+i+''+j+'" class="collapse multi-collapse p-3">';
+              r += '  <pre>'+decodeURIComponent(escape(atob(result.raw)))+'</pre>';
+              r += '</div>';
+            }
+            if (result.interpolated && result.interpolated !== '') {
+              r += '<div id="interpolated-'+i+''+j+'" class="collapse multi-collapse p-3">';
+              r += '  <pre>'+decodeURIComponent(escape(atob(result.interpolated)))+'</pre>';
+              r += '</div>';
+            }
+            if (result.computedInfos && result.computedInfos !== '') {
+              r += '<div id="computedInfos-'+i+''+j+'" class="collapse multi-collapse p-3"><ul>';
+              for (var k = 0; k < result.computedInfos.length; k++) {
+                r += '<li><span class="badge rounded-pill text-bg-info" title="info">Info</span>';
+                r += ' <code class="nt">'+result.computedInfos[k]+'</code></li>';
+              }
+              r += '</ul></div>';
+            }
             if (result.systemout && result.systemout !== '') {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#systemout-'+i+''+j+'">System Out</button>';
-              r += '<div id="systemout-'+i+''+j+'" class="collapse">';
+              r += '<div id="systemout-'+i+''+j+'" class="collapse multi-collapse p-3">';
               r += '  <pre>'+YAML.stringify(result.systemout)+'</pre>';
               r += '</div>';
             }
             if (result.systemerr && result.systemerr !== '') {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#systemerr-'+i+''+j+'">System Err</button>';
-              r += '<div id="systemerr-'+i+''+j+'" class="collapse">';
+              r += '<div id="systemerr-'+i+''+j+'" class="collapse multi-collapse p-3">';
               r += '  <pre>'+YAML.stringify(result.systemerr)+'</pre>';
               r += '</div>';
             }
             if (result.inputVars && result.inputVars !== '') {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#inputVars-'+i+''+j+'">Input Vars</button>';
-              r += '<div id="inputVars-'+i+''+j+'" class="collapse">';
+              r += '<div id="inputVars-'+i+''+j+'" class="collapse multi-collapse p-3">';
               r += '  <pre>'+YAML.stringify(result.inputVars)+'</pre>';
               r += '</div>';
             }
             if (result.computedVars && result.computedVars !== '') {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#computedVars-'+i+''+j+'">Computed Vars</button>';
-              r += '<div id="computedVars-'+i+''+j+'" class="collapse">';
+              r += '<div id="computedVars-'+i+''+j+'" class="collapse multi-collapse p-3">';
               r += '  <pre>'+YAML.stringify(result.computedVars)+'</pre>';
               r += '</div>';
             }
             if (result.assertionsApplied && result.assertionsApplied.assertions && result.assertionsApplied.assertions.length > 0) {
-              r += '<button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#assertionsApplied-'+i+''+j+'">Assertions applied Infos</button>';
-              r += '<div id="assertionsApplied-'+i+''+j+'" class="collapse"><ul>';
+              r += '<div id="assertionsApplied-'+i+''+j+'" class="collapse multi-collapse p-3"><ul>';
               for (var k = 0; k < result.assertionsApplied.assertions.length; k++) {
                 var assertionStatus = "PASS";
                 if (result.assertionsApplied.assertions[k].isOK !== true) {
@@ -366,11 +454,6 @@
               }
               r += '</ul></div>';
             }
-
-            r += '</p><small class="text-muted">'+parseFloat(result.duration).toFixed(2)+'s';
-            r += ' - start:'+ToLocaleString(result.start);
-            r += ' - end:'+ToLocaleString(result.end);
-            r += '</small>';
 
             r += '</li>';
           }
@@ -390,6 +473,11 @@
       var cards = '<div class="">'+testcases+'</div>';
       $('#testcases').html(cards);
     }
+  }
+
+  function toggle(id) {
+    $(".multi-collapse").hide();
+    $(id).show();
   }
 
   function dis(id, value, sing, plu) {

--- a/venom_output.html
+++ b/venom_output.html
@@ -172,8 +172,6 @@
         nb++;
       }
 
-      
-
       var infob = '';
       if (a.nbTestsuitesFail > 0) {
         var badge = '<span class="badge text-bg-danger">'+a.nbTestsuitesFail+' FAILED</span>';

--- a/venom_output_html.go
+++ b/venom_output_html.go
@@ -1,0 +1,37 @@
+package venom
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"text/template"
+
+	"github.com/pkg/errors"
+)
+
+//go:embed venom_output.html
+var templateHTML string
+
+type TestsHTML struct {
+	Tests     Tests  `json:"tests"`
+	JSONValue string `json:"jsonValue"`
+}
+
+func outputHTML(testsResult *Tests) ([]byte, error) {
+	var buf bytes.Buffer
+
+	testJSON, err := json.MarshalIndent(testsResult, "", " ")
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to make json value")
+	}
+
+	testsHTML := TestsHTML{
+		Tests:     *testsResult,
+		JSONValue: string(testJSON),
+	}
+	tmpl := template.Must(template.New("reportHTML").Parse(templateHTML))
+	if err := tmpl.Execute(&buf, testsHTML); err != nil {
+		return nil, errors.Wrap(err, "unable to make template")
+	}
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
example of usage:
venom run --format=html --output-dir=. *.yml
venom run --format=html,json --output-dir=. *.yml

refact internal struct, json output is more detailed

close #20

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>