### PR TITLE
Change the default verbosity to 0

### DIFF
--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -32,7 +32,7 @@ var (
 	outputDir     string
 	libDir        string
 	stopOnFailure bool
-	verbose       int = 1 // Set the default value for verboseFlag
+	verbose       int = 0 // Set the default value for verboseFlag
 
 	variablesFlag     *[]string
 	formatFlag        *string


### PR DESCRIPTION
venom's default verbosity level should be 0 unless set by the user. This follows the general unix philosophy of tools being quiet unless there is an error