### PR TITLE
fix(executor/exec): manage \n in xml output

### DIFF
--- a/process_teststep.go
+++ b/process_teststep.go
@@ -131,8 +131,8 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 		tsResult.appendFailure(assertRes.errors...)
 	}
 
-	tsResult.Systemerr += assertRes.systemerr
-	tsResult.Systemout += assertRes.systemout
+	tsResult.Systemerr += assertRes.systemerr + "\n"
+	tsResult.Systemout += assertRes.systemout + "\n"
 
 	return result
 }

--- a/venom_output.go
+++ b/venom_output.go
@@ -172,8 +172,8 @@ func outputXMLFormat(tests Tests) ([]byte, error) {
 						Value: failure.Value,
 					})
 				}
-				systemout.Value += result.Systemout
-				systemerr.Value += result.Systemerr
+				systemout.Value += result.Systemout + "\n"
+				systemerr.Value += result.Systemerr + "\n"
 			}
 
 			tcXML := TestCaseXML{

--- a/venom_output.go
+++ b/venom_output.go
@@ -172,8 +172,8 @@ func outputXMLFormat(tests Tests) ([]byte, error) {
 						Value: failure.Value,
 					})
 				}
-				systemout.Value += result.Systemout + "\n"
-				systemerr.Value += result.Systemerr + "\n"
+				systemout.Value += result.Systemout
+				systemerr.Value += result.Systemerr
 			}
 
 			tcXML := TestCaseXML{


### PR DESCRIPTION
Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>