### PR TITLE
feat: `skip` support at step level

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Venom is a CLI (Command Line Interface) that aim to create, manage and run your 
 * [Export tests report](#export-tests-report)
 * [Advanced usage](#advanced-usage)
   * [Debug your testsuites](#debug-your-testsuites)
-  * [Skip testcase](#skip-testcase)
+  * [Skip testcase and teststeps](#skip-testcase--and-teststeps)
   * [Iterating over data](#iterating-over-data)
 * [FAQ](#faq)
   * [Common errors with quotes](#common-errors-with-quotes)
@@ -774,7 +774,7 @@ $ venom run test.yml
     [info] the value of result.systemoutjson is map[foo:bar] (exec.yml:34)
 ```
 
-## Skip testcase
+## Skip testcase and teststeps
 
 It is possible to skip `testcase` according to some `assertions`. For instance, the following example will skip the last testcase.
 
@@ -807,6 +807,34 @@ testcases:
     script: command_not_found
     assertions:
     - result.code ShouldEqual 0
+
+```
+
+A `skip` statement may also be placed at steps level to partially execute a testcase.
+If all steps from a testcase are skipped, the testcase itself will also be treated as "skipped" rather than "passed"/"failed".
+
+```yaml
+name: "Skip testsuite"
+vars:
+  foo: bar
+
+testcases:
+- name: skip-one-of-these
+  steps:
+  - name: do-not-skip-this
+    type: exec
+    script: exit 0
+    assertions:
+    - result.code ShouldEqual 0
+    skip:
+    - foo ShouldNotBeEmpty
+  - name: skip-this
+    type: exec
+    script: exit 1
+    assertions:
+    - result.code ShouldEqual 0
+    skip:
+    - foo ShouldBeEmpty
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Venom is a CLI (Command Line Interface) that aim to create, manage and run your 
 * [Export tests report](#export-tests-report)
 * [Advanced usage](#advanced-usage)
   * [Debug your testsuites](#debug-your-testsuites)
-  * [Skip testcase and teststeps](#skip-testcase--and-teststeps)
+  * [Skip testcase and teststeps](#skip-testcase-and-teststeps)
   * [Iterating over data](#iterating-over-data)
 * [FAQ](#faq)
   * [Common errors with quotes](#common-errors-with-quotes)

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -111,6 +111,9 @@ func (v *Venom) runTestCases(ctx context.Context, ts *TestSuite) {
 			start := time.Now()
 			tc.Start = start
 			ts.Status = StatusRun
+			if verboseReport || hasRanged {
+				v.Print("\n")
+			}
 			// ##### RUN Test Case Here
 			v.runTestCase(ctx, ts, tc)
 			tc.End = time.Now()
@@ -128,10 +131,6 @@ func (v *Venom) runTestCases(ctx context.Context, ts *TestSuite) {
 			if testStepResult.Status == StatusSkip {
 				skippedSteps++
 			}
-		}
-
-		if verboseReport || hasRanged {
-			v.Print("\n")
 		}
 
 		if hasFailure {

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -26,3 +26,30 @@ testcases:
     script: command_not_found
     assertions:
     - result.code ShouldEqual 0
+
+- name: skip-one-of-these
+  steps:
+  - name: do-not-skip-this
+    type: exec
+    script: exit 0
+    assertions:
+    - result.code ShouldEqual 0
+    skip:
+    - foo ShouldNotBeEmpty
+  - name: skip-this
+    type: exec
+    script: exit 1
+    assertions:
+    - result.code ShouldEqual 0
+    skip:
+    - foo ShouldBeEmpty
+
+- name: skip-all-of-steps
+  steps:
+  - name: skip-this
+    type: exec
+    script: exit 1
+    assertions:
+    - result.code ShouldEqual 0
+    skip:
+    - foo ShouldBeEmpty

--- a/types.go
+++ b/types.go
@@ -175,6 +175,7 @@ type TestCase struct {
 type TestStepResult struct {
 	Name              string            `json:"name"`
 	Errors            []Failure         `json:"errors"`
+	Skipped           []Skipped         `json:"skipped" yaml:"skipped"`
 	Status            string            `json:"status" yaml:"status"`
 	Raw               interface{}       `json:"raw" yaml:"raw"`
 	Interpolated      interface{}       `json:"interpolated" yaml:"interpolated"`


### PR DESCRIPTION
Closes #486 

Make it possible to `skip` at step level (currently it's only possible to do so at case level)
If all steps from a case are skipped, then the case will also change its state to "SKIP" rather than "PASS"

*Default output:*
![image](https://user-images.githubusercontent.com/22963968/196242740-c6ea1208-07a7-4be8-8ab7-dcbb871a554f.png)

*Verbose output:*
![image](https://user-images.githubusercontent.com/22963968/196242642-3315b5df-93aa-4135-ae4e-ebafc62bb7fb.png)

Additionally this slightly changes the output of skipped test case when verbose mode is enabled to display that "all steps were skipped" rather than nothing, which could be misleading as a user may think that something is wrong with their test case definition

<details>
<summary>Current output</summary>

![image](https://user-images.githubusercontent.com/22963968/196245049-8a8088e7-79a6-4e39-aa35-d70ee67cce84.png)

</details>
