### PR TITLE
fix: interpolate helper

### DIFF
--- a/.build/go.mk
+++ b/.build/go.mk
@@ -95,7 +95,7 @@ $(GO_GOJUNIT):
 
 GO_COBERTURA = ${GOPATH}/bin/gocover-cobertura
 $(GO_COBERTURA):
-	go install github.com/t-yuki/gocover-cobertura@latest
+	go install github.com/richardlt/gocover-cobertura@latest
 
 GO_XUTOOLS = ${GOPATH}/bin/xutools
 $(GO_XUTOOLS):

--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -65,7 +65,7 @@ func initArgs(cmd *cobra.Command) {
 
 	if err := initFromConfigFile(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
-		venom.OSExit(2)
+		venom.OSExit(3)
 	}
 	cmd.LocalFlags().VisitAll(initFromCommandArguments)
 }
@@ -341,7 +341,7 @@ var Cmd = &cobra.Command{
 
 		if err := v.InitLogger(); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			venom.OSExit(2)
+			venom.OSExit(4)
 		}
 
 		if v.Verbose == 3 {
@@ -380,23 +380,23 @@ var Cmd = &cobra.Command{
 		mapvars, err := readInitialVariables(context.Background(), variables, readers, os.Environ())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			venom.OSExit(2)
+			venom.OSExit(5)
 		}
 		v.AddVariables(mapvars)
 
 		if err := v.Parse(context.Background(), path); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			venom.OSExit(2)
+			venom.OSExit(6)
 		}
 
 		if err := v.Process(context.Background(), path); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			venom.OSExit(2)
+			venom.OSExit(7)
 		}
 
 		if err := v.OutputResult(); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			venom.OSExit(2)
+			venom.OSExit(8)
 		}
 
 		if v.Tests.Status == venom.StatusPass {
@@ -404,7 +404,7 @@ var Cmd = &cobra.Command{
 			venom.OSExit(0)
 		}
 		fmt.Fprintf(os.Stdout, "final status: %v\n", venom.Red(v.Tests.Status))
-		venom.OSExit(2)
+		venom.OSExit(9)
 
 		return nil
 	},

--- a/process_files.go
+++ b/process_files.go
@@ -61,11 +61,6 @@ func uniq(stringSlice []string) []string {
 	return list
 }
 
-type partialTestSuite struct {
-	Name string `json:"name" yaml:"name"`
-	Vars H      `yaml:"vars" json:"vars"`
-}
-
 func (v *Venom) readFiles(ctx context.Context, filesPath []string) (err error) {
 	for _, filePath := range filesPath {
 		log.Info("Reading ", filePath)
@@ -114,7 +109,7 @@ func (v *Venom) readFiles(ctx context.Context, filesPath []string) (err error) {
 
 		content, err := interpolate.Do(string(btes), vars)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "unable to interpolate file %s content: %s", filePath, string(btes))
 		}
 
 		var testSuiteInput TestSuiteInput

--- a/tests/interpolate_quote.yml
+++ b/tests/interpolate_quote.yml
@@ -1,0 +1,19 @@
+name: MyTestSuiteInterpolate
+testcases:
+- name: testA
+  steps:
+  - type: exec
+    script: echo 'foo with a bar here'
+    vars:
+      myvariable:
+        from: result.systemout
+        regex: foo with a ([a-z]+) here
+        default: "somevalue"
+
+- name: test
+  steps:
+  - type: exec
+    script: echo "foo{{.testA.myvariable | replace "b" "c" }}"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring car

--- a/types_executor.go
+++ b/types_executor.go
@@ -273,7 +273,7 @@ func (v *Venom) RunUserExecutor(ctx context.Context, runner ExecutorRunner, tcIn
 
 	outputS, err := interpolate.Do(string(outputString), computedVars)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "unable to interpolate user executor")
 	}
 
 	// re-inject info into executorRunner

--- a/venom.go
+++ b/venom.go
@@ -252,7 +252,7 @@ func (v *Venom) registerUserExecutors(ctx context.Context, name string, vars map
 
 		content, err := interpolate.Do(string(btes), varsComputed)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "unable to interpolate in register user executors")
 		}
 
 		ux := UserExecutor{Filename: f}


### PR DESCRIPTION
Using quote in helper as

```
echo "foo{{.testA.myvariable | replace "b" "c" }}"
```
is now ok.

The trick is to use yml format in interpolate.Do, instead of json format.

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>