### PR TITLE
Add support for sqlite3 to dbfixtures executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,9 +930,42 @@ To display properly the venom output, you probably will have to export the envir
 
 [How to write your own executor?](https://github.com/ovh/venom/tree/master/executors#venom-executor)
 
-How to compile?
+## How to compile?
 ```bash
 $ make build
+```
+
+## How to test?
+
+### Unit tests:
+
+```bash
+make test
+```
+
+### Integration tests:
+
+Prepare the stack:
+
+```bash
+make build OS=linux ARCH=amd64
+cp dist/venom.linux-amd64 tests/venom
+cd tests
+make start-test-stack  # (wait a few seconds)
+make build-test-binary-docker
+```
+
+Run integration tests:
+
+```bash
+make run-test
+```
+
+Cleanup:
+
+```bash
+make clean
+make stop-test-stack
 ```
 
 # Contributing

--- a/executors/dbfixtures/README.md
+++ b/executors/dbfixtures/README.md
@@ -9,7 +9,7 @@ Please read its documentation for further details about the parameters of this e
 In your yaml file, you declare tour step like this
 
 ```yaml
-  - database mandatory [mysql/postgres/sqlit3]
+  - database mandatory [mysql/postgres/sqlite3]
   - dsn mandatory
   - schemas optional
   - migrations optional

--- a/executors/dbfixtures/README.md
+++ b/executors/dbfixtures/README.md
@@ -9,7 +9,7 @@ Please read its documentation for further details about the parameters of this e
 In your yaml file, you declare tour step like this
 
 ```yaml
-  - database mandatory [mysql/postgres]
+  - database mandatory [mysql/postgres/sqlit3]
   - dsn mandatory
   - schemas optional
   - migrations optional

--- a/executors/dbfixtures/dbfixtures.go
+++ b/executors/dbfixtures/dbfixtures.go
@@ -15,6 +15,7 @@ import (
 	// SQL drivers.
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/ovh/venom"
 )
@@ -182,6 +183,8 @@ func getDialect(name string, skipResetSequences bool) func(*fixtures.Loader) err
 		}
 	case "mysql":
 		return fixtures.Dialect("mysql")
+	case "sqlite3":
+		return fixtures.Dialect("sqlite3")
 	}
 	return nil
 }

--- a/tests/db_fixtures.yml
+++ b/tests/db_fixtures.yml
@@ -35,3 +35,20 @@ testcases:
      dsn: "user=venom password=venom dbname=venom host={{.pgHost}} port={{.pgPort}} sslmode=disable"
      migrations_path: dbfixtures/testdata/migrations
      folder: dbfixtures/testdata/fixtures
+
+- name: load-fixtures-into-sqlite3-database
+  steps:
+   - type: dbfixtures
+     database: sqlite3
+     dsn: ":memory:"
+     schemas:
+       - dbfixtures/testdata/schemas/sqlite3.sql
+     folder: dbfixtures/testdata/fixtures
+
+- name: initialize-sqlite3-database-with-migrations
+  steps:
+   - type: dbfixtures
+     database: sqlite3
+     dsn: "memory"
+     migrations: dbfixtures/testdata/migrations
+     folder: dbfixtures/testdata/fixtures

--- a/tests/dbfixtures/testdata/schemas/sqlite3.sql
+++ b/tests/dbfixtures/testdata/schemas/sqlite3.sql
@@ -1,0 +1,45 @@
+DROP TABLE IF EXISTS comments;
+DROP TABLE IF EXISTS posts_tags;
+DROP TABLE IF EXISTS posts;
+DROP TABLE IF EXISTS tags;
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE posts (
+	id SERIAL PRIMARY KEY
+	,title VARCHAR NOT NULL
+	,content TEXT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE tags (
+	id SERIAL PRIMARY KEY
+	,name VARCHAR NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE posts_tags (
+	post_id INTEGER NOT NULL
+	,tag_id INTEGER NOT NULL
+	,PRIMARY KEY (post_id, tag_id)
+	,FOREIGN KEY (post_id) REFERENCES posts (id)
+	,FOREIGN KEY (tag_id) REFERENCES tags (id)
+);
+
+CREATE TABLE comments (
+	id SERIAL PRIMARY KEY NOT NULL
+	,post_id INTEGER NOT NULL
+	,author_name VARCHAR NOT NULL
+	,author_email VARCHAR NOT NULL
+	,content TEXT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (post_id) REFERENCES posts (id)
+);
+
+CREATE TABLE users (
+	id SERIAL PRIMARY KEY NOT NULL
+	,attributes VARCHAR NOT NULL
+);
+


### PR DESCRIPTION
It seems the underlying libraries used by `dbfixtures` support sqlite3, so I'm adding support for it as well.

I **think** the tests are passing locally, that's why I'm opening this PR, but TBH I'm not completely sure: `make integration-test` exits successfully with `0`, but I don't see any venom output in my stdout.

Do let me know if anything else needs changing.