### PR TITLE
fix: avoid `nil` pointer dereference in `ShouldContain` assertions

### DIFF
--- a/assertions/assertions.go
+++ b/assertions/assertions.go
@@ -549,7 +549,7 @@ func ShouldContain(actual interface{}, expected ...interface{}) error {
 	if err := need(1, expected); err != nil {
 		return err
 	}
-	if reflect.TypeOf(actual).Kind() != reflect.Slice {
+	if actual == nil || reflect.TypeOf(actual).Kind() != reflect.Slice {
 		return ShouldEqual(actual, expected[0])
 	}
 	actualSlice, err := cast.ToSliceE(actual)

--- a/assertions/assertions_test.go
+++ b/assertions/assertions_test.go
@@ -666,6 +666,13 @@ func TestShouldContain(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "raise error with nothing",
+			args: args{
+				expected: []interface{}{"something"},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
It is possible to trigger `nil` pointer dereference by calling `ShouldContain` assertions.

Possible minimal reproducer in `venom`:

```yaml
testcases:
  - steps:
      - assertions:
          - result.systemoutjson ShouldContain value
```

This PR fixes that by avoiding unconditional calls to `Kind()` when `ShouldContain()` contains a `nil` pointer like in previous example and adds a test to double-check that.