### PR TITLE
fix(exec): panic on cmd.Start error

### DIFF
--- a/executors/exec/exec.go
+++ b/executors/exec/exec.go
@@ -181,7 +181,7 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 		result.Err = err.Error()
 		result.Code = "127"
 		venom.Debug(ctx, err.Error())
-		return dump.ToMap(e, nil, dump.WithDefaultLowerCaseFormatter())
+		return dump.ToMap(e, dump.WithDefaultLowerCaseFormatter())
 	}
 
 	<-outchan


### PR DESCRIPTION
When trying to do **crimes** to get around  #604 I found a way to crash the exec executor.

This fixes said crash. 

Sadly I don't have the code that caused the error anymore so I can't provide it here.