### PR TITLE
fix/xml output

### DIFF
--- a/venom_output.go
+++ b/venom_output.go
@@ -152,6 +152,7 @@ func outputXMLFormat(tests Tests) ([]byte, error) {
 		tsXML := TestSuiteXML{
 			Name:    ts.Name,
 			Package: ts.Filepath,
+			Time:    fmt.Sprintf("%f", ts.Duration),
 		}
 
 		for _, tc := range ts.TestCases {


### PR DESCRIPTION
fix: TestSuiteXML is missing the Time property

Value is converted from float64 to string. This will resolve gh actions test reporters for junit xml, showing missing test suite time execution values