### PR TITLE
fix: TestSuiteXML is missing the Time property

### DIFF
--- a/venom_output.go
+++ b/venom_output.go
@@ -152,6 +152,7 @@ func outputXMLFormat(tests Tests) ([]byte, error) {
 		tsXML := TestSuiteXML{
 			Name:    ts.Name,
 			Package: ts.Filepath,
+			Time:    fmt.Sprintf("%f", ts.Duration),
 		}
 
 		for _, tc := range ts.TestCases {


### PR DESCRIPTION
Value is converted from float64 to string. This will resolve gh actions test reporters for junit xml, showing missing test suite time execution values

<img width="520" alt="Screenshot 2023-02-09 at 7 54 22 PM" src="https://user-images.githubusercontent.com/100229229/217996843-1756cc6d-f23e-4791-9b1a-835fce7943df.png">
