### PR TITLE
fix: bodyfile path not found error was suppressed

### DIFF
--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -266,7 +266,10 @@ func (e Executor) getRequest(ctx context.Context, workdir string) (*http.Request
 		body = bytes.NewBuffer([]byte(e.Body))
 	} else if e.BodyFile != "" {
 		bodyfilePath := filepath.Join(workdir, e.BodyFile)
-		if _, err := os.Stat(bodyfilePath); !os.IsNotExist(err) {
+		if _, err := os.Stat(bodyfilePath); os.IsNotExist(err) {
+			if err != nil {
+				return nil, err
+			}
 			temp, err := os.ReadFile(bodyfilePath)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
now http executor will return early and avoid confusion when working with custom http executors and various bodyfiles

Signed-off-by: Ivan Velasco <ivan.velasco@socotra.com>

This is for issue #630

unit tests fully passed locally