### PR TITLE
fix: assigned variables are not available in user http defined executors

### DIFF
--- a/process_testcase.go
+++ b/process_testcase.go
@@ -359,6 +359,7 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 				break
 			}
 
+			tc.Vars.AddAll(assign)
 			tc.computedVars.AddAll(assign)
 			previousStepVars.AddAll(assign)
 		}


### PR DESCRIPTION
step 1 vars were assigned successfully, but not available in step 2 of http executor

To reproduce
```yaml
executor: foo-bar1
input:
  token: {}

steps:
- type: http
  method: POST
  headers:
    Accept: application/json
    Content-Type: application/json
    Authorization: "{{.input.token}}"
  url: "{{.url}}/call1"
  bodyfile: "/testdata/test1.json"
  assertions:
    - result.statuscode ShouldEqual 200
  vars:
    property:
      from: result.bodyjson.property

- type: http
  method: POST
  headers:
    Accept: application/json
    Content-Type: application/json
    Authorization: "{{.input.token}}"
  url: "{{.url}}/call2"
  bodyfile: /testdata/test2.json <====bodyfile will use the value set "property": "{{.property}}",
output:

```

```json
Feb 13 19:28:49.526 [DEBU] [TestSuite covering api] [test-case] [test1] Processing property assignment
Feb 13 19:28:49.526 [INFO] [TestSuite covering api] [test-case] [test1] Assign 'property' value '5f7bfe97-6f2b-48ca-a116-9981ef5a1b24'
Feb 13 19:28:49.528 [INFO] [TestSuite covering api] [test-case] [test1] Step #1 content is: {"assertions":["result.statuscode ShouldEqual 200"],"bodyfile":"/testdata/test1.json","headers":{"Accept":"application/json","Authorization":"eyJ....","Content-Type":"application/json"},"info":"request assigned property value 5f7bfe97-6f2b-48ca-a116-9981ef5a1b24","method":"POST","type":"http","url":"https://test.com","workdir":"lib"}
Feb 13 19:28:50.284 [DEBU] [TestSuite covering api] [test-case] [http] result of runTestStepExecutor: {TimeSeconds:0.751256249 StatusCode:404 Request:{Method:POST URL:https://test.com Header:map[Accept:[application/json] Authorization:[eyJ....] Content-Type:[application/json]] Body:{
    "test": "test",
    "property": "{{.property}}",
    "test2": "test2",
} 
```

Signed-off-by: Ivan Velasco <ivan.velasco@socotra.com>