### PR TITLE
feat(mongo): add "loadFixtures" action

### DIFF
--- a/executors/mongo/README.md
+++ b/executors/mongo/README.md
@@ -19,6 +19,33 @@ Example:
 }
 ```
 
+### Load fixtures
+
+```yaml
+- type: mongo
+  uri: mongodb://localhost:27017
+  database: my-database
+  actions:
+    - type: loadFixtures
+      folder: fixtures/
+```
+
+This action will first **drop all the collections in the database**, and then load multiple collections at once from a folder.
+The fixtures folder must contain one file per collection, and be named after the collection. For example, `cards.yml` will create a `cards` collection.
+The items in the collections are declared as a YAML array. For example:
+
+```yaml
+# fixtures/cards.yml
+- suit: clubs
+  value: jack
+
+- suit: clubs
+  value: queen
+
+- suit: clubs
+  value: king
+```
+
 ### Insert documents
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	golang.org/x/net v0.8.0
 	google.golang.org/grpc v1.53.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.21.0
 )
 
@@ -101,7 +102,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
 	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect
 	modernc.org/cc/v3 v3.40.0 // indirect
 	modernc.org/ccgo/v3 v3.16.13 // indirect

--- a/tests/mongo.yml
+++ b/tests/mongo.yml
@@ -5,6 +5,50 @@ vars:
   mongo_collection: cards
 
 testcases:
+  - name: Load fixtures
+    steps:
+      - type: mongo
+        uri: "{{.mongo_uri}}"
+        database: "{{.mongo_database}}"
+        actions:
+          - type: loadFixtures
+            folder: mongo/fixturesA
+
+      - type: mongo
+        uri: "{{.mongo_uri}}"
+        database: "{{.mongo_database}}"
+        collection: cards
+        actions:
+          - type: count
+        assertions:
+          - result.actions.actions0.count ShouldEqual 3
+
+      - type: mongo
+        uri: "{{.mongo_uri}}"
+        database: "{{.mongo_database}}"
+        actions:
+          - type: loadFixtures
+            folder: mongo/fixturesB
+
+      # Ensure fixturesA have been dropped
+      - type: mongo
+        uri: "{{.mongo_uri}}"
+        database: "{{.mongo_database}}"
+        collection: cards
+        actions:
+          - type: count
+        assertions:
+          - result.actions.actions0.count ShouldEqual 0
+        
+      - type: mongo
+        uri: "{{.mongo_uri}}"
+        database: "{{.mongo_database}}"
+        collection: pokemons
+        actions:
+          - type: count
+        assertions:
+          - result.actions.actions0.count ShouldEqual 3
+
   - name: Reset collection
     steps:
       - type: mongo

--- a/tests/mongo/fixturesA/cards.yml
+++ b/tests/mongo/fixturesA/cards.yml
@@ -1,0 +1,8 @@
+- suit: clubs
+  value: jack
+
+- suit: clubs
+  value: queen
+
+- suit: clubs
+  value: king

--- a/tests/mongo/fixturesB/pokemons.yml
+++ b/tests/mongo/fixturesB/pokemons.yml
@@ -1,0 +1,12 @@
+- name: Bulbasaur
+  types:
+    - grass
+    - poison
+
+- name: Charmander
+  types:
+    - fire
+
+- name: Squirtle
+  types:
+    - water


### PR DESCRIPTION
It works roughly the same as the dbfixtures executor. I wanted to implement it directly in dbfixtures but it's too tied to database/sql so it doesn't work well with Mongo

Note that I used yaml.v3 instead of v2, because v2 unmarshals yaml objects as `map[any]any` instead of `map[string]any`, it's too hard to deal with when inserting in Mongo