### PR TITLE
feat: Logging level flag added

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Flags and their equivalent with environment variables usage:
 
 - `--format="json"` flag is equivalent to `VENOM_FORMAT="json"` environment variable
 - `--lib-dir="/etc/venom/lib:$HOME/venom.d/lib"` flag is equivalent to `VENOM_LIB_DIR="/etc/venom/lib"` environment variable
-- `--logging-level="info"` flag is equivalent to `VENOM_LOGGING_LEVEL` environment variable
+- `--logging-level="info"` flag is equivalent to `VENOM_LOGGING_LEVEL="info"` environment variable
 - `--output-dir="test-results"` flag is equivalent to `VENOM_OUTPUT_DIR="test-results"` environment variable
 - `--stop-on-failure` flag is equivalent to `VENOM_STOP_ON_FAILURE=true` environment variable
 - `--var foo=bar` flag is equivalent to `VENOM_VAR_foo='bar'` environment variable
@@ -283,6 +283,7 @@ format: xml
 output_dir: output
 lib_dir: lib
 verbosity: 3
+logging_level: info
 ```
 
 Please note that the command line flags overrides the configuration file. The configuration file overrides the environment variables.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Flags:
   -h, --help                    help for run
       --html-report             Generate HTML Report
       --lib-dir string          Lib Directory: can contain user executors. example:/etc/venom/lib:$HOME/venom.d/lib
+      --logging-level string    Change the logging level (default "debug")
       --output-dir string       Output Directory: create tests results file inside this directory
       --stop-on-failure         Stop running Test Suite on first Test Case failure
       --var stringArray         --var cds='cds -f config.json' --var cds2='cds -f config.json'
@@ -234,6 +235,7 @@ Flags:
   -h, --help                    help for run
       --html-report             Generate HTML Report
       --lib-dir string          Lib Directory: can contain user executors. example:/etc/venom/lib:$HOME/venom.d/lib
+      --logging-level string    Change the logging level (default "debug")      
       --output-dir string       Output Directory: create tests results file inside this directory
       --stop-on-failure         Stop running Test Suite on first Test Case failure
       --var stringArray         --var cds='cds -f config.json' --var cds2='cds -f config.json'
@@ -257,6 +259,7 @@ Flags and their equivalent with environment variables usage:
 
 - `--format="json"` flag is equivalent to `VENOM_FORMAT="json"` environment variable
 - `--lib-dir="/etc/venom/lib:$HOME/venom.d/lib"` flag is equivalent to `VENOM_LIB_DIR="/etc/venom/lib"` environment variable
+- `--logging-level="info"` flag is equivalent to `VENOM_LOGGING_LEVEL` environment variable
 - `--output-dir="test-results"` flag is equivalent to `VENOM_OUTPUT_DIR="test-results"` environment variable
 - `--stop-on-failure` flag is equivalent to `VENOM_STOP_ON_FAILURE=true` environment variable
 - `--var foo=bar` flag is equivalent to `VENOM_VAR_foo='bar'` environment variable

--- a/process.go
+++ b/process.go
@@ -17,7 +17,16 @@ import (
 // InitLogger initializes venom logger
 func (v *Venom) InitLogger() error {
 	v.Tests.TestSuites = []TestSuite{}
-	logrus.SetLevel(logrus.DebugLevel)
+
+	if v.LoggingLevel != "" {
+		level, err := logrus.ParseLevel(v.LoggingLevel)
+		if err != nil {
+			return errors.Wrapf(err, "unable to parse logging level")
+		}
+		logrus.SetLevel(level)
+	} else {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 
 	if v.OutputDir != "" {
 		if err := os.MkdirAll(v.OutputDir, os.FileMode(0755)); err != nil {

--- a/venom.go
+++ b/venom.go
@@ -72,6 +72,7 @@ type Venom struct {
 	StopOnFailure bool
 	HtmlReport    bool
 	Verbose       int
+	LoggingLevel  string
 }
 
 var trace = color.New(color.Attribute(90)).SprintFunc()


### PR DESCRIPTION
- feature: to partially solve this issue, introduced `loggingLevel` 
-  supported values are based on logrus package
```
"panic"
"fatal"
"error"
"warn"
"info"
"debug"
"trace"
```
https://github.com/ovh/venom/issues/666

Additional discussion should occur as this logging package is in maintenance mode and performance is not the best. Migrate to a different library in the future. For instance https://github.com/rs/zerolog 