### PR TITLE
feat: print info statements after each test step instead of being at the end

### DIFF
--- a/process_testcase.go
+++ b/process_testcase.go
@@ -418,10 +418,10 @@ func (v *Venom) printTestStepResult(tc *TestCase, ts *TestStepResult, tsIn *Test
 					v.Println(" %s (after %d attempts)", Green(StatusPass), ts.Retries)
 				}
 			}
-			for _, i := range tc.computedInfo {
+			for _, i := range ts.ComputedInfo {
 				v.Println("\t  %s%s %s", "\t  ", Cyan("[info]"), Cyan(i))
 			}
-			for _, i := range tc.computedVerbose {
+			for _, i := range ts.ComputedVerbose {
 				v.PrintlnIndentedTrace(i, "\t  ")
 			}
 

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -418,6 +418,13 @@ func (v *Venom) printTestStepResult(tc *TestCase, ts *TestStepResult, tsIn *Test
 					v.Println(" %s (after %d attempts)", Green(StatusPass), ts.Retries)
 				}
 			}
+			for _, i := range tc.computedInfo {
+				v.Println("\t  %s%s %s", "\t  ", Cyan("[info]"), Cyan(i))
+			}
+			for _, i := range tc.computedVerbose {
+				v.PrintlnIndentedTrace(i, "\t  ")
+			}
+
 		}
 	}
 }

--- a/process_teststep.go
+++ b/process_teststep.go
@@ -66,6 +66,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 			if err := os.WriteFile(filename, []byte(output), 0644); err != nil {
 				return fmt.Errorf("Error while creating file %s: %v", filename, err)
 			}
+			tsResult.ComputedVerbose = append(tsResult.ComputedVerbose, fmt.Sprintf("writing %s", filename))
 			tc.computedVerbose = append(tc.computedVerbose, fmt.Sprintf("writing %s", filename))
 		}
 

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -143,9 +143,9 @@ func (v *Venom) runTestCases(ctx context.Context, ts *TestSuite) {
 		}
 
 		// Verbose mode already reported tests status, so just print them when non-verbose
-		indent := ""
+
 		if hasRanged || verboseReport {
-			indent = "\t  "
+
 			// If the testcase was entirely skipped, then the verbose mode will not have any output
 			// Print something to inform that the testcase was indeed processed although skipped
 			if len(tc.TestStepResults) == 0 {
@@ -161,14 +161,6 @@ func (v *Venom) runTestCases(ctx context.Context, ts *TestSuite) {
 			} else {
 				v.Println(" %s", Green(StatusPass))
 			}
-		}
-
-		for _, i := range tc.computedInfo {
-			v.Println("\t  %s%s %s", indent, Cyan("[info]"), Cyan(i))
-		}
-
-		for _, i := range tc.computedVerbose {
-			v.PrintlnIndentedTrace(i, indent)
 		}
 
 		// Verbose mode already reported failures, so just print them when non-verbose

--- a/types.go
+++ b/types.go
@@ -187,6 +187,7 @@ type TestStepResult struct {
 	InputVars         map[string]string `json:"inputVars" yaml:"-"`
 	ComputedVars      H                 `json:"computedVars" yaml:"-"`
 	ComputedInfo      []string          `json:"computedInfos" yaml:"-"`
+	ComputedVerbose   []string          `json:"computedVerbose" yaml:"-"`
 	AssertionsApplied AssertionsApplied `json:"assertionsApplied" yaml:"-"`
 	Retries           int               `json:"retries" yaml:"retries"`
 


### PR DESCRIPTION
Have the info statements displayed as the tests are running instead of being in the end

![Screenshot 2023-05-31 at 09 43 28](https://github.com/ovh/venom/assets/1316474/40f637bc-2b5c-4b07-a768-7bfe5a5a8356)
