### PR TITLE
Update the skip as it was not working correctly

### DIFF
--- a/assertion_test.go
+++ b/assertion_test.go
@@ -1,6 +1,8 @@
 package venom
 
 import (
+	"context"
+	"github.com/ovh/venom/assertions"
 	"reflect"
 	"testing"
 )
@@ -20,5 +22,16 @@ func Test_splitAssertion(t *testing.T) {
 		if !reflect.DeepEqual(args, tt.Args) {
 			t.Errorf("expected args to be equal to %#v, got %#v", tt.Args, args)
 		}
+	}
+}
+
+func Test_parseAssertions(t *testing.T) {
+	vars := make(map[string]string)
+	vars["out"] = "2"
+	assertion, err := parseAssertions(context.Background(), "out ShouldEqual '2'", vars)
+	_ = assertions.ShouldNotBeNil(&assertion)
+	e := assertions.ShouldBeNil(err)
+	if e != nil {
+		t.Errorf("The err should be nil")
 	}
 }

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -333,7 +333,6 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 
 				tsResult.End = time.Now()
 				tsResult.Duration = tsResult.End.Sub(tsResult.Start).Seconds()
-
 				tc.testSteps = append(tc.testSteps, step)
 			}
 
@@ -440,13 +439,13 @@ func parseSkip(ctx context.Context, tc *TestCase, ts *TestStepResult, rawStep []
 
 	// Evaluate skip assertions
 	if len(assertions.Skip) > 0 {
-		results, err := testConditionalStatement(ctx, tc, assertions.Skip, tc.Vars, fmt.Sprintf("skipping testcase %%q step #%d: %%v", stepNumber))
+		failures, err := testConditionalStatement(ctx, tc, assertions.Skip, tc.computedVars, fmt.Sprintf("skipping testcase %%q step #%d: %%v", stepNumber))
 		if err != nil {
 			Error(ctx, "unable to evaluate \"skip\" assertions: %v", err)
 			return false, err
 		}
-		if len(results) > 0 {
-			for _, s := range results {
+		if len(failures) == 0 {
+			for _, s := range failures {
 				ts.Skipped = append(ts.Skipped, Skipped{Value: s})
 				Warn(ctx, s)
 			}

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -163,21 +163,23 @@ func (v *Venom) processSecrets(ctx context.Context, ts *TestSuite, tc *TestCase)
 }
 
 func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepResult) {
-	results, err := testConditionalStatement(ctx, tc, tc.Skip, tc.Vars, "skipping testcase %q: %v")
-	if err != nil {
-		Error(ctx, "unable to evaluate \"skip\" assertions: %v", err)
-		testStepResult := TestStepResult{}
-		testStepResult.appendError(err)
-		tc.TestStepResults = append(tc.TestStepResults, testStepResult)
-		return
-	}
-	if len(results) > 0 {
-		tc.Status = StatusSkip
-		for _, s := range results {
-			tc.Skipped = append(tc.Skipped, Skipped{Value: s})
-			Warn(ctx, s)
+	if len(tc.Skip) > 0 {
+		results, err := testConditionalStatement(ctx, tc, tc.Skip, tc.Vars, "skipping testcase %q: %v")
+		if err != nil {
+			Error(ctx, "unable to evaluate \"skip\" assertions: %v", err)
+			testStepResult := TestStepResult{}
+			testStepResult.appendError(err)
+			tc.TestStepResults = append(tc.TestStepResults, testStepResult)
+			return
 		}
-		return
+		if len(results) == 0 {
+			tc.Status = StatusSkip
+			for _, s := range results {
+				tc.Skipped = append(tc.Skipped, Skipped{Value: s})
+				Warn(ctx, s)
+			}
+			return
+		}
 	}
 
 	var knowExecutors = map[string]struct{}{}

--- a/process_teststep.go
+++ b/process_teststep.go
@@ -112,15 +112,17 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 		if assertRes.OK {
 			break
 		}
-		failures, err := testConditionalStatement(ctx, tc, e.RetryIf(), AllVarsFromCtx(ctx), "")
-		if err != nil {
-			tsResult.appendError(fmt.Errorf("Error while evaluating retry condition: %v", err))
-			break
-		}
-		if len(failures) > 0 {
-			failure := newFailure(ctx, *tc, stepNumber, rangedIndex, "", fmt.Errorf("retry conditions not fulfilled, skipping %d remaining retries", e.Retry()-tsResult.Retries))
-			tsResult.Errors = append(tsResult.Errors, *failure)
-			break
+		if len(e.RetryIf()) > 0{
+			failures, err := testConditionalStatement(ctx, tc, e.RetryIf(), AllVarsFromCtx(ctx), "")
+			if err != nil {
+				tsResult.appendError(fmt.Errorf("Error while evaluating retry condition: %v", err))
+				break
+			}
+			if len(failures) == 0 {
+				failure := newFailure(ctx, *tc, stepNumber, rangedIndex, "", fmt.Errorf("retry conditions not fulfilled, skipping %d remaining retries", e.Retry()-tsResult.Retries))
+				tsResult.Errors = append(tsResult.Errors, *failure)
+				break
+			}
 		}
 	}
 

--- a/process_teststep.go
+++ b/process_teststep.go
@@ -112,7 +112,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 		if assertRes.OK {
 			break
 		}
-		failures, err := testConditionalStatement(ctx, tc, e.RetryIf(), tsResult.ComputedVars, "")
+		failures, err := testConditionalStatement(ctx, tc, e.RetryIf(), AllVarsFromCtx(ctx), "")
 		if err != nil {
 			tsResult.appendError(fmt.Errorf("Error while evaluating retry condition: %v", err))
 			break

--- a/tests/skip/skip-testcase.yml
+++ b/tests/skip/skip-testcase.yml
@@ -1,0 +1,19 @@
+name : "Testing skip"
+testcases:
+  - name : "producer"
+    steps:
+      - info:
+          - Set a variable to 1
+      - script : "echo '1'"
+        vars :
+          out:
+            from : result.systemout
+  - name: "consumer"
+    skip:
+      - producer.out ShouldEqual 1
+    step:
+      - info:
+          - "Fail should be skipped"
+        script: |
+          exit 1
+

--- a/tests/skip/skip.yml
+++ b/tests/skip/skip.yml
@@ -1,0 +1,29 @@
+name : "Testing skip"
+testcases:
+  - name : "skip something"
+    steps:
+      - info:
+          - Set a variable to 1
+      - script : "echo '1'"
+        vars :
+          out:
+            from : result.systemout
+      - info:
+          - "do not skip it as the value of out is different to 2"
+        skip :
+          - out ShouldEqual '2'
+      - name: skip-this
+        skip:
+          - out ShouldEqual '1'
+      - script: "echo 'false'"
+        vars:
+          outAsBool:
+            from: result.systemout
+      - info:
+          - "Fail should be skipped"
+        skip :
+          - out ShouldEqual 1
+      - info:
+          - "Fail should be skipped as false"
+        skip:
+          - outAsBool ShouldBeFalse

--- a/tests/skip/skip.yml
+++ b/tests/skip/skip.yml
@@ -13,6 +13,8 @@ testcases:
         skip :
           - out ShouldEqual '2'
       - name: skip-this
+        script: |
+          exit 1
         skip:
           - out ShouldEqual '1'
       - script: "echo 'false'"
@@ -21,9 +23,13 @@ testcases:
             from: result.systemout
       - info:
           - "Fail should be skipped"
+        script: |
+          exit 1
         skip :
           - out ShouldEqual 1
       - info:
           - "Fail should be skipped as false"
+        script: |
+          exit 1
         skip:
           - outAsBool ShouldBeFalse


### PR DESCRIPTION
It could not evaluate a variable that was defined on previous steps and during processing.

In the venom.log we would see something like that in the comparison
```
[skip-something] evaluating out ShouldEqual '1'
[skip-something] failed to evaluate : expected: 1  got: <nil>
```
which means that it does not get the value of `out` 

now it is  only `[skip-something] evaluating out ShouldEqual '1'` which means that it  evaluates  it correctly.


furthermore the test is working correctly 

```
 • Testing skip (skip/skip.yml)
        • skip-something
                •  PASS
                  [info] Set a variable to 1
                • exec PASS
                •  PASS
                  [info] do not skip it as the value of out is different to 2
                • skip-this SKIP
                • exec PASS
                •  SKIP
                •  SKIP
```

for 

```
name : "Testing skip"
testcases:
  - name : "skip something"
    steps:
      - info:
          - Set a variable to 1
      - script : "echo '1'"
        vars :
          out:
            from : result.systemout
      - info:
          - "do not skip it as the value of out is different to 2"
        skip :
          - out ShouldEqual '2'
      - name: skip-this
        skip:
          - out ShouldEqual '1'
      - script: "echo 'false'"
        vars:
          outAsBool:
            from: result.systemout
      - info:
          - "Fail should be skipped"
        skip :
          - out ShouldEqual 1
      - info:
          - "Fail should be skipped as false"
        skip:
          - outAsBool ShouldBeFalse
```



