### PR TITLE
Cache properly the executors

### DIFF
--- a/process_testcase.go
+++ b/process_testcase.go
@@ -43,7 +43,7 @@ func (v *Venom) parseTestCase(ts *TestSuite, tc *TestCase) ([]string, []string, 
 			return nil, nil, errors.Wrapf(err, "unable to unmarshal teststep")
 		}
 
-		_, exec, err := v.GetExecutorRunner(context.Background(), step, tc.Vars)
+		_, exec, err := v.GetExecutorRunner(context.Background(), &step, &tc.Vars)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -285,7 +285,7 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 			tc.testSteps = append(tc.testSteps, step)
 			var e ExecutorRunner
 			Info(ctx, "variables before execution %v", stepVars)
-			ctx, e, err = v.GetExecutorRunner(ctx, step, stepVars)
+			ctx, e, err = v.GetExecutorRunner(ctx, &step, &stepVars)
 			if err != nil {
 				tsResult.appendError(err)
 				Error(ctx, "unable to get executor: %v", err)

--- a/read_partial.go
+++ b/read_partial.go
@@ -44,6 +44,21 @@ func getVarFromPartialYML(ctx context.Context, btesIn []byte) (H, error) {
 	return partial.Vars, nil
 }
 
+func getExecutorName(btes []byte) (string, error) {
+	content := readPartialYML(btes, "executor")
+	type partialType struct {
+		Executor string `yaml:"executor" json:"executor"`
+	}
+	partial := &partialType{}
+	if len(content) > 0 {
+		if err := yaml.Unmarshal([]byte(content), &partial); err != nil {
+			Error(context.Background(), "file content: %s", string(btes))
+			return "", errors.Wrapf(err, "error while unmarshal - see venom.log")
+		}
+	}
+	return partial.Executor, nil
+}
+
 // readPartialYML extract a yml part from a given string
 func readPartialYML(btes []byte, attribute string) string {
 	var result []string

--- a/types_executor.go
+++ b/types_executor.go
@@ -219,7 +219,7 @@ func (v *Venom) RunUserExecutor(ctx context.Context, runner ExecutorRunner, tcIn
 		}
 	}
 	// reload the user executor with the interpolated vars
-	_, exe, err := v.GetExecutorRunner(ctx, step, vrs)
+	_, exe, err := v.GetExecutorRunner(ctx, &step, &vrs)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to reload executor")
 	}


### PR DESCRIPTION
avoid doing interpolation as we are doing this during execution and register the executors only once not every time.

@fsamin , @yesnault 