### PR TITLE
Feature/default http headers

### DIFF
--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -180,6 +180,11 @@ func initFromReaderConfigFile(reader io.Reader) error {
 	}
 	if configFileData.LibDir != nil {
 		libDir = *configFileData.LibDir
+		if absPath, err := filepath.Abs(libDir); err == nil {
+			libDir = absPath
+		} else {
+			return err
+		}
 	}
 	if configFileData.OutputDir != nil {
 		outputDir = *configFileData.OutputDir

--- a/executors/http/README.md
+++ b/executors/http/README.md
@@ -14,7 +14,7 @@ In your yaml file, you can use:
   - body (optional)
   - bodyFile (optional)
   - preserve_bodyfile (optional) skip file content interpolation
-  - headers (optional)
+  - headers (optional), default values: Accept and Content-type are set to "application/json"
   - proxy (optional): set to use a proxy server for connection to url
   - resolve (optional): array of custom resolver of host and port pair. example: foo.com:443:127.0.0.1
   - ignore_verify_ssl (optional): set to true if you use a self-signed SSL on remote for example

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -109,6 +109,9 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 		return nil, err
 	}
 
+	e.setDefaultHeader("Accept", "application/json")
+	e.setDefaultHeader("Content-Type", "application/json")
+
 	for k, v := range e.Headers {
 		req.Header.Set(k, v)
 		if strings.ToLower(k) == "host" {
@@ -415,6 +418,13 @@ func isContentTypeSupported(contentType string) bool {
 func isBodyJSONSupported(resp *http.Response) bool {
 	contentType := parseContentType(resp.Header.Get("Content-Type"))
 	return strings.Contains(contentType, "application/json") || strings.HasSuffix(contentType, "+json")
+}
+
+// setDefaultHeader is a utility function to set a default header if it's not already present
+func (e Executor) setDefaultHeader(headerName, defaultValue string) {
+	if _, present := e.Headers[headerName]; !present {
+		e.Headers[headerName] = defaultValue
+	}
 }
 
 func (e Executor) TLSOptions(ctx context.Context) ([]func(*http.Transport) error, error) {

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -110,7 +110,6 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 	}
 
 	if e.MultipartForm == nil {
-		e.setDefaultHeader("Accept", "application/json")
 		e.setDefaultHeader("Content-Type", "application/json")
 	}
 

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -109,8 +109,10 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 		return nil, err
 	}
 
-	e.setDefaultHeader("Accept", "application/json")
-	e.setDefaultHeader("Content-Type", "application/json")
+	if e.MultipartForm == nil {
+		e.setDefaultHeader("Accept", "application/json")
+		e.setDefaultHeader("Content-Type", "application/json")
+	}
 
 	for k, v := range e.Headers {
 		req.Header.Set(k, v)


### PR DESCRIPTION
Enhance header handling efficiency

In situations where a significant number of test cases require the same headers to be consistently set, the existing approach led to redundancy. Prior to this enhancement, header definitions were repeated for each request, as exemplified:

```yaml
- type: http
  method: PUT
  headers:
    Authorization: ***
    Accept: application/json
    Content-Type: application/json
```
The objective of this feature is to streamline the process by reducing repetitive lines for the commonly used content type. Subsequently, the optimized configuration appears as follows:
after
```yml
    - type: http
      method: PUT
      headers:
        Authorization: ***
```

Furthermore, it's important to note that if the context involves `multipart_form` requests, no default headers will be automatically set.