### PR TITLE
fix(venom): env variables with equal sign

### DIFF
--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -289,7 +289,7 @@ func initFromEnv(environ []string) ([]string, error) {
 		if strings.HasPrefix(env, "VENOM_VAR_") {
 			tuple := strings.Split(env, "=")
 			k := strings.TrimPrefix(tuple[0], "VENOM_VAR_")
-			variables = append(variables, fmt.Sprintf("%v=%v", k, cast(tuple[1])))
+			variables = append(variables, fmt.Sprintf("%v=%v", k, cast(strings.Join(tuple[1:], "="))))
 		}
 	}
 

--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -287,9 +287,9 @@ func initFromEnv(environ []string) ([]string, error) {
 
 	for _, env := range environ {
 		if strings.HasPrefix(env, "VENOM_VAR_") {
-			tuple := strings.Split(env, "=")
+			tuple := strings.SplitN(env, "=", 2)
 			k := strings.TrimPrefix(tuple[0], "VENOM_VAR_")
-			variables = append(variables, fmt.Sprintf("%v=%v", k, cast(strings.Join(tuple[1:], "="))))
+			variables = append(variables, fmt.Sprintf("%v=%v", k, cast(tuple[1])))
 		}
 	}
 

--- a/cmd/venom/run/cmd_test.go
+++ b/cmd/venom/run/cmd_test.go
@@ -90,10 +90,10 @@ func Test_mergeVariables(t *testing.T) {
 }
 
 func Test_initFromEnv(t *testing.T) {
-	env := []string{`VENOM_VAR_a=1`, `VENOM_VAR_b="B"`, `VENOM_VAR_c=[1,2,3]`}
+	env := []string{`VENOM_VAR_a=1`, `VENOM_VAR_b="B"`, `VENOM_VAR_c=[1,2,3]`, `VENOM_VAR_d="e=f"`}
 	found, err := initFromEnv(env)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(found))
+	require.Equal(t, 4, len(found))
 	var nb int
 	for i := range found {
 		if found[i] == "a=1" {
@@ -101,6 +101,8 @@ func Test_initFromEnv(t *testing.T) {
 		} else if found[i] == "b=B" {
 			nb++
 		} else if found[i] == "c=[1,2,3]" {
+			nb++
+		} else if found[i] == "d=e=f" {
 			nb++
 		}
 	}


### PR DESCRIPTION
This PR fixes the following issue:
VENOM_VAR_a='host=localhost'
results in a='host' because of the split on '=' and only taking the first value back

With this the var would end up like this:
a = 'host=localhost'

Making it possible to add equal signs in the variable