### PR TITLE
fix(venom): output dump file

### DIFF
--- a/process_teststep.go
+++ b/process_teststep.go
@@ -61,7 +61,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 			if oDir == "" {
 				oDir = "."
 			}
-			filename := path.Join(oDir, fmt.Sprintf("%s.%s.step.%d.%d.dump.json", slug.Make(StringVarFromCtx(ctx, "venom.testsuite.shortName")), slug.Make(tc.Name), stepNumber, rangedIndex))
+			filename := path.Join(oDir, fmt.Sprintf("%s.%s.testcase.%d.step.%d.%d.dump.json", slug.Make(StringVarFromCtx(ctx, "venom.testsuite.shortName")), slug.Make(tc.Name), tc.number, stepNumber, rangedIndex))
 
 			if err := os.WriteFile(filename, []byte(HideSensitive(ctx, string(output))), 0644); err != nil {
 				Error(ctx, "Error while creating file %s: %v", filename, err)

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -210,6 +210,7 @@ func (v *Venom) parseTestCases(ts *TestSuite) ([]string, []string, error) {
 	for i := range ts.TestCases {
 		tc := &ts.TestCases[i]
 		tc.originalName = tc.Name
+		tc.number = i
 		tc.Name = slug.Make(tc.Name)
 		tc.Vars = ts.Vars.Clone()
 		tc.Vars.Add("venom.testcase", tc.Name)

--- a/types.go
+++ b/types.go
@@ -160,6 +160,7 @@ type TestCase struct {
 
 	// Computed
 	originalName string
+	number       int
 	Skipped      []Skipped `json:"skipped" yaml:"-"`
 	Status       Status    `json:"status" yaml:"-"`
 

--- a/types_executor.go
+++ b/types_executor.go
@@ -231,6 +231,7 @@ func (v *Venom) RunUserExecutor(ctx context.Context, runner ExecutorRunner, tcIn
 			RawTestSteps: ux.RawTestSteps,
 			Vars:         vrs,
 		},
+		number:          tcIn.number,
 		TestSuiteVars:   tcIn.TestSuiteVars,
 		IsExecutor:      true,
 		TestStepResults: make([]TestStepResult, 0),


### PR DESCRIPTION
```yml
name: testsuite with a user executor
testcases:
- name: testJSON
  steps:
  - type: hello
    myarg: World
  - type: hello
    myarg: World
- name: testJSON
  steps:
  - type: hello
    myarg: World
```

returns:

```
❯ venom run -vvv b.yml
          [trac] writing venom.2.log
 • testsuite with a user executor (b.yml)
        • testJSON
                • hello PASS
                • hello PASS
                  [trac] writing b.testJSON.testcase.0.step.0.0.dump.json
                  [trac] writing b.testJSON.testcase.0.step.1.0.dump.json
        • testJSON
                • hello PASS
                  [trac] writing b.testJSON.testcase.1.step.0.0.dump.json
final status: PASS
```

close #722 