### PR TITLE
Lazy expansion of json payloads that we get from user executors

### DIFF
--- a/cmd/venom/root/root.go
+++ b/cmd/venom/root/root.go
@@ -18,7 +18,7 @@ func New() *cobra.Command {
 	return rootCmd
 }
 
-//AddCommands adds child commands to the root command rootCmd.
+// AddCommands adds child commands to the root command rootCmd.
 func addCommands(cmd *cobra.Command) {
 	cmd.AddCommand(run.Cmd)
 	cmd.AddCommand(version.Cmd)

--- a/process_testcase_test.go
+++ b/process_testcase_test.go
@@ -3,6 +3,7 @@ package venom
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,4 +44,57 @@ script: echo 'foo'
 	assert.NoError(t, err)
 	assert.Nil(t, result)
 	assert.Empty(t, result)
+}
+
+func TestProcessVariableAssignmentsWithJSON(t *testing.T) {
+	InitTestLogger(t)
+	assign := AssignStep{}
+	assign.Assignments = make(map[string]Assignment)
+	assign.Assignments["name"] = Assignment{
+		From: "payloadjson.users.users0.name",
+	}
+
+	b, _ := yaml.Marshal(assign)
+	t.Log("\n" + string(b))
+
+	tcVars := H{"payload": "{\"users\": [{\"name\":\"Tester\"}]}"}
+	os.Setenv(LAZY_JSON_EXPANSION_FLAG, FLAG_ENABLED)
+	result, is, err := processVariableAssignments(context.TODO(), "", tcVars, b)
+	assert.True(t, is)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "Tester", result["name"])
+	t.Log(result)
+	os.Unsetenv(LAZY_JSON_EXPANSION_FLAG)
+}
+
+func TestProcessJsonBlobWithObject(t *testing.T) {
+	InitTestLogger(t)
+	items, err := UnmarshalJSON("test", "{\"key\":123,\"another\":\"one\"}")
+	assert.NoError(t, err)
+	assert.NotNil(t, items)
+	assert.Contains(t, items, "testjson.key")
+	assert.Contains(t, items, "testjson.another")
+	assert.Contains(t, items, "testjson")
+	assert.Contains(t, items, "__Type__")
+	assert.Contains(t, items, "__Len__")
+}
+
+func TestProcessJsonBlobWithArray(t *testing.T) {
+	InitTestLogger(t)
+	items, err := UnmarshalJSON("test", "{\"key\":123,\"anArray\":[\"one\",\"two\"]}")
+	assert.NoError(t, err)
+	assert.NotNil(t, items)
+	assert.Contains(t, items, "testjson.key")
+	assert.Contains(t, items, "testjson.anArray")
+	assert.Contains(t, items, "testjson")
+	assert.Equal(t, items["anArray.__Type__"], "Array")
+	assert.Equal(t, items["anArray.__Len__"], "2")
+	assert.Contains(t, items, "testjson.anArray.anArray0")
+	assert.Equal(t, items["testjson.anArray.anArray0"], "one")
+	assert.Contains(t, items, "testjson.anArray.anArray1")
+	assert.Equal(t, items["testjson.anArray.anArray1"], "two")
+	assert.Contains(t, items, "__Type__")
+	assert.Equal(t, items["__Type__"], "Map")
+	assert.Contains(t, items, "__Len__")
 }

--- a/types_executor.go
+++ b/types_executor.go
@@ -165,7 +165,7 @@ func GetExecutorResult(r interface{}) map[string]interface{} {
 		panic(err)
 	}
 	jsonUpdates := os.Getenv(LAZY_JSON_EXPANSION_FLAG)
-	if jsonUpdates == "ON" {
+	if jsonUpdates == FLAG_ENABLED {
 		for key, value := range d {
 			switch z := value.(type) {
 			case string:
@@ -175,7 +175,8 @@ func GetExecutorResult(r interface{}) map[string]interface{} {
 				}
 				if len(m) > 0 {
 					for s, i := range m {
-						if !strings.Contains(strings.ToUpper(s), "__Type__") && !strings.Contains(strings.ToUpper(s), "__Len__") {
+						//we are skipping this as whenever we use a value we will do DumpString or Dump which means will generate those values
+						if !strings.Contains(strings.ToUpper(s), "__TYPE__") && !strings.Contains(strings.ToUpper(s), "__LEN__") {
 							d[s] = i
 						}
 					}

--- a/types_executor_test.go
+++ b/types_executor_test.go
@@ -1,0 +1,20 @@
+package venom
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetExecutorResult(t *testing.T) {
+	payload := map[string]string{}
+	payload["key"] = "{\"name\":\"test\"}"
+	os.Setenv(LAZY_JSON_EXPANSION_FLAG, FLAG_ENABLED)
+	result := GetExecutorResult(payload)
+	assert.NotNil(t, result)
+	assert.Equal(t, "Map", result["__type__"])
+	assert.Equal(t, int64(1), result["__len__"])
+	assert.Equal(t, "test", result["keyjson.name"])
+	os.Unsetenv(LAZY_JSON_EXPANSION_FLAG)
+}

--- a/venom.go
+++ b/venom.go
@@ -27,6 +27,12 @@ var (
 	IsTest  = ""
 )
 
+const (
+	LAZY_JSON_EXPANSION_FLAG = "VENOM_NO_JSON_EXPANSION"
+	FLAG_ENABLED             = "ON"
+	FLAG_DISABLED            = "OFF"
+)
+
 func OSExit(exitCode int) {
 	if IsTest != "" {
 		bincover.ExitCode = exitCode

--- a/venom.go
+++ b/venom.go
@@ -30,7 +30,6 @@ var (
 const (
 	LAZY_JSON_EXPANSION_FLAG = "VENOM_NO_JSON_EXPANSION"
 	FLAG_ENABLED             = "ON"
-	FLAG_DISABLED            = "OFF"
 )
 
 func OSExit(exitCode int) {


### PR DESCRIPTION
This is done in order to avoid expanding and storing big payloads that we dont need and we dont use for assertions. The flag is called `VENOM_NO_JSON_EXPANSION`.