### PR TITLE
Update examples for queries length assert #763

### DIFF
--- a/executors/sql/README.md
+++ b/executors/sql/README.md
@@ -37,7 +37,7 @@ testcases:
           - "SELECT * FROM employee;"
           - "SELECT * FROM person;"
         assertions:
-          - result.queries.__len__ ShouldEqual 2
+          - result.queries.__Len__ ShouldEqual 2
           - result.queries.queries0.rows.rows0.name ShouldEqual Jack
           - result.queries.queries1.rows.rows0.age ShouldEqual 21
 
@@ -63,7 +63,7 @@ testcases:
         dsn: user:password@(localhost:3306)/venom
         file: ./test.sql
         assertions:
-          - result.queries.__len__ ShouldEqual 1
+          - result.queries ShouldHaveLength 1
 ```
 
 *note: in the example above, the results of each command is stored in the results array


### PR DESCRIPTION
This PR amends examples for query length in the documentation to match beta4 changes.