### PR TITLE
exec: add a 'stdin' attribute

### DIFF
--- a/executors/exec/README.md
+++ b/executors/exec/README.md
@@ -34,6 +34,18 @@ testcases:
             echo "Bar"
 ```
 
+Input:
+
+```yaml
+name: Title of TestSuite
+testcases:
+- name: with stdin
+  steps:
+  - type: exec
+    stdin: Foo
+    script: cat
+```
+
 ## Output
 
 ```yaml

--- a/tests/exec.yml
+++ b/tests/exec.yml
@@ -40,9 +40,18 @@ testcases:
       bar:
         from: result.systemoutjson.notexisting
         default: "test"
+      json:
+        from: result.systemoutjson
 
 - name: verify default
   steps:
   - script: echo "{{.cat-json.foo}} {{.cat-json.bar}}"
     assertions:
     - result.systemout ShouldEqual "bar test"
+
+- name: stdin
+  steps:
+  - stdin: "{{.cat-json.json}}"
+    script: cat
+    assertions:
+    - result.systemoutjson.foo ShouldContainSubstring bar


### PR DESCRIPTION
If set, the value is written to the script stdin. This avoid the need to use 'echo' in the script, which makes thing clearer.

It is also particularly useful in the following case (probably other issues with variable substitution):

```yaml
name: simple_test
vars:
  payload: {"s": "\n"}
testcases:
- name: simple_test
  steps:
  - type: exec
    script: echo {{.payload | toJSON}} | jq .
    assertions:
    - result.code MustEqual 0
```

This will fail because the \n is not properly escaped.

Using the new stdin attribute solves the issue:

```yaml
name: simple_test
vars:
  payload: {"s": "\n"}
testcases:
- name: simple_test
  steps:
  - type: exec
    stdin: {{.payload | toJSON}}
    script: jq .
    assertions:
    - result.code MustEqual 0
```