### PR TITLE
 Add a 'command' property to 'exec'

### DIFF
--- a/executors/exec/README.md
+++ b/executors/exec/README.md
@@ -46,6 +46,18 @@ testcases:
     script: cat
 ```
 
+Explicit command (no shell):
+
+```yaml
+name: Title of TestSuite
+testcases:
+- name: explicit command
+  steps:
+  - type: exec
+    stdin: "{\"foo\":\"bar\"}"
+    command: ["jq", ".foo"]
+```
+
 ## Output
 
 ```yaml

--- a/executors/exec/README.md
+++ b/executors/exec/README.md
@@ -34,6 +34,18 @@ testcases:
             echo "Bar"
 ```
 
+Input:
+
+```yaml
+name: Title of TestSuite
+testcases:
+- name: with stdin
+  steps:
+  - type: exec
+    stdin: Foo
+    script: cat
+```
+
 ## Output
 
 ```yaml

--- a/tests/exec.yml
+++ b/tests/exec.yml
@@ -55,3 +55,9 @@ testcases:
     script: cat
     assertions:
     - result.systemoutjson.foo ShouldContainSubstring bar
+
+- name: command
+  steps:
+  - command: ["echo", "{{.cat-json.json}}"]
+    assertions:
+    - result.systemoutjson.foo ShouldContainSubstring bar

--- a/tests/exec.yml
+++ b/tests/exec.yml
@@ -40,9 +40,18 @@ testcases:
       bar:
         from: result.systemoutjson.notexisting
         default: "test"
+      json:
+        from: result.systemoutjson
 
 - name: verify default
   steps:
   - script: echo "{{.cat-json.foo}} {{.cat-json.bar}}"
     assertions:
     - result.systemout ShouldEqual "bar test"
+
+- name: stdin
+  steps:
+  - stdin: "{{.cat-json.json}}"
+    script: cat
+    assertions:
+    - result.systemoutjson.foo ShouldContainSubstring bar

--- a/venom.go
+++ b/venom.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	//Version is set with -ldflags "-X github.com/ovh/venom/venom.Version=$(VERSION)"
+	// Version is set with -ldflags "-X github.com/ovh/venom/venom.Version=$(VERSION)"
 	Version = "snapshot"
 	IsTest  = ""
 )
@@ -126,7 +126,8 @@ func (v *Venom) RegisterExecutorUser(name string, e Executor) {
 func (v *Venom) GetExecutorRunner(ctx context.Context, ts TestStep, h H) (context.Context, ExecutorRunner, error) {
 	name, _ := ts.StringValue("type")
 	script, _ := ts.StringValue("script")
-	if name == "" && script != "" {
+	command, _ := ts.StringSliceValue("command")
+	if name == "" && (script != "" || len(command) != 0) {
 		name = "exec"
 	}
 	retry, err := ts.IntValue("retry")
@@ -346,7 +347,7 @@ func AllVarsFromCtx(ctx context.Context) H {
 }
 
 func JSONUnmarshal(btes []byte, i interface{}) error {
-	var d = json.NewDecoder(bytes.NewReader(btes))
+	d := json.NewDecoder(bytes.NewReader(btes))
 	d.UseNumber()
 	return d.Decode(i)
 }


### PR DESCRIPTION
Add a 'command' property to 'exec'

It is an alternative to 'script' that takes an explicit list of strings
and does not use a shell.

It makes it easier to deal with escaping special characters, and gives
more control on how the command is run.

:warning: It is based on PR #767 