### PR TITLE
feat(executor/redis): Redis auth (ACL) support

### DIFF
--- a/executors/redis/redis.go
+++ b/executors/redis/redis.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	shellwords "github.com/mattn/go-shellwords"
 	"github.com/mitchellh/mapstructure"
 	"github.com/ovh/venom"

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/fsamin/go-dump v1.8.0
 	github.com/fullstorydev/grpcurl v1.8.8
-	github.com/garyburd/redigo v1.6.4
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/go-testfixtures/testfixtures/v3 v3.9.0
 	github.com/golang/protobuf v1.5.3
+	github.com/gomodule/redigo v1.9.2
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/gosimple/slug v1.13.1
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf

--- a/go.sum
+++ b/go.sum
@@ -701,8 +701,6 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fullstorydev/grpcurl v1.8.8 h1:74MrTXbTlsNEAAhbwc4r2F5P4Qu7Rkyn9BflEer8vss=
 github.com/fullstorydev/grpcurl v1.8.8/go.mod h1:TRM21TqPbPzHkA9DqSh94oI2g1pD2AFRhLhmGrSht+Q=
-github.com/garyburd/redigo v1.6.4 h1:LFu2R3+ZOPgSMWMOL+saa/zXRjw0ID2G8FepO53BGlg=
-github.com/garyburd/redigo v1.6.4/go.mod h1:rTb6epsqigu3kYKBnaF028A7Tf/Aw5s0cqA47doKKqw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
@@ -781,6 +779,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomodule/redigo v1.9.2 h1:HrutZBLhSIU8abiSfW8pj8mPhOyMYjZT/wcA4/L9L9s=
+github.com/gomodule/redigo v1.9.2/go.mod h1:KsU3hiK/Ay8U42qpaJk+kuNa3C+spxapWpM+ywhcgtw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=


### PR DESCRIPTION
Hello,

Bump the redis client to the latest version to support ACL (introduced [here](https://github.com/gomodule/redigo/pull/480))
Btw, the `garyburd/redigo/redis` has moved to `gomodule/redigo/redis`. The old repo is unmaintained.

## Behavior
### Test
```yml
- name: Test commands
  steps:
    - type: redis
      dialURL: "redis://{{.user}}:{{.password}}@localhost:6379/0"
      commands:
        - SET foo bar
        - GET foo
        - KEYS *
      assertions:
        - result.commands.commands0.response ShouldEqual OK
        - result.commands.commands1.response ShouldEqual bar
        - result.commands.commands2.response.response0 ShouldEqual foo
```

### Current result
```bash
 	• Test-commands
 		• redis FAIL
 		  Testcase "Test commands", step #0-0: WRONGPASS invalid username-password pair or user is disabled.
final status: FAIL
```

### New result
```bash
 	• Test-commands
 		• redis PASS
final status: PASS
```

