### PR TITLE
fix: [Make] Create windows binaries with .exe extension

### DIFF
--- a/.build/go.mk
+++ b/.build/go.mk
@@ -48,9 +48,12 @@ mk_go_build_clean:
 
 $(CROSS_COMPILED_BINARIES): $(GOFILES) $(TARGET_DIST)
 	$(info *** compiling $@)
-	@GOOS=$(call get_os_from_binary_file,$@) \
+	@os=$(call get_os_from_binary_file,$@); \
+	filename=$@ ; \
+	if [[ $${os} == 'windows' ]]; then filename=$@.exe; fi; \
+	GOOS=$${os} \
 	GOARCH=$(call get_arch_from_binary_file,$@) \
-	$(GO_BUILD) $(BUILD_MODE) $(LDFLAGS) -o $@;
+	$(GO_BUILD) $(BUILD_MODE) $(LDFLAGS) -o $${filename};
 
 ##### =====> Compile Tests <===== #####
 


### PR DESCRIPTION
When fetching Venom binaries, I noticed that Windows releases didn't include an extension. For Windows, it means that the users will face the program-picker prompt due to a lack of extension, and would have to add it manually. 

This PR changes the `CROSS_COMPILED_BINARIES` make target in `.build/go.mk` to check if the current target OS is windows, and if so, changing the filename to include the `.exe` extension.

I assume that the point of `BINARIES` is precisely this, but probably due to some lack of Make syntax knowledge, I couldn't figure out why `IS_WINDOWS` isn't being recognized :) 

That being the case, I am opening a suggestion to leverage the `GOOS` env var taken from the `get_os_from_binary_file` call, and changing the filename if the OS is `windows`.

Any suggestions for changes are welcome, provided that we are able to distribute windows binaries with the proper extension :) 