### PR TITLE
feat(executor/rabbitmq): Add support for RPC

### DIFF
--- a/executors/rabbitmq/README.md
+++ b/executors/rabbitmq/README.md
@@ -1,6 +1,11 @@
 # Venom - Executor RabbitMQ
 
-Step to use publish / subscribe on a RabbitMQ
+Three types of execution are supported:
+- **publisher**: publish a message to a queue or to an exchange.
+- **subscriber**: bind to a queue or an exchange (using routing key) and wait for message(s) to be consumed.
+- **client**: publish a message to a queue or to an exchange and wait for the response message to be received on the [reply-to](https://www.rabbitmq.com/docs/direct-reply-to) queue.
+
+Steps to use publish / subscribe on a RabbitMQ:
 
 ## Input
 In your yaml file, you can use:
@@ -12,7 +17,7 @@ In your yaml file, you can use:
   - user optional         (default guest)
   - password optional     (default guest)
 
-  - clientType mandatory (publisher or subscriber)
+  - clientType mandatory (publisher, subscriber or client)
 
   # RabbitMQ Q configuration
   - qName mandatory
@@ -22,10 +27,10 @@ In your yaml file, you can use:
   - exchangeType optional  (default "fanout")
   - exchange optional     (default "")
 
-  # For subscriber only
+  # For subscriber and client only
   - messageLimit optional (default 1)
 
-  # For publisher only
+  # For publisher and client only
   - messages
     - durable optional      (true or false) (default false)
     - contentType optional  
@@ -139,4 +144,35 @@ vars:
           - result.headers.headers0.mycustomheader2 ShouldEqual value2
           - result.messages.messages0.contentencoding ShouldEqual utf8
           - result.messages.messages0.contenttype ShouldEqual application/json
+```
+
+### Client (pubsub RPC)
+```yaml
+name: TestSuite RabbitMQ
+vars:
+  addrs: 'amqp://localhost:5672'
+  user: 
+  password: 
+testcases:
+  - name: RabbitMQ request/reply
+    steps:
+      - type: rabbitmq
+        addrs: "{{.addrs}}"
+        user: "{{.user}}"
+        password: "{{.password}}"
+        clientType: client
+        exchange: exchange_test
+        routingKey: pubsub_test
+        messages: 
+          - value: '{"a": "b"}'
+            contentType: application/json
+            contentEncoding: utf8
+            persistent: false
+            headers: 
+              myCustomHeader: value
+              myCustomHeader2: value2
+        messageLimit: 1
+        assertions: 
+          - result.bodyjson.bodyjson0 ShouldContainKey Status
+          - result.bodyjson.bodyjson0.Status ShouldEqual Succeeded
 ```


### PR DESCRIPTION
# Description
Introduced new client type to use for testing RPC pattern using [Direct Reply-to](https://www.rabbitmq.com/docs/direct-reply-to).
This can not be achieved using existing client types (publisher and subscriber), because a Direct reply-to has some specific requirements and the client must have a reply consumer running before publishing a request.
The new client type is simply referred to as 'client' to indicate a client-server communication using RPC pattern.
It can be used to test a server that is expected to respond to the received message by sending a reply using Direct Reply-to feature of RabbitMQ.

# Usage
Example testsuite:
```
name: TestSuite RabbitMQ
testcases:
  - name: Send data and await reply
    steps:
      - type: rabbitmq
        addrs: "{{.addrs}}"
        user: "{{.user}}"
        password: "{{.password}}"
        clientType: client
        exchange: test-exchange
        exchangeType: direct
        durable: true
        routingKey: OrderDetailsRequest
        messages: 
          - value: '{{.messageFromVariableFile}}'
            contentType: application/json
            contentEncoding: utf8
            persistant: false
            durable: true
        assertions: 
          - result.bodyjson.bodyjson0 ShouldContainKey Status
          - result.bodyjson.bodyjson0.Status ShouldEqual Ok
```
In the above example, a direct-reply-to consumer will first be started and then a message will be published to the exchange using the provided routing key. Then, the test executor will wait for the reply to be received on the direct reply queue. Existing logic of the subscriber client type will be used to parse the results, close the connection and validate against assertions.