### PR TITLE
feat: test case and test suite `totalSteps` built-in variables added

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,8 +573,8 @@ testcases:
 - name: testA
   steps:
   - type: exec
-    script: echo '{{.venom.testsuite}} {{.venom.testsuite.filename}} {{.venom.testcase}} {{.venom.teststep.number}} {{.venom.datetime}} {{.venom.timestamp}}'
-    # will display something as: MyTestSuite MyTestSuiteWithVenomBuiltinVar.yml testA 0 2018-08-05T21:38:24+02:00 1533497904
+    script: echo '{{.venom.testsuite}} {{.venom.testsuite.filename}} {{.venom.testcase}} {{.venom.teststep.number}} {{.venom.datetime}} {{.venom.timestamp}} {{.venom.testcase.totalSteps}} {{.venom.testsuite.totalSteps}}'
+    # will display something as: MyTestSuite MyTestSuiteWithVenomBuiltinVar.yml testA 0 2018-08-05T21:38:24+02:00 1533497904 3 5
 
 ```
 
@@ -585,6 +585,7 @@ Builtin variables:
 * {{.venom.libdir}}
 * {{.venom.outputdir}}
 * {{.venom.testcase}}
+* {{.venom.testcase.totalSteps}}
 * {{.venom.teststep.number}}
 * {{.venom.testsuite.name}}
 * {{.venom.testsuite.filename}}
@@ -592,6 +593,7 @@ Builtin variables:
 * {{.venom.testsuite.shortName}}
 * {{.venom.testsuite.workdir}}
 * {{.venom.testsuite}}
+* {{.venom.testsuite.totalSteps}}
 * {{.venom.timestamp}}
 
 

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -139,6 +139,7 @@ func (v *Venom) runTestCase(ctx context.Context, ts *TestSuite, tc *TestCase) {
 	tc.Vars = ts.Vars.Clone()
 	tc.Vars.Add("venom.testcase", tc.Name)
 	tc.Vars.AddAll(ts.ComputedVars)
+	tc.Vars.Add("venom.testcase.totalSteps", len(tc.RawTestSteps))
 	tc.computedVars = H{}
 
 	ctx = v.processSecrets(ctx, ts, tc)
@@ -185,10 +186,13 @@ func (v *Venom) runTestSteps(ctx context.Context, tc *TestCase, tsIn *TestStepRe
 	fromUserExecutor := tsIn != nil
 
 loopRawTestSteps:
-	for stepNumber, rawStep := range tc.RawTestSteps {
+	for stepIndex, rawStep := range tc.RawTestSteps {
 		stepVars := tc.Vars.Clone()
 		stepVars.AddAll(previousStepVars)
 		stepVars.AddAllWithPrefix(tc.Name, tc.computedVars)
+
+		// Use stepNumber as a 1-based index
+		stepNumber := stepIndex + 1
 		stepVars.Add("venom.teststep.number", stepNumber)
 
 		ranged, err := parseRanged(ctx, rawStep, stepVars)

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -421,7 +421,7 @@ func (v *Venom) printTestStepResult(tc *TestCase, ts *TestStepResult, tsIn *Test
 				v.Println(" \t\t  %s", Yellow(f.Value))
 			}
 			if mustAssertionFailed {
-				skipped := len(tc.RawTestSteps) - stepNumber - 1
+				skipped := len(tc.RawTestSteps) - stepNumber
 				if skipped == 1 {
 					v.Println(" \t\t  %s", Gray(fmt.Sprintf("%d other step was skipped", skipped)))
 				} else {

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -61,9 +61,10 @@ func (v *Venom) runTestSuite(ctx context.Context, ts *TestSuite) error {
 
 	totalSteps := 0
 	for _, tc := range ts.TestCases {
-		totalSteps += len(tc.testSteps)
+		totalSteps += len(tc.RawTestSteps)
 	}
 
+	ts.Vars.Add(("venom.testsuite.totalSteps"), totalSteps)
 	ts.Status = StatusRun
 	Info(ctx, "With secrets in testsuite")
 	for _, v := range ts.Secrets {
@@ -218,7 +219,7 @@ func (v *Venom) parseTestCases(ts *TestSuite) ([]string, []string, error) {
 	for i := range ts.TestCases {
 		tc := &ts.TestCases[i]
 		tc.originalName = tc.Name
-		tc.number = i
+		tc.number = i + 1
 		tc.Name = slug.Make(tc.Name)
 		tc.Vars = ts.Vars.Clone()
 		tc.Vars.Add("venom.testcase", tc.Name)


### PR DESCRIPTION
close https://github.com/ovh/venom/issues/808

```json
  "venom.testcase.totalSteps": "3",
  "venom.teststep.number": "1",
  "venom.testsuite.totalSteps": "5",
```

- I have adjusted the `teststep.number` and test case numbering to be 1-based instead of zero-based indexing.

Now, the dumps logged in the console will display as follows:
```bash
 • test.venom (test.venom.yml)
        • Test-1
                • http PASS
                • http PASS
                  [trac] writing output/test-venom.Test-1.testcase.1.step.1.0.dump.json
                  [trac] writing output/test-venom.Test-1.testcase.1.step.2.0.dump.json
        • Test-2
                • http PASS
                • http PASS
                • http PASS
                  [trac] writing output/test-venom.Test-2.testcase.2.step.1.0.dump.json
                  [trac] writing output/test-venom.Test-2.testcase.2.step.2.0.dump.json
                  [trac] writing output/test-venom.Test-2.testcase.2.step.3.0.dump.json
```