### PR TITLE
ux(logs): info log level changed to debug

### DIFF
--- a/process_files.go
+++ b/process_files.go
@@ -63,7 +63,7 @@ func uniq(stringSlice []string) []string {
 
 func (v *Venom) readFiles(ctx context.Context, filesPath []string) (err error) {
 	for _, filePath := range filesPath {
-		Info(ctx, "Reading %v", filePath)
+		Debug(ctx, "Reading %v", filePath)
 		btes, err := os.ReadFile(filePath)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read file %q", filePath)

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -346,7 +346,7 @@ loopRawTestSteps:
 			var isRequired bool
 
 			if tsResult.Status != StatusFail {
-				Warn(ctx, "Step %q result is %q", tsResult.Name, tsResult.Status)
+				Info(ctx, "Step %q result is %q", tsResult.Name, tsResult.Status)
 			}
 
 			if tsResult.Status == StatusFail {

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -100,7 +100,7 @@ func (v *Venom) runTestSuite(ctx context.Context, ts *TestSuite) error {
 }
 
 func (v *Venom) runTestCases(ctx context.Context, ts *TestSuite) {
-	verboseReport := v.Verbose >= 1
+	verboseReport := v.Verbose > 1
 
 	v.Println(" • %s (%s)", ts.Name, ts.Filepath)
 

--- a/venom.go
+++ b/venom.go
@@ -224,7 +224,7 @@ func (v *Venom) registerUserExecutors(ctx context.Context, name string, vars map
 	}
 
 	for _, f := range executorsPath {
-		Info(ctx, "Reading %v", f)
+		Debug(ctx, "Reading %v", f)
 		btes, ok := v.executorFileCache[f]
 		if !ok {
 			btes, err = os.ReadFile(f)


### PR DESCRIPTION
Running Venom in non-verbose mode results in additional "debug" logs being recorded at the "info" level. This not only uses more storage space but also slows down the debugging process for test case failures. Currently, we've shifted these logs to the debug level, but it's worth considering moving them to the trace level OR remove them entirely.