### PR TITLE
fix(teststep): include step previous vars when checking skip

### DIFF
--- a/process_testcase.go
+++ b/process_testcase.go
@@ -325,7 +325,9 @@ loopRawTestSteps:
 			}
 
 			// ##### RUN Test Step Here
-			skip, err := parseSkip(ctx, tc, tsResult, rawStep, stepNumber)
+			skipVars := tc.Vars.Clone()
+			skipVars.AddAllWithPrefix(tc.Name, previousStepVars)
+			skip, err := parseSkip(ctx, tc, tsResult, rawStep, stepNumber, skipVars)
 			if err != nil {
 				tsResult.appendError(err)
 				tsResult.Status = StatusFail
@@ -444,7 +446,7 @@ func (v *Venom) printTestStepResult(tc *TestCase, ts *TestStepResult, tsIn *Test
 }
 
 // Parse and format skip conditional
-func parseSkip(ctx context.Context, tc *TestCase, ts *TestStepResult, rawStep []byte, stepNumber int) (bool, error) {
+func parseSkip(ctx context.Context, tc *TestCase, ts *TestStepResult, rawStep []byte, stepNumber int, vars H) (bool, error) {
 	// Load "skip" attribute from step
 	var assertions struct {
 		Skip []string `yaml:"skip"`
@@ -455,7 +457,7 @@ func parseSkip(ctx context.Context, tc *TestCase, ts *TestStepResult, rawStep []
 
 	// Evaluate skip assertions
 	if len(assertions.Skip) > 0 {
-		results, err := testConditionalStatement(ctx, tc, assertions.Skip, tc.Vars, fmt.Sprintf("skipping testcase %%q step #%d: %%v", stepNumber))
+		results, err := testConditionalStatement(ctx, tc, assertions.Skip, vars, fmt.Sprintf("skipping testcase %%q step #%d: %%v", stepNumber))
 		if err != nil {
 			Error(ctx, "unable to evaluate \"skip\" assertions: %v", err)
 			return false, err

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -1,6 +1,7 @@
 name: "Skip testsuite"
 vars:
   foo: bar
+  set_var_exit_code: 2
 
 testcases:
 - name: init
@@ -53,3 +54,30 @@ testcases:
     - result.code ShouldEqual 0
     skip:
     - foo ShouldBeEmpty
+
+- name: skip-test-step-same-test-case
+  steps:
+  - name: set-var
+    type: exec
+    script: exit 0
+    assertions:
+    - result.code ShouldEqual 0
+    vars:
+      set_var_exit_code:
+        from: result.code
+  - name: dont-skip-step
+    type: exec
+    script: echo set_var_exit_code={{.skip-test-step-same-test-case.exit_step_code}}
+    skip:
+      - skip-test-step-same-test-case.set_var_exit_code ShouldEqual 0
+  - name: skip-step
+    type: exec
+    script: echo set_var_exit_code={{.skip-test-step-same-test-case.exit_step_code}}
+    skip:
+      - skip-test-step-same-test-case.set_var_exit_code ShouldNotBeNil
+      - skip-test-step-same-test-case.set_var_exit_code ShouldEqual 1
+  - name: dont-skip-step
+    type: exec
+    script: echo set_var_exit_code={{.skip-test-step-same-test-case.exit_step_code}}
+    skip:
+      - set_var_exit_code ShouldEqual 2


### PR DESCRIPTION
Hi,

it should close #777 

## Behavior

### Test

```yaml
name: "Do not skip testcase"
vars:
  set_var_exit_code: 2

testcases:
- name: skip-test-step-same-test-case
  steps:
  - name: init
    type: exec
    script: exit 0
    assertions:
    - result.code ShouldEqual 0
    vars:
      set_var_exit_code:
        from: result.code
  - name: dont-skip-step
    type: exec
    script: echo set_var_exit_code={{.skip-test-step-same-test-case.exit_step_code}}
    skip:
      - skip-test-step-same-test-case.set_var_exit_code ShouldEqual 0
  - name: skip-step
    type: exec
    script: echo set_var_exit_code={{.skip-test-step-same-test-case.exit_step_code}}
    skip:
      - skip-test-step-same-test-case.set_var_exit_code ShouldNotBeNil
      - skip-test-step-same-test-case.set_var_exit_code ShouldEqual 1
  - name: dont-skip-step
    type: exec
    script: echo set_var_exit_code={{.skip-test-step-same-test-case.exit_step_code}}
    skip:
      - set_var_exit_code ShouldEqual 2
```

### Without this patch

```
        • skip-test-step-same-test-case
                • set-var PASS
                • dont-skip-step SKIP
                • skip-step SKIP
                • dont-skip-step PASS
                  [trac] writing skip.skip-test-step-same-test-case.testcase.5.step.0.0.dump.json
                  [trac] writing skip.skip-test-step-same-test-case.testcase.5.step.3.0.dump.json
```

Logs:
```
$ grep skip-test-step-same-test-case venom.log | grep skipping
Mar 23 11:58:02.388 [WARN] [Skip testsuite] [skip-test-step-same-test-case] skipping testcase "skip-test-step-same-test-case" step #1: expected: 0  got: <nil>
Mar 23 11:58:02.389 [WARN] [Skip testsuite] [skip-test-step-same-test-case] skipping testcase "skip-test-step-same-test-case" step #2: expected: Not Nil but is was
Mar 23 11:58:02.389 [WARN] [Skip testsuite] [skip-test-step-same-test-case] skipping testcase "skip-test-step-same-test-case" step #2: expected: 1  got: <nil>
```

### With this patch

```
        • skip-test-step-same-test-case
                • set-var PASS
                • dont-skip-step PASS
                • skip-step SKIP
                • dont-skip-step PASS
                  [trac] writing skip.skip-test-step-same-test-case.testcase.5.step.0.0.dump.json
                  [trac] writing skip.skip-test-step-same-test-case.testcase.5.step.1.0.dump.json
                  [trac] writing skip.skip-test-step-same-test-case.testcase.5.step.3.0.dump.json
```

Logs

```
$ grep skip-test-step-same-test-case venom.log | grep skipping
Mar 23 11:59:06.887 [WARN] [Skip testsuite] [skip-test-step-same-test-case] skipping testcase "skip-test-step-same-test-case" step #2: expected: 1  got: 0
```

Only the expected step to be skipped is skipped.

