### PR TITLE
feat(tags): possibility to execute tests with filtering tags inclusive or exclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Venom is a CLI (Command Line Interface) that aims to create, manage and run your
       * [`Must` Keywords](#must-keywords)
     * [Using logical operators](#using-logical-operators)
 * [Write and run your first test suite](#write-and-run-your-first-test-suite)
+* [Include and/or exclude tests cases from execution](#include-exclude-test-cases)
 * [Export tests report](#export-tests-report)
 * [Advanced usage](#advanced-usage)
   * [Debug your testsuites](#debug-your-testsuites)
+  * [Anchors](#anchors)
   * [Skip testcase and teststeps](#skip-testcase-and-teststeps)
   * [Iterating over data](#iterating-over-data)
 * [FAQ](#faq)
@@ -750,6 +752,22 @@ $ venom run
 
 You wrote and executed your first testsuite with the HTTP executor! :)
 
+# Include and/or exclude tests cases from execution
+
+You might want to execute only a subsets or tests to split your testing job into several or gather tests by their functional purpose.
+To do so, you can use the flag `--include-tags` to include only tests matching provided tags and/or the flag `--exclude-tags` to exclude only tests matching provided tags.
+The test case you want to include/exclude must have tags array attribute :
+```
+- name: sleep 1
+  tags: ["@sleep"]
+  steps:
+  - type: exec
+    script: sleep 1
+```
+
+The venom command to include tag @smoke and exclude tag @sleep would be the following:
+`venom run ../tests/tags.yml --exclude-tags @sleep --include-tags @smoke --output-dir ./tmp/venom`
+
 # Export tests report
 
 You can export your testsuite results as a report in several available formats: xUnit (XML), JSON, YAML, TAP.
@@ -810,6 +828,29 @@ $ venom run test.yml
   • cat json SUCCESS
     [info] the value of result.systemoutjson is map[foo:bar] (exec.yml:34)
 ```
+
+## Anchors
+
+If you have some code that is common to several test cases within your test suite, you might consider using YAML anchors to avoid duplicating the same code through all your test cases.
+Here's how you can reuse a block of code using anchors and be more specific afterwards:
+
+```
+default-settings: &default
+  timeout: 60
+  retries: 3
+  logging: verbose
+
+server1:
+  <<: *default
+  host: server1.example.com
+
+server2:
+  <<: *default
+  host: server2.example.com
+  retries: 5  # Overrides the default retries
+```
+
+Note that the anchor is declared with `&` char and refered to with alias `<<: *${anchor-declared-name}`.
 
 ## Skip testcase and teststeps
 

--- a/cmd/venom/run/cmd.go
+++ b/cmd/venom/run/cmd.go
@@ -43,6 +43,8 @@ var (
 	stopOnFailureFlag *bool
 	htmlReportFlag    *bool
 	verboseFlag       *int
+	includeTagsFlag   *[]string
+	excludeTagsFlag   *[]string
 )
 
 func init() {
@@ -54,6 +56,8 @@ func init() {
 	variablesFlag = Cmd.Flags().StringArray("var", nil, "--var cds='cds -f config.json' --var cds2='cds -f config.json'")
 	outputDirFlag = Cmd.PersistentFlags().String("output-dir", "", "Output Directory: create tests results file inside this directory")
 	libDirFlag = Cmd.PersistentFlags().String("lib-dir", "", "Lib Directory: can contain user executors. example:/etc/venom/lib:$HOME/venom.d/lib")
+	includeTagsFlag = Cmd.PersistentFlags().StringSliceP("include-tags", "t", nil, "Run tests that match any of the given tags (e.g., --include-tags @negative,@smoke)")
+	excludeTagsFlag = Cmd.PersistentFlags().StringSliceP("exclude-tags", "e", nil, "Skip tests that match any of the given tags (e.g., --exclude-tags @negative,@smoke)")
 }
 
 func initArgs(cmd *cobra.Command) {
@@ -344,6 +348,13 @@ var Cmd = &cobra.Command{
 		v.StopOnFailure = stopOnFailure
 		v.HtmlReport = htmlReport
 		v.Verbose = verbose
+		if includeTagsFlag != nil {
+            v.IncludedTags = append(v.IncludedTags, *includeTagsFlag...)
+        }
+
+        if excludeTagsFlag != nil {
+            v.ExcludedTags = append(v.ExcludedTags, *excludeTagsFlag...)
+        }
 
 		if err := v.InitLogger(); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/tests/tags.yml
+++ b/tests/tags.yml
@@ -1,0 +1,32 @@
+name: Exec testsuite
+testcases:
+- name: testA
+  tags: ["@negative"]
+  steps:
+  - type: exec
+    script: echo 'foo with a bar here'
+    info:
+      - this a first info
+      - and a second...
+    assertions:
+    - result.code ShouldEqual 0
+    - result.timeseconds ShouldBeLessThan 1
+    vars:
+      myvariable:
+        from: result.systemout
+        regex: foo with a ([a-z]+) here
+
+- name: testB
+  tags: ["@negative", "@smoke"]
+  steps:
+  - type: exec
+    script: echo {{.testA.myvariable}}
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring bar
+
+- name: sleep 1
+  tags: ["@sleep"]
+  steps:
+  - type: exec
+    script: sleep 1

--- a/types.go
+++ b/types.go
@@ -155,6 +155,7 @@ type TestCaseInput struct {
 	Skip         []string          `json:"skip" yaml:"skip"`
 	RawTestSteps []json.RawMessage `json:"steps" yaml:"steps"`
 	ID           string            `json:"id" yaml:"id"`
+	Tags         []string          `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type TestCase struct {

--- a/venom.go
+++ b/venom.go
@@ -74,6 +74,8 @@ type Venom struct {
 	StopOnFailure bool
 	HtmlReport    bool
 	Verbose       int
+	IncludedTags  []string
+	ExcludedTags  []string
 }
 
 var trace = color.New(color.Attribute(90)).SprintFunc()


### PR DESCRIPTION
you can now apply filtering tags to your venom tests cases and apply `--include-tags` flag in CLI command to filter-in the test cases matching your tags inputs (and/or `--exclude-tags` flag in CLI command to filter-out test cases)

here's how to declare tags on a **test case** (doesn't work on steps, `skip` feature is to be used there):
```
- name: testB
  tags: ["@negative", "@smoke"]
  steps:
```

here's how to **include** tests using `--include-tags` CLI flag (separate tags with a comma if there are several):
`./venom run venom_tests/tests.yaml --include-tags @negative`
`./venom run venom_tests/ --include-tags @negative,@smoke`

here's how to **exclude** tests using `--exclude-tags` CLI flag (separate tags with a comma if there are several):
`./venom run venom_tests/tests.yaml --exclude-tags @negative`
`./venom run venom_tests/--exclude-tags @negative,@smoke`

how reporting looks like with command `./venom run tests.yaml --include-tags @sleep,@smoke` (having 1 test matching each of them):

<img width="1387" alt="Capture d’écran 2025-04-02 à 11 19 36" src="https://github.com/user-attachments/assets/3c2bb448-a1df-486c-aaca-929186de2081" />