### PR TITLE
fix(testcase): log correctly user executors info - fixes #699

### DIFF
--- a/process_testcase.go
+++ b/process_testcase.go
@@ -417,8 +417,13 @@ func (v *Venom) setTestStepName(ts *TestStepResult, e ExecutorRunner, step TestS
 
 // Print a single step result (if verbosity is enabled)
 func (v *Venom) printTestStepResult(tc *TestCase, ts *TestStepResult, tsIn *TestStepResult, stepNumber int, mustAssertionFailed bool) {
-	if tsIn != nil {
-		tsIn.appendFailure(ts.Errors...)
+	fromUserExecutor := tsIn != nil
+	if fromUserExecutor {
+		// move back up user executor errors to parent test step for later logging
+		tsIn.Errors = append(tsIn.Errors, ts.Errors...)
+
+		// move back up user executor logs to parent test step for later logging
+		tsIn.ComputedInfo = append(tsIn.ComputedInfo, ts.ComputedInfo...)
 	} else if v.Verbose >= 1 {
 		if len(ts.Errors) > 0 {
 			v.Println(" %s", Red(StatusFail))


### PR DESCRIPTION
Fixes an issue where `info` from user executors (and sub executors) aren't logged since v1.2.0-beta and logging refactor.

Proposals:
1. Move back up logs from user executors to parent teststep and let the teststep itself log the infos (current implementation)
2. Edit condition with `v.Verbose >=1` to make the user executor log its own logs, it will however needs checking to avoid relogging test step result (PASS, FAIL, SKIP).

Feel free to ask for whichever fix, I will take care of the implementation.

Tested with:

```sh
go build ./cmd/venom
./venom run --lib-dir=tests/lib ./tests/user_executor_many.yml -v
          [trac] writing venom.30.log
 • Many user executor (./tests/user_executor_many.yml)
        • info
                • exec PASS
                  [info] value foo vars foo_from_vars
        • mytc
                • userExecutorA PASS
                  [info] value on A: foo_from_vars
                  [info] value on B: foo_from_vars_on_b
final status: PASS
```

```sh
go build ./cmd/venom
./venom run --lib-dir=tests/lib ./tests/user_executor_many.yml -vv
          [trac] writing venom.31.log
 • Many user executor (./tests/user_executor_many.yml)
        • info
                • exec PASS
                  [info] value foo vars foo_from_vars
                  [trac] writing user_executor_many.info.testcase.1.step.1.0.dump.json
        • mytc
                • userExecutorA PASS
                  [info] value on A: foo_from_vars
                  [info] value on B: foo_from_vars_on_b
                  [trac] writing user_executor_many.mytc.testcase.2.step.1.0.dump.json
final status: PASS
```

Logs files:

```txt
May 28 18:35:57.236 [DEBU] [Many user executor] [mytc] [exec] teststep exec '/bin/sh /tmp/venom-4171763483'
May 28 18:35:57.237 [DEBU] [Many user executor] [mytc] [exec] result of executor: {foo_from_vars <nil>  <nil>  0 0.000873677}
May 28 18:35:57.238 [INFO] [Many user executor] [mytc] [exec] value on A: foo_from_vars%!(EXTRA <nil>)
May 28 18:35:57.238 [INFO] [Many user executor] [mytc] [userExecutorA] Step "exec" result is "PASS"
May 28 18:35:57.238 [INFO] [Many user executor] [mytc] [userExecutorA] Step #2 content is: {"foo":"foo_from_vars_on_b","type":"userExecutorB"}
May 28 18:35:57.238 [DEBU] [Many user executor] [mytc] [userExecutorB] running user executor userExecutorB
May 28 18:35:57.238 [DEBU] [Many user executor] [mytc] [userExecutorB] with vars: map[__Len__:11 __Type__:Map foo:foo_from_vars input.foo:foo_from_vars_on_b venom.datetime:2025-05-28T18:35:57Z venom.executable:/home/debian/workspaces/github.com/kilianpaquier/venom/venom venom.executor.filename:tests/lib/user_executor_B.yml venom.executor.name:userExecutorB venom.libdir:tests/lib venom.outputdir: venom.testcase:userExecutorB venom.testsuite:Many user executor venom.testsuite.filename:user_executor_many.yml venom.testsuite.filepath:./tests/user_executor_many.yml venom.testsuite.name:Many user executor venom.testsuite.shortName:user_executor_many venom.testsuite.totalSteps:2 venom.testsuite.workdir:/home/debian/workspaces/github.com/kilianpaquier/venom/tests venom.timestamp:1748457357]
May 28 18:35:57.238 [INFO] [Many user executor] [mytc] [userExecutorB] Step #1 content is: {"info":"value on B: foo_from_vars_on_b","script":"echo 'foo_from_vars_on_b'"}
May 28 18:35:57.239 [DEBU] [Many user executor] [mytc] [exec] work with tmp file /tmp/venom-2355295364
May 28 18:35:57.239 [DEBU] [Many user executor] [mytc] [exec] teststep exec '/bin/sh /tmp/venom-2355295364'
May 28 18:35:57.240 [DEBU] [Many user executor] [mytc] [exec] result of executor: {foo_from_vars_on_b <nil>  <nil>  0 0.000831407}
May 28 18:35:57.240 [INFO] [Many user executor] [mytc] [exec] value on B: foo_from_vars_on_b%!(EXTRA <nil>)
```