### PR TITLE
fix(reports): use filepath.Join instead or linux sep or path.Join for file that will be written on OS - fixes #794

### DIFF
--- a/process_teststep.go
+++ b/process_teststep.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/gosimple/slug"
@@ -57,11 +57,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 				Error(ctx, "unable to marshal result: %v", err)
 			}
 
-			oDir := v.OutputDir
-			if oDir == "" {
-				oDir = "."
-			}
-			filename := path.Join(oDir, fmt.Sprintf("%s.%s.testcase.%d.step.%d.%d.dump.json", slug.Make(StringVarFromCtx(ctx, "venom.testsuite.shortName")), slug.Make(tc.Name), tc.number, stepNumber, rangedIndex))
+			filename := filepath.Join(v.OutputDir, fmt.Sprintf("%s.%s.testcase.%d.step.%d.%d.dump.json", slug.Make(StringVarFromCtx(ctx, "venom.testsuite.shortName")), slug.Make(tc.Name), tc.number, stepNumber, rangedIndex))
 
 			if err := os.WriteFile(filename, []byte(HideSensitive(ctx, string(output))), 0o644); err != nil {
 				Error(ctx, "Error while creating file %s: %v", filename, err)

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime/pprof"
 	"time"
 
@@ -14,12 +15,8 @@ import (
 
 func (v *Venom) runTestSuite(ctx context.Context, ts *TestSuite) error {
 	if v.Verbose == 3 {
-		var filename, filenameCPU, filenameMem string
-		if v.OutputDir != "" {
-			filename = v.OutputDir + "/"
-		}
-		filenameCPU = filename + "pprof_cpu_profile_" + ts.Filename + ".prof"
-		filenameMem = filename + "pprof_mem_profile_" + ts.Filename + ".prof"
+		filenameCPU := filepath.Join(v.OutputDir, "pprof_cpu_profile_"+ts.Filename+".prof")
+		filenameMem := filepath.Join(v.OutputDir, "pprof_mem_profile_"+ts.Filename+".prof")
 		fCPU, errCPU := os.Create(filenameCPU)
 		fMem, errMem := os.Create(filenameMem)
 		if errCPU != nil || errMem != nil {

--- a/venom_output.go
+++ b/venom_output.go
@@ -7,7 +7,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -109,9 +108,8 @@ func (v *Venom) OutputResult() error {
 			return errors.New("Error: you have to use the --html-report flag")
 		}
 
-		fname := strings.TrimSuffix(ts.Filepath, filepath.Ext(ts.Filepath))
-		fname = strings.ReplaceAll(fname, "/", "_")
-		filename := path.Join(v.OutputDir, "test_results_"+fname+"."+v.OutputFormat)
+		fname := strings.TrimSuffix(filepath.Base(ts.Filepath), filepath.Ext(ts.Filepath))
+		filename := filepath.Join(v.OutputDir, "test_results_"+fname+"."+v.OutputFormat)
 		if err := os.WriteFile(filename, data, 0o600); err != nil {
 			return fmt.Errorf("Error while creating file %s: %v", filename, err)
 		}


### PR DESCRIPTION
Fixes an issue for Windows where report files can't be written since we were replacing / by _ and not taking into account Windows separator \.

Proposals:
1. Only use testfile name and not the whole path for the test result filename (current implementation).
2. Extend replace to os.PathSeparator which will replace \ or / depending on executing OS.