### PR TITLE
feat(http): support cookies in redirects

### DIFF
--- a/executors/http/README.md
+++ b/executors/http/README.md
@@ -155,3 +155,8 @@ Example if you want to get value of `path` key of *second* element in `apis` arr
 ```yaml
 result.statuscode ShouldEqual 200
 ```
+
+## Cookies
+
+Cookies are automatically handled when following a redirect in a single step.
+They are not supported between successive steps.

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -172,7 +173,14 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 		tr.Proxy = http.ProxyURL(proxyURL)
 	}
 
-	client := &http.Client{Transport: tr}
+	// cookie jar can be used with redirects in the same call
+	// this doesn't support cross steps cookies.
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Transport: tr, Jar: jar}
 	if e.NoFollowRedirect {
 		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse


### PR DESCRIPTION
This PR aims at supporting cookies in same-step redirects.
It does not handle cookies more globally (across steps).