### PR TITLE
Feature/generate failure link

### DIFF
--- a/executors/ovhapi/README.md
+++ b/executors/ovhapi/README.md
@@ -76,7 +76,7 @@ result.timeseconds
 result.statuscode
 result.body
 result.bodyjson
-result.error
+result.err
 ```
 - result.timeseconds: execution duration
 - result.err: if exists, this field contains error

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -275,7 +275,7 @@ loopRawTestSteps:
 				tsResult.appendError(err)
 				Error(ctx, "unable to parse step #%d: %v", stepNumber, err)
 				Error(ctx, content, nil)
-				v.printTestStepResult(tc, tsResult, tsIn, stepNumber, false)
+				v.printTestStepResult(ctx, tc, tsResult, tsIn, stepNumber, false)
 				break loopRawTestSteps
 			}
 
@@ -297,7 +297,7 @@ loopRawTestSteps:
 			if err != nil {
 				tsResult.appendError(err)
 				Error(ctx, "unable to get executor: %v", err)
-				v.printTestStepResult(tc, tsResult, tsIn, stepNumber, false)
+				v.printTestStepResult(ctx, tc, tsResult, tsIn, stepNumber, false)
 				break loopRawTestSteps
 			}
 
@@ -372,10 +372,10 @@ loopRawTestSteps:
 				if isRequired {
 					failure := newFailure(ctx, *tc, stepNumber, rangedIndex, "", errors.New("At least one required assertion failed, skipping remaining steps"))
 					tsResult.appendFailure(*failure)
-					v.printTestStepResult(tc, tsResult, tsIn, stepNumber, true)
+					v.printTestStepResult(ctx, tc, tsResult, tsIn, stepNumber, true)
 					return
 				}
-				v.printTestStepResult(tc, tsResult, tsIn, stepNumber, false)
+				v.printTestStepResult(ctx, tc, tsResult, tsIn, stepNumber, false)
 				continue
 			}
 
@@ -388,7 +388,7 @@ loopRawTestSteps:
 				Error(ctx, "unable to process variable assignments: %v", errAssignment)
 			}
 
-			v.printTestStepResult(tc, tsResult, tsIn, stepNumber, false)
+			v.printTestStepResult(ctx, tc, tsResult, tsIn, stepNumber, false)
 
 			if errAssignment != nil {
 				break loopRawTestSteps
@@ -416,7 +416,7 @@ func (v *Venom) setTestStepName(ts *TestStepResult, e ExecutorRunner, step TestS
 }
 
 // Print a single step result (if verbosity is enabled)
-func (v *Venom) printTestStepResult(tc *TestCase, ts *TestStepResult, tsIn *TestStepResult, stepNumber int, mustAssertionFailed bool) {
+func (v *Venom) printTestStepResult(ctx context.Context, tc *TestCase, ts *TestStepResult, tsIn *TestStepResult, stepNumber int, mustAssertionFailed bool) {
 	fromUserExecutor := tsIn != nil
 	if fromUserExecutor {
 		// move back up user executor errors to parent test step for later logging

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -433,6 +433,10 @@ func (v *Venom) printTestStepResult(tc *TestCase, ts *TestStepResult, tsIn *Test
 			for _, f := range ts.Errors {
 				v.Println(" \t\t  %s", Yellow(f.Value))
 			}
+			// Display failure link if available
+			if ts.FailureLink != "" {
+				v.Println(" \t\t  %s", Cyan("Failure Link: "+ts.FailureLink))
+			}
 			if mustAssertionFailed {
 				skipped := len(tc.RawTestSteps) - stepNumber
 				if skipped == 1 {

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -50,6 +50,8 @@ func (v *Venom) runTestSuite(ctx context.Context, ts *TestSuite) error {
 	ts.Vars.Add("venom.outputdir", v.OutputDir)
 	ts.Vars.Add("venom.libdir", v.LibDir)
 	ts.Vars.Add("venom.testsuite", ts.Name)
+	ts.Vars.Add("venom.failure_link_header", v.FailureLinkHeader)
+	ts.Vars.Add("venom.failure_link_template", v.FailureLinkTemplate)
 	ts.ComputedVars = H{}
 
 	ctx = context.WithValue(ctx, ContextKey("testsuite"), ts.Name)

--- a/types.go
+++ b/types.go
@@ -194,6 +194,7 @@ type TestStepResult struct {
 	ComputedInfo      []string          `json:"computedInfos" yaml:"-"`
 	AssertionsApplied AssertionsApplied `json:"assertionsApplied" yaml:"-"`
 	Retries           int               `json:"retries" yaml:"retries"`
+	FailureLink       string            `json:"failure_link,omitempty" yaml:"failure_link,omitempty"`
 
 	Systemout string    `json:"systemout"`
 	Systemerr string    `json:"systemerr"`

--- a/venom.go
+++ b/venom.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/confluentinc/bincover"
 	"github.com/fatih/color"
+	"github.com/ovh/venom/reporting"
 	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 )
@@ -65,12 +66,14 @@ type Venom struct {
 	variables H
 	secrets   H
 
-	LibDir        string
-	OutputFormat  string
-	OutputDir     string
-	StopOnFailure bool
-	HtmlReport    bool
-	Verbose       int
+	LibDir              string
+	OutputFormat        string
+	OutputDir           string
+	StopOnFailure       bool
+	HtmlReport          bool
+	Verbose             int
+	FailureLinkHeader   string
+	FailureLinkTemplate string
 }
 
 var trace = color.New(color.Attribute(90)).SprintFunc()

--- a/venom.go
+++ b/venom.go
@@ -187,32 +187,13 @@ func (v *Venom) GetExecutorRunner(ctx context.Context, ts TestStep, h H) (contex
 
 func (v *Venom) getUserExecutorFilesPath(ctx context.Context, vars map[string]string) []string {
 	var libpaths []string
-	// ensure libpaths is unique
-	seen := make(map[string]struct{})
-
 	if v.LibDir != "" {
-		for _, lp := range strings.Split(v.LibDir, string(os.PathListSeparator)) {
-			abs := strings.TrimSpace(lp)
-			if abs == "" {
-				continue
-			}
-			absPath, err := filepath.Abs(abs)
-			if err == nil {
-				seen[absPath] = struct{}{}
-				libpaths = append(libpaths, absPath)
-			}
-		}
+		p := strings.Split(v.LibDir, string(os.PathListSeparator))
+		libpaths = append(libpaths, p...)
 	}
+	libpaths = append(libpaths, path.Join(vars["venom.testsuite.workdir"], "lib"))
 
-	relLib := path.Join(vars["venom.testsuite.workdir"], "lib")
-	if absRelLib, err := filepath.Abs(relLib); err == nil {
-		if _, exists := seen[absRelLib]; !exists {
-			libpaths = append(libpaths, absRelLib)
-			seen[absRelLib] = struct{}{}
-		}
-	}
-
-	// use a map to avoid duplicates
+	//use a map to avoid duplicates
 	filepaths := make(map[string]bool)
 
 	for _, p := range libpaths {

--- a/venom_output.go
+++ b/venom_output.go
@@ -198,9 +198,8 @@ func outputXMLFormat(tests Tests, verbose int) ([]byte, error) {
 			for _, result := range tc.TestStepResults {
 				for _, failure := range result.Errors {
 					failureValue := failure.Value
-					// Add failure link to the failure message for Jenkins compatibility
 					if result.FailureLink != "" {
-						failureValue += fmt.Sprintf(" – see trace at %s", result.FailureLink)
+						failureValue += fmt.Sprintf(" – see more details at %s", result.FailureLink)
 					}
 					failureXML := FailureXML{
 						Value: failureValue,

--- a/venom_output.go
+++ b/venom_output.go
@@ -197,9 +197,15 @@ func outputXMLFormat(tests Tests, verbose int) ([]byte, error) {
 			systemerr := InnerResult{}
 			for _, result := range tc.TestStepResults {
 				for _, failure := range result.Errors {
-					failuresXML = append(failuresXML, FailureXML{
-						Value: failure.Value,
-					})
+					failureValue := failure.Value
+					// Add failure link to the failure message for Jenkins compatibility
+					if result.FailureLink != "" {
+						failureValue += fmt.Sprintf(" – see trace at %s", result.FailureLink)
+					}
+					failureXML := FailureXML{
+						Value: failureValue,
+					}
+					failuresXML = append(failuresXML, failureXML)
 				}
 				if len(result.Errors) > 0 {
 					appendCleanValue(&systemout.Value, result.Systemout)

--- a/venom_output.html
+++ b/venom_output.html
@@ -355,6 +355,11 @@
               r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#errors-'+i+''+j+'")>Errors</a>';
               r += '</li>';
             }
+            if (result.failure_link && result.failure_link !== '') {
+              r += '<li class="nav-item">';
+              r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#failure-link-'+i+''+j+'")>Failure Link</a>';
+              r += '</li>';
+            }
             if (result.raw && result.raw !== '') {
               r += '<li class="nav-item">';
               r += '<a class="nav-link" aria-current="page" href="#" data-bs-toggle="collapse" onclick=toggle("#raw-'+i+''+j+'")>Raw</a>';
@@ -405,6 +410,11 @@
                 r += ' <code class="nt">'+result.errors[k].value+'</code></li>';
               }
               r += '</ul></div>';
+            }
+            if (result.failure_link && result.failure_link !== '') {
+              r += '<div id="failure-link-'+i+''+j+'" class="collapse multi-collapse p-3">';
+              r += '  <a href="'+result.failure_link+'" target="_blank" class="btn btn-primary">View Failure Details</a>';
+              r += '</div>';
             }
 
             if (result.raw && result.raw !== '') {

--- a/venom_output.html
+++ b/venom_output.html
@@ -413,7 +413,7 @@
             }
             if (result.failure_link && result.failure_link !== '') {
               r += '<div id="failure-link-'+i+''+j+'" class="collapse multi-collapse p-3">';
-              r += '  <a href="'+result.failure_link+'" target="_blank" class="btn btn-primary">View Failure Details</a>';
+              r += '  <a href="'+result.failure_link+'" target="_blank" class="btn btn-primary btn-sm">View Failure Details</a>';
               r += '</div>';
             }
 


### PR DESCRIPTION
# Configurable Failure Links Feature

## Overview

The Configurable Failure Links feature enables Venom to automatically generate clickable links in test failure reports using values extracted from **HTTP** **response** headers. This saves QA and SDET engineers time by surfacing relevant external resources (e.g., trace dashboards, logs, issue trackers) directly in the failure output.

## Features

- **Automatic link generation**: Extract a configured **response** header value and inject it into a user-defined URL template when test assertions fail
- **Configurable**: Support both YAML config and CLI flags for template and header key
- **Visibility**: Present the link in CLI output, HTML/JSON reports

### From Manual Link Construction

Before:
```bash
# Manual process
venom run tests.yml
# Copy header value from output
# Manually construct URL
# Open in browser
```

After:
```bash
# Automatic process
venom run --failure-link-header="X-Request-ID" \
          --failure-link-template="https://dashboard.example.com/trace/{{header}}" \
          tests.yml
# Click the generated link in output
```

### YAML Configuration

Add the failure link configuration to your `.venomrc` file:

```yaml
failure_link_header: "X-Request-ID"
failure_link_template: "https://dashboard.example.com/trace/{{header}}"
```

### CLI Flags

Use command-line flags to configure failure links:

```bash
venom run --failure-link-header="X-Request-ID" --failure-link-template="https://dashboard.example.com/trace/{{header}}" tests.yml
```

### Environment Variables

Set environment variables for configuration:

```bash
export FAILURE_LINK_HEADER="X-Request-ID"
export FAILURE_LINK_TEMPLATE="https://dashboard.example.com/trace/{{header}}"
venom run tests.yml
```

### Advanced Template Usage

You can use the `{{header}}` placeholder in any part of your template, including:

- **URL parameters**: `https://example.com/search?q={{header}}`
- **Query strings**: `query:(language:kuery,query:'requestId:%20{{header}}')`
- **Path segments**: `https://logs.example.com/trace/{{header}}/details`
- **Complex queries**: `https://kibana.example.com/app/discover#/?_a=(query:(language:kuery,query:'requestId:%20{{header}}'))`

Potential future improvements:
- Support for multiple header placeholders (e.g., `{{header1}}`, `{{header2}}`)
- Custom header value transformations
- Integration with more external systems
- Template validation at startup
- Support for non-HTTP executors
