### PR TITLE
feat(assertions): support custom assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Venom is a CLI (Command Line Interface) that aims to create, manage and run your
   - [Assertions](#assertions)
     - [Keywords](#keywords)
       - [`Must` keywords](#must-keywords)
+      - [Custom assertions](#custom-assertions)
     - [Using logical operators](#using-logical-operators)
 - [Write and run your first test suite](#write-and-run-your-first-test-suite)
 - [Export tests report](#export-tests-report)
@@ -693,6 +694,45 @@ Example:
     assertions:
       - result.code MustEqual 0
   # Remaining steps in this context will not be executed
+```
+
+#### Custom assertions
+
+It is possible to use the [user defined executors syntax](#user-defined-executors) and prefixing your executor name with `Should` to create a new custom assertion keyword. 
+
+Example:
+```yml
+# lib/ShouldBeHttp2XX.yml
+executor: ShouldBeHttp2XX
+steps:
+  - assertions:
+    - a ShouldBeGreaterThanOrEqualTo 200
+    - a ShouldBeLessThan 300
+```
+
+You may also include additional steps like a regular user defined executor.
+
+Custom assertions are executed in an entirely clean context, containing only the following variables:
+- `a`: the left operand
+- `b`: the (first) right operand
+- `argv`: the rights operands
+
+If you need to be compatible with the `input` syntax of user defined executors, you could use the `argv` as the default value and access these through the regular `input.*` syntax. 
+```yaml
+input:
+  test: "{{.argv.argv1}}"
+```
+
+To call a registered custom assertions, just use its registered name in the `assertions` array, like any built-in assertion keyword.
+
+```yml
+# test.yml
+testcases:
+- steps:
+  - type: http
+    url: https://example.com
+    assertions:
+    - result.statuscode ShouldBeHttp2XX
 ```
 
 ### Using logical operators

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Venom is a CLI (Command Line Interface) that aims to create, manage and run your
   - [Assertions](#assertions)
     - [Keywords](#keywords)
       - [`Must` keywords](#must-keywords)
-      - [Custom assertions](#custom-assertions)
+      - [User assertions](#user-assertions)
     - [Using logical operators](#using-logical-operators)
 - [Write and run your first test suite](#write-and-run-your-first-test-suite)
 - [Export tests report](#export-tests-report)
@@ -696,9 +696,9 @@ Example:
   # Remaining steps in this context will not be executed
 ```
 
-#### Custom assertions
+#### User assertions
 
-It is possible to use the [user defined executors syntax](#user-defined-executors) and prefixing your executor name with `Should` to create a new custom assertion keyword. 
+It is possible to use the [user defined executors syntax](#user-defined-executors) and prefixing your executor name with `Should` to create a new "user assertion" keyword. 
 
 Example:
 ```yml
@@ -712,7 +712,7 @@ steps:
 
 You may also include additional steps like a regular user defined executor.
 
-Custom assertions are executed in an entirely clean context, containing only the following variables:
+User assertions are executed in an entirely clean context, containing only the following variables:
 - `a`: the left operand
 - `b`: the (first) right operand
 - `argv`: the rights operands
@@ -723,7 +723,7 @@ input:
   test: "{{.argv.argv1}}"
 ```
 
-To call a registered custom assertions, just use its registered name in the `assertions` array, like any built-in assertion keyword.
+To call a registered user assertions, just use its registered name in the `assertions` array, like any built-in assertion keyword.
 
 ```yml
 # test.yml

--- a/assertions/assertions.go
+++ b/assertions/assertions.go
@@ -1509,8 +1509,8 @@ func getTimeFromString(in interface{}) (time.Time, error) {
 	return t, nil
 }
 
-// RegisterCustomAssertFunc registers a custom assertion function
-func RegisterCustomAssertFunc(name string, ux AssertFunc) error {
+// RegisterUserAssertFunc registers a user assertion function
+func RegisterUserAssertFunc(name string, ux AssertFunc) error {
 	if _, ok := assertMap[name]; ok {
 		return errors.Errorf("cannot redefine existing assertion %q", name)
 	}

--- a/assertions/assertions.go
+++ b/assertions/assertions.go
@@ -1508,3 +1508,13 @@ func getTimeFromString(in interface{}) (time.Time, error) {
 
 	return t, nil
 }
+
+// RegisterCustomAssertFunc registers a custom assertion function
+func RegisterCustomAssertFunc(name string, ux AssertFunc) error {
+	if _, ok := assertMap[name]; ok {
+		return errors.Errorf("cannot redefine existing assertion %q", name)
+	}
+
+	assertMap[name] = ux
+	return nil
+}

--- a/assertions/assertions_test.go
+++ b/assertions/assertions_test.go
@@ -2438,3 +2438,37 @@ func TestShouldNotJSONEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestRegisterCustomAssertFunc(t *testing.T) {
+	var assertFunc AssertFunc
+
+	tests := []struct {
+		name    string
+		actual  string
+		wantErr bool
+	}{
+		{
+			name:   "register custom assertion",
+			actual: "ShouldCustom",
+		},
+		{
+			name:    "redefine custom assertion error",
+			actual:  "ShouldCustom",
+			wantErr: true,
+		},
+		{
+			name:    "redefine builtin assertion error",
+			actual:  "ShouldEqual",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RegisterCustomAssertFunc(tt.actual, assertFunc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RegisterCustomAssertFunc() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/assertions/assertions_test.go
+++ b/assertions/assertions_test.go
@@ -2439,7 +2439,7 @@ func TestShouldNotJSONEqual(t *testing.T) {
 	}
 }
 
-func TestRegisterCustomAssertFunc(t *testing.T) {
+func TestRegisterUserAssertFunc(t *testing.T) {
 	var assertFunc AssertFunc
 
 	tests := []struct {
@@ -2465,9 +2465,9 @@ func TestRegisterCustomAssertFunc(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := RegisterCustomAssertFunc(tt.actual, assertFunc)
+			err := RegisterUserAssertFunc(tt.actual, assertFunc)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("RegisterCustomAssertFunc() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("RegisterUserAssertFunc() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/tests/assertions/ShouldCustom.yml
+++ b/tests/assertions/ShouldCustom.yml
@@ -1,0 +1,8 @@
+name: Assertions testsuite
+testcases:
+- name: test assertion ShouldCustom
+  steps:
+  - script: echo foo
+    assertions:
+    - result.systemout ShouldCustom bar qux
+    - result.systemout MustCustom bar qux

--- a/tests/lib/ShouldCustom.yml
+++ b/tests/lib/ShouldCustom.yml
@@ -1,0 +1,15 @@
+executor: ShouldCustom
+input:
+  test: "{{.argv.argv1}}"
+steps:
+  - script: echo baz
+    vars: 
+      c:
+        from: result.systemout
+  - assertions:
+    - a ShouldEqual foo
+    - b ShouldEqual bar
+    - c ShouldEqual baz
+    - input.test ShouldEqual qux
+    - argv.argv1 ShouldEqual qux
+    - argv.__Len__ ShouldEqual 2

--- a/venom.go
+++ b/venom.go
@@ -285,7 +285,7 @@ func (v *Venom) registerUserExecutors(ctx context.Context) error {
 		if strings.HasPrefix(ux.Executor, "Should") {
 			err = v.registerUserAssertFunc(ctx, ux.Executor)
 			if err != nil {
-				return errors.Wrapf(err, "unable to register user executor %q from file %q as custom assertion", ux.Executor, f)
+				return errors.Wrapf(err, "unable to register user executor %q from file %q as user assertion", ux.Executor, f)
 			}
 		}
 	}
@@ -299,7 +299,7 @@ func (v *Venom) registerUserAssertFunc(ctx context.Context, name string) error {
 		return errors.Wrapf(err, "unable to load user executor %q", name)
 	}
 
-	err = assertions.RegisterCustomAssertFunc(name, func(actual interface{}, expected ...interface{}) error {
+	err = assertions.RegisterUserAssertFunc(name, func(actual interface{}, expected ...interface{}) error {
 		// Prepare a minimal context in which the user executor can be run
 		// We only need to register the operands in the var set
 		// as parent contexts will already have been templated
@@ -325,7 +325,7 @@ func (v *Venom) registerUserAssertFunc(ctx context.Context, name string) error {
 			}
 			return errors.New(strings.Join(msg, "\n"))
 		} else if err != nil {
-			return errors.Wrapf(err, "custom assertion failed during execution")
+			return errors.Wrapf(err, "user assertion failed during execution")
 		}
 
 		return nil


### PR DESCRIPTION
This PR introduces a way to call user-defined executors directly in the `assertions` array so it's possible for end-users to create custom assertions functions.

If the custom executor name starts with `Should`, it is also automatically registered in the `assertMap` allowing its use as a regular assertion keywords

Example:
```yml
# lib/ShouldBeHttp2XX.yml
executor: ShouldBeHttp2XX 
steps:
  - assertions:
    - a ShouldBeGreaterThanOrEqualTo 200
    - a ShouldBeLessThan 300
```


```yml
# test.yml
testcases:
- steps:
  - type: http
    url: https://example.com
    assertions:
    - result.statuscode ShouldBeHttp2XX
```

The code reuses the same implementation as user defined executors which makes it a really low maintenance feature despite bringing a nice QOL change. The only difference is that the variables context is cleaned (as assertions executes independently from venom testcases) to ensure assertions are context independent and only depends on the given operands  