### PR TITLE
fix(venom): some hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ $(ALL_RESULTS_TARGETS):
 	$(info copying $(call get_results_from_target, $@) to $@)
 	@cp -f $(call get_results_from_target, $@) $@
 
-.PHONY: build lint clean testrun test dist test-xunit package
+.PHONY: build lint clean testrun test dist test-xunit package vulncheck checksums
+
+vulncheck: ## scan dependencies for known CVEs (uses golang.org/x/vuln/cmd/govulncheck)
+	@which govulncheck > /dev/null 2>&1 || go install golang.org/x/vuln/cmd/govulncheck@latest
+	govulncheck ./...
 
 build: ## build all components and push them into dist directory
 	$(info Building Component venom)
@@ -58,6 +62,10 @@ plugins: ## build all components and push them into dist directory
 	mv executors/plugins/dist/lib/* dist/lib;
 
 dist: $(ALL_DIST_TARGETS)
+
+checksums: dist ## generate checksums.txt with SHA256 of all dist binaries (sha256sum format)
+	@cd $(DIST_DIR) && sha256sum venom.* > checksums.txt
+	$(info checksums.txt generated in $(DIST_DIR))
 
 run: ## build binary for current OS only and run it. For development purpose only
 	OS=${UNAME_LOWERCASE} $(MAKE) build -C cmd/venom

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ Notice the variable `alljson`. All variables declared in output are automaticall
 Venom will load user-defined executors from the directory `lib/` relative to the testsuite path. You can add executor source paths using the flag `--lib-dir`. 
 Note that all folders listed with `--lib-dir` will be scanned recursively to find `.yml` files as user executors.
 
+Compiled Go plugins (`.so`) are **only** loaded from `--lib-dir`; they are no longer auto-discovered from `<workdir>/lib/`. The plugin name (the YAML `type:` field) must match `[A-Za-z0-9_-]+`.
+
 The user defined executors work with templating, you can check the templating result in `venom.log`. In this file, if you see an error such as `error converting YAML to JSON: yaml: line 14: found unexpected end of stream`, you probably need to adjust indentation with the templating function `indent`. 
 
 Example:

--- a/assertion.go
+++ b/assertion.go
@@ -1,11 +1,9 @@
 package venom
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -51,8 +49,8 @@ func applyAssertions(ctx context.Context, r interface{}, tc TestCase, stepNumber
 
 	isOK := true
 	assertions := []AssertionApplied{}
-	for _, assertion := range sa.Assertions {
-		errs := check(ctx, tc, stepNumber, rangedIndex, assertion, executorResult)
+	for assertionIndex, assertion := range sa.Assertions {
+		errs := check(ctx, tc, stepNumber, rangedIndex, assertionIndex, assertion, executorResult)
 		isAssertionOK := true
 		if errs != nil {
 			errors = append(errors, *errs)
@@ -128,25 +126,25 @@ func parseAssertions(ctx context.Context, s string, input interface{}) (*asserti
 }
 
 // check selects the correct assertion function to call depending on typing provided by user
-func check(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertion Assertion, r interface{}) *Failure {
+func check(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertionIndex int, assertion Assertion, r interface{}) *Failure {
 	var errs *Failure
 	switch t := assertion.(type) {
 	case string:
-		errs = checkString(ctx, tc, stepNumber, rangedIndex, assertion.(string), r)
+		errs = checkString(ctx, tc, stepNumber, rangedIndex, assertionIndex, assertion.(string), r)
 	case map[string]interface{}:
-		errs = checkBranch(ctx, tc, stepNumber, rangedIndex, assertion.(map[string]interface{}), r)
+		errs = checkBranch(ctx, tc, stepNumber, rangedIndex, assertionIndex, assertion.(map[string]interface{}), r)
 	default:
-		errs = newFailure(ctx, tc, stepNumber, rangedIndex, "", fmt.Errorf("unsupported assertion format: %v", t))
+		errs = newFailure(ctx, tc, stepNumber, rangedIndex, assertionIndex, "", fmt.Errorf("unsupported assertion format: %v", t))
 	}
 	return errs
 }
 
 // checkString evaluate a complex assertion containing logical operators
 // it recursively calls checkAssertion for each operand
-func checkBranch(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, branch map[string]interface{}, r interface{}) *Failure {
+func checkBranch(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertionIndex int, branch map[string]interface{}, r interface{}) *Failure {
 	// Extract logical operator
 	if len(branch) != 1 {
-		return newFailure(ctx, tc, stepNumber, rangedIndex, "", fmt.Errorf("expected exactly 1 logical operator but %d were provided", len(branch)))
+		return newFailure(ctx, tc, stepNumber, rangedIndex, assertionIndex, "", fmt.Errorf("expected exactly 1 logical operator but %d were provided", len(branch)))
 	}
 	var operator string
 	for k := range branch {
@@ -159,7 +157,7 @@ func checkBranch(ctx context.Context, tc TestCase, stepNumber int, rangedIndex i
 	case []interface{}:
 		operands = branch[operator].([]interface{})
 	default:
-		return newFailure(ctx, tc, stepNumber, rangedIndex, "", fmt.Errorf("expected %s operands to be an []interface{}, got %v", operator, t))
+		return newFailure(ctx, tc, stepNumber, rangedIndex, assertionIndex, "", fmt.Errorf("expected %s operands to be an []interface{}, got %v", operator, t))
 	}
 	if len(operands) == 0 {
 		return nil
@@ -170,7 +168,7 @@ func checkBranch(ctx context.Context, tc TestCase, stepNumber int, rangedIndex i
 	assertionsCount := len(operands)
 	assertionsSuccess := 0
 	for _, assertion := range operands {
-		errs := check(ctx, tc, stepNumber, rangedIndex, assertion, r)
+		errs := check(ctx, tc, stepNumber, rangedIndex, assertionIndex, assertion, r)
 		if errs != nil {
 			results = append(results, fmt.Sprintf("  - fail: %s", assertion))
 		}
@@ -203,23 +201,23 @@ func checkBranch(ctx context.Context, tc TestCase, stepNumber int, rangedIndex i
 			err = fmt.Errorf("some assertions succeeded but expected none to succeed:\n%s\n", strings.Join(results, "\n"))
 		}
 	default:
-		return newFailure(ctx, tc, stepNumber, rangedIndex, "", fmt.Errorf("unsupported assertion operator %s", operator))
+		return newFailure(ctx, tc, stepNumber, rangedIndex, assertionIndex, "", fmt.Errorf("unsupported assertion operator %s", operator))
 	}
 	if err != nil {
-		return newFailure(ctx, tc, stepNumber, rangedIndex, "", err)
+		return newFailure(ctx, tc, stepNumber, rangedIndex, assertionIndex, "", err)
 	}
 	return nil
 }
 
 // checkString evaluate a single string assertion
-func checkString(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertion string, r interface{}) *Failure {
+func checkString(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertionIndex int, assertion string, r interface{}) *Failure {
 	assert, err := parseAssertions(context.Background(), assertion, r)
 	if err != nil {
-		return newFailure(ctx, tc, stepNumber, rangedIndex, assertion, err)
+		return newFailure(ctx, tc, stepNumber, rangedIndex, assertionIndex, assertion, err)
 	}
 
 	if err := assert.Func(assert.Actual, assert.Args...); err != nil {
-		failure := newFailure(ctx, tc, stepNumber, rangedIndex, assertion, err)
+		failure := newFailure(ctx, tc, stepNumber, rangedIndex, assertionIndex, assertion, err)
 		failure.AssertionRequired = assert.Required
 		return failure
 	}
@@ -294,69 +292,6 @@ func stringToType(val string, valType interface{}) (interface{}, error) {
 		return time.ParseDuration(val)
 	}
 	return val, nil
-}
-
-func findLineNumber(filename, testcase string, stepNumber int, assertion string, infoNumber int) int {
-	countLine := 0
-	file, err := os.Open(filename)
-	if err != nil {
-		return countLine
-	}
-	defer file.Close()
-
-	lineFound := false
-	testcaseFound := false
-	commentBlock := false
-	countStep := 0
-	countInfo := 0
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		countLine++
-		line := strings.Trim(scanner.Text(), " ")
-		if strings.HasPrefix(line, "/*") {
-			commentBlock = true
-			continue
-		}
-		if strings.HasPrefix(line, "*/") {
-			commentBlock = false
-			continue
-		}
-		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//") || commentBlock {
-			continue
-		}
-		if !testcaseFound && strings.Contains(line, testcase) {
-			testcaseFound = true
-			continue
-		}
-		if testcaseFound && countStep <= stepNumber && (strings.Contains(line, "type") || strings.Contains(line, "script")) {
-			countStep++
-			continue
-		}
-
-		if testcaseFound && countStep > stepNumber {
-			if strings.Contains(line, assertion) {
-				lineFound = true
-				break
-			} else if strings.Contains(strings.ReplaceAll(line, " ", ""), "info:") {
-				countInfo++
-				if infoNumber == countInfo {
-					lineFound = true
-					break
-				}
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return countLine
-	}
-
-	if !lineFound {
-		return 0
-	}
-
-	return countLine
 }
 
 // This evaluates a string of assertions with a given vars scope, and returns a slice of failures (i.e. empty slice = all pass)

--- a/cmd/venom/update/cmd.go
+++ b/cmd/venom/update/cmd.go
@@ -1,8 +1,14 @@
 package update
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"net/http"
 	"runtime"
 	"strings"
@@ -17,6 +23,8 @@ import (
 
 var urlGitubReleases = "https://github.com/ovh/venom/releases"
 
+const checksumsAssetName = "checksums.txt"
+
 // Cmd update
 var Cmd = &cobra.Command{
 	Use:   "update",
@@ -27,7 +35,9 @@ var Cmd = &cobra.Command{
 	},
 }
 
-func getURLArtifactFromGithub() string {
+// releaseAssets returns, for the latest release, the download URL of the
+// binary for the current OS/arch and the URL of the checksums.txt file.
+func releaseAssets() (binaryURL, checksumsURL, binaryAssetName string) {
 	client := github.NewClient(nil)
 	release, resp, err := client.Repositories.GetLatestRelease(context.TODO(), "ovh", "venom")
 	if err != nil {
@@ -38,21 +48,89 @@ func getURLArtifactFromGithub() string {
 		cmd.Exit("you already have the latest release: %s", *release.TagName)
 	}
 
-	if len(release.Assets) > 0 {
-		for _, asset := range release.Assets {
-			assetName := strings.ReplaceAll(*asset.Name, ".", "-")
-			current := fmt.Sprintf("venom-%s-%s", runtime.GOOS, runtime.GOARCH)
-			if assetName == current {
-				return *asset.BrowserDownloadURL
-			}
+	current := fmt.Sprintf("venom-%s-%s", runtime.GOOS, runtime.GOARCH)
+	for _, asset := range release.Assets {
+		normalised := strings.ReplaceAll(*asset.Name, ".", "-")
+		if normalised == current {
+			binaryURL = *asset.BrowserDownloadURL
+			binaryAssetName = *asset.Name
+		}
+		if *asset.Name == checksumsAssetName {
+			checksumsURL = *asset.BrowserDownloadURL
 		}
 	}
 
-	const text = `Invalid Artifacts on latest release. Please try again in few minutes.
+	if binaryURL == "" {
+		const text = `Invalid Artifacts on latest release. Please try again in few minutes.
 If the problem persists, please open an issue on https://github.com/ovh/venom/issues
 `
-	cmd.Exit(text)
-	return ""
+		cmd.Exit(text)
+	}
+	return binaryURL, checksumsURL, binaryAssetName
+}
+
+// fetchExpectedChecksum downloads checksums.txt from the release and
+// returns the expected SHA256 (hex) for assetName. The checksums.txt
+// format is the standard `sha256sum` output: "<hex>  <filename>" lines.
+func fetchExpectedChecksum(checksumsURL, assetName string) (string, error) {
+	if checksumsURL == "" {
+		return "", fmt.Errorf("this release does not publish %s; refusing to update for security reasons", checksumsAssetName)
+	}
+	resp, err := http.Get(checksumsURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch %s: %w", checksumsAssetName, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch %s: HTTP %d", checksumsAssetName, resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Accept both "<hex>  <name>" (two spaces) and "<hex> <name>"
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		// The filename in checksums.txt may be a relative path; match on basename.
+		name := fields[1]
+		if idx := strings.LastIndexAny(name, "/\\"); idx >= 0 {
+			name = name[idx+1:]
+		}
+		if name == assetName {
+			return strings.ToLower(fields[0]), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error parsing %s: %w", checksumsAssetName, err)
+	}
+	return "", fmt.Errorf("no checksum entry for asset %q in %s", assetName, checksumsAssetName)
+}
+
+// downloadAndVerify reads the response body fully into memory, verifies its
+// SHA256 against expectedHex (constant-time compare), and returns a Reader
+// suitable for update.Apply. Memory cost is acceptable: venom binaries are
+// only a few tens of MB.
+func downloadAndVerify(body io.Reader, expectedHex string) (io.Reader, error) {
+	hasher := sha256.New()
+	var buf bytes.Buffer
+	if _, err := io.Copy(io.MultiWriter(&buf, hasher), body); err != nil {
+		return nil, fmt.Errorf("failed to download binary: %w", err)
+	}
+	got := hex.EncodeToString(hasher.Sum(nil))
+	expected, err := hex.DecodeString(expectedHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid expected checksum %q: %w", expectedHex, err)
+	}
+	gotBytes := hasher.Sum(nil)
+	if subtle.ConstantTimeCompare(gotBytes, expected) != 1 {
+		return nil, fmt.Errorf("checksum mismatch: expected %s, got %s", expectedHex, got)
+	}
+	return &buf, nil
 }
 
 func getContentType(resp *http.Response) string {
@@ -65,27 +143,37 @@ func getContentType(resp *http.Response) string {
 }
 
 func doUpdate() {
-	url := getURLArtifactFromGithub()
-	fmt.Printf("Url to update venom: %s\n", url)
+	binaryURL, checksumsURL, assetName := releaseAssets()
+	fmt.Printf("Url to update venom: %s\n", binaryURL)
 
-	resp, err := http.Get(url)
+	expected, err := fetchExpectedChecksum(checksumsURL, assetName)
 	if err != nil {
-		cmd.Exit("Error when downloading venom from url %s: %v\n", url, err)
+		cmd.Exit("%s\nDownload the binary manually from %s if needed.\n", err.Error(), urlGitubReleases)
 	}
 
+	resp, err := http.Get(binaryURL)
+	if err != nil {
+		cmd.Exit("Error when downloading venom from url %s: %v\n", binaryURL, err)
+	}
+	defer resp.Body.Close()
+
 	if contentType := getContentType(resp); contentType != "application/octet-stream" {
-		fmt.Printf("Url: %s\n", url)
+		fmt.Printf("Url: %s\n", binaryURL)
 		cmd.Exit("Invalid Binary (Content-Type: %s). Please try again or download it manually from %s\n", contentType, urlGitubReleases)
 	}
 
 	if resp.StatusCode != 200 {
-		cmd.Exit("Error http code: %d, url called: %s\n", resp.StatusCode, url)
+		cmd.Exit("Error http code: %d, url called: %s\n", resp.StatusCode, binaryURL)
 	}
 
-	fmt.Printf("Getting latest release from: %s ...\n", url)
-	defer resp.Body.Close()
-	if err = update.Apply(resp.Body, update.Options{}); err != nil {
-		cmd.Exit("Error when updating venom from url: %s err:%s\n", url, err.Error())
+	fmt.Printf("Getting latest release from: %s ...\n", binaryURL)
+	verified, err := downloadAndVerify(resp.Body, expected)
+	if err != nil {
+		cmd.Exit("Error when verifying venom binary from url: %s err:%s\n", binaryURL, err.Error())
+	}
+
+	if err = update.Apply(verified, update.Options{}); err != nil {
+		cmd.Exit("Error when updating venom from url: %s err:%s\n", binaryURL, err.Error())
 	}
 	fmt.Println("Update done.")
 }

--- a/executors/dbfixtures/dbfixtures.go
+++ b/executors/dbfixtures/dbfixtures.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"path"
 
 	fixtures "github.com/go-testfixtures/testfixtures/v3"
 	"github.com/mitchellh/mapstructure"
@@ -73,13 +72,16 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, er
 	if len(e.Schemas) != 0 {
 		for _, s := range e.Schemas {
 			venom.Debug(ctx, "loading schema from file %s\n", s)
-			s = path.Join(workdir, s)
-			sbytes, errs := os.ReadFile(s)
+			schemaPath, errResolve := venom.ResolveWorkdirPath(workdir, s)
+			if errResolve != nil {
+				return nil, errResolve
+			}
+			sbytes, errs := os.ReadFile(schemaPath)
 			if errs != nil {
 				return nil, errs
 			}
 			if _, err = db.Exec(string(sbytes)); err != nil {
-				return nil, errors.Wrapf(err, "failed to exec schema from file %q", s)
+				return nil, errors.Wrapf(err, "failed to exec schema from file %q", schemaPath)
 			}
 		}
 	} else if e.Migrations != "" {
@@ -89,7 +91,10 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, er
 			migrate.SetTable(e.MigrationsTable)
 		}
 
-		dir := path.Join(workdir, e.Migrations)
+		dir, errResolve := venom.ResolveWorkdirPath(workdir, e.Migrations)
+		if errResolve != nil {
+			return nil, errResolve
+		}
 		migrations := &migrate.FileMigrationSource{
 			Dir: dir,
 		}
@@ -124,26 +129,34 @@ func (e Executor) GetDefaultAssertions() venom.StepAssertions {
 // and switch to the list of files if no folder was specified.
 func loadFixtures(ctx context.Context, db *sql.DB, files []string, folder string, dialect func(*fixtures.Loader) error, workdir string) error {
 	if folder != "" {
-		venom.Debug(ctx, "loading fixtures from folder %s\n", path.Join(workdir, folder))
+		folderPath, err := venom.ResolveWorkdirPath(workdir, folder)
+		if err != nil {
+			return err
+		}
+		venom.Debug(ctx, "loading fixtures from folder %s\n", folderPath)
 		loader, err := fixtures.New(
 			// By default the package refuse to load if the database
 			// does not contains "test" to avoid wiping a production db.
 			fixtures.DangerousSkipTestDatabaseCheck(),
 			fixtures.Database(db),
-			fixtures.Directory(path.Join(workdir, folder)),
+			fixtures.Directory(folderPath),
 			dialect)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create folder loader")
 		}
 		if err = loader.Load(); err != nil {
-			return errors.Wrapf(err, "failed to load fixtures from folder %q", path.Join(workdir, folder))
+			return errors.Wrapf(err, "failed to load fixtures from folder %q", folderPath)
 		}
 		return nil
 	}
 	if len(files) != 0 {
 		venom.Debug(ctx, "loading fixtures from files: %v\n", files)
 		for i := range files {
-			files[i] = path.Join(workdir, files[i])
+			resolved, err := venom.ResolveWorkdirPath(workdir, files[i])
+			if err != nil {
+				return err
+			}
+			files[i] = resolved
 		}
 		loader, err := fixtures.New(
 			// By default the package refuse to load if the database

--- a/executors/dbfixtures/dbfixtures.go
+++ b/executors/dbfixtures/dbfixtures.go
@@ -14,7 +14,7 @@ import (
 	// SQL drivers.
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 
 	"github.com/ovh/venom"
 )
@@ -52,10 +52,16 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, er
 	if err := mapstructure.Decode(step, &e); err != nil {
 		return nil, err
 	}
-	// Connect to the database and ping it.
-	venom.Debug(ctx, "connecting to database %s, %s\n", e.Database, e.DSN)
+	// Map user-facing database name to the registered Go driver name.
+	driverName := e.Database
+	if driverName == "sqlite3" {
+		driverName = "sqlite" // modernc.org/sqlite registers under "sqlite"
+	}
 
-	db, err := sql.Open(e.Database, e.DSN)
+	// Connect to the database and ping it.
+	venom.Debug(ctx, "connecting to database %s, %s\n", e.Database, venom.RedactURI(e.DSN))
+
+	db, err := sql.Open(driverName, e.DSN)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to connect to database")
 	}
@@ -194,7 +200,10 @@ func getDialect(name string, skipResetSequences bool) func(*fixtures.Loader) err
 		}
 	case "mysql":
 		return fixtures.Dialect("mysql")
-	case "sqlite3":
+	case "sqlite", "sqlite3":
+		// Both names are accepted: "sqlite" matches the modernc.org/sqlite
+		// driver name, "sqlite3" is kept for testsuite backward compatibility
+		// (the testfixtures dialect identifier remains "sqlite3").
 		return fixtures.Dialect("sqlite3")
 	}
 	return nil

--- a/executors/exec/exec.go
+++ b/executors/exec/exec.go
@@ -2,9 +2,12 @@ package exec
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -97,47 +100,42 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 			opts = append(opts, "-ExecutionPolicy", "Bypass", "-Command")
 		}
 
-		// Create a tmp file
-		tmpscript, err := os.CreateTemp(os.TempDir(), "venom-")
+		// Create the tmp script file atomically with the right permissions
+		// (O_EXCL avoids races, 0o700 keeps the script private to the user).
+		nameBytes := make([]byte, 16)
+		if _, err := rand.Read(nameBytes); err != nil {
+			return nil, fmt.Errorf("cannot generate tmp name: %s", err)
+		}
+		baseName := "venom-" + hex.EncodeToString(nameBytes)
+		if runtime.GOOS == "windows" {
+			baseName += ".PS1"
+		}
+		scriptPath := filepath.Join(os.TempDir(), baseName)
+		tmpscript, err := os.OpenFile(scriptPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o700)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create tmp file: %s", err)
 		}
 
-		// Put script in file
-		venom.Debug(ctx, "work with tmp file %s", tmpscript.Name())
+		venom.Debug(ctx, "work with tmp file %s", scriptPath)
 		n, err := tmpscript.Write([]byte(scriptContent))
 		if err != nil || n != len(scriptContent) {
+			tmpscript.Close()
+			os.Remove(scriptPath)
 			if err != nil {
 				return nil, fmt.Errorf("cannot write script: %s", err)
 			}
 			return nil, fmt.Errorf("cannot write all script: %d/%d", n, len(scriptContent))
 		}
-
-		oldPath := tmpscript.Name()
 		tmpscript.Close()
-		var scriptPath string
+
 		if runtime.GOOS == "windows" {
-			// Remove all .txt Extensions, there is not always a .txt extension
-			newPath := strings.ReplaceAll(oldPath, ".txt", "")
-			// and add .PS1 extension
-			newPath += ".PS1"
-			if err := os.Rename(oldPath, newPath); err != nil {
-				return nil, fmt.Errorf("cannot rename script to add powershell extension, aborting")
-			}
 			// This aims to stop a the very first error and return the right exit code
-			psCommand := fmt.Sprintf("& { $ErrorActionPreference='Stop'; & %s ;exit $LastExitCode}", newPath)
-			scriptPath = newPath
+			psCommand := fmt.Sprintf("& { $ErrorActionPreference='Stop'; & %s ;exit $LastExitCode}", scriptPath)
 			opts = append(opts, psCommand)
 		} else {
-			scriptPath = oldPath
 			opts = append(opts, scriptPath)
 		}
 		defer os.Remove(scriptPath)
-
-		// Chmod file
-		if err := os.Chmod(scriptPath, 0o700); err != nil {
-			return nil, fmt.Errorf("cannot chmod script %s: %s", scriptPath, err)
-		}
 
 		command = shell
 	}
@@ -161,6 +159,12 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 	}
 
 	result := Result{}
+
+	// The two goroutines below are the only writers of result.Systemout and
+	// result.Systemerr. The parent reads these fields only after <-outchan
+	// and <-errchan have unblocked, which happens-after their respective
+	// close. Do not access result.Systemout / result.Systemerr from any
+	// other goroutine while the command is running.
 	outchan := make(chan bool)
 
 	go func() {
@@ -194,7 +198,7 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 			if n > 0 {
 				chunk := buf[:n]
 				sb.Write(chunk)
-				venom.Debug(ctx, venom.HideSensitive(ctx, string(chunk)))
+				venom.Debug(ctx, "%s", venom.HideSensitive(ctx, string(chunk)))
 			}
 			if err != nil {
 				break

--- a/executors/http/README.md
+++ b/executors/http/README.md
@@ -23,9 +23,9 @@ In your yaml file, you can use:
   - no_follow_redirect (optional): indicates that you don't want to follow Location if server returns a Redirect (301/302/...)
   - skip_body: skip the body and bodyjson result
   - skip_headers: skip the headers result
-  - tls_client_cert (optional): a chain of certificates to identify the caller, first certificate in the chain is considered as the leaf, followed by intermediates. Setting it enables mutual TLS authentication. Set the PEM content or the path to the PEM file.
-  - tls_client_key (optional): private key corresponding to the certificate. Set the PEM content or the path to the PEM file.
-  - tls_root_ca (optional): defines additional root CAs to perform the call. Can contain multiple CAs concatenated together. Set the PEM content or the path to the PEM file.
+  - tls_client_cert (optional): a chain of certificates to identify the caller, first certificate in the chain is considered as the leaf, followed by intermediates. Setting it enables mutual TLS authentication. Provide either inline PEM content (must contain "-----BEGIN") or a path relative to the testsuite workdir. Absolute paths are rejected.
+  - tls_client_key (optional): private key corresponding to the certificate. Provide either inline PEM content or a path relative to the testsuite workdir.
+  - tls_root_ca (optional): additional root CAs used for the call. Can contain multiple CAs concatenated together. Provide either inline PEM content or a path relative to the testsuite workdir.
 
 ```
 

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -428,6 +428,25 @@ func isBodyJSONSupported(resp *http.Response) bool {
 	return strings.Contains(contentType, "application/json") || strings.HasSuffix(contentType, "+json")
 }
 
+// loadPEMOrFile decides whether the given value is inline PEM content or a
+// path to a file under the testsuite workdir. Inline PEM (recognised by the
+// "-----BEGIN" marker) is returned as-is. Otherwise the value is treated as
+// a relative path, sanitised against escapes, and read from disk.
+func loadPEMOrFile(workdir, value, fieldName string) ([]byte, error) {
+	if strings.Contains(value, "-----BEGIN") {
+		return []byte(value), nil
+	}
+	resolved, err := venom.ResolveWorkdirPath(workdir, value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s path: %w", fieldName, err)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read %s from file %s: %w", fieldName, resolved, err)
+	}
+	return data, nil
+}
+
 func (e Executor) TLSOptions(ctx context.Context) ([]func(*http.Transport) error, error) {
 	var opts []func(*http.Transport) error
 
@@ -438,51 +457,28 @@ func (e Executor) TLSOptions(ctx context.Context) ([]func(*http.Transport) error
 	workdir := venom.StringVarFromCtx(ctx, "venom.testsuite.workdir")
 
 	if e.TLSRootCA != "" {
-		TLSRootCAFilepath := e.TLSRootCA
-		if !filepath.IsAbs(e.TLSRootCA) {
-			TLSRootCAFilepath = filepath.Join(workdir, e.TLSRootCA)
+		data, err := loadPEMOrFile(workdir, e.TLSRootCA, "TLSRootCA")
+		if err != nil {
+			return nil, err
 		}
-		var TLSRootCA []byte
-		if _, err := os.Stat(TLSRootCAFilepath); err == nil {
-			TLSRootCA, err = os.ReadFile(TLSRootCAFilepath)
-			if err != nil {
-				return nil, fmt.Errorf("unable to read TLSRootCA from file %s", TLSRootCAFilepath)
-			}
-		} else {
-			TLSRootCA = []byte(e.TLSRootCA)
-		}
-		opts = append(opts, WithTLSRootCA(ctx, TLSRootCA))
+		opts = append(opts, WithTLSRootCA(ctx, data))
 	}
 
 	var TLSClientCert, TLSClientKey []byte
 	if e.TLSClientCert != "" {
-		TLSClientCertFilepath := e.TLSClientCert
-		if !filepath.IsAbs(e.TLSClientCert) {
-			TLSClientCertFilepath = filepath.Join(workdir, e.TLSClientCert)
+		data, err := loadPEMOrFile(workdir, e.TLSClientCert, "TLSClientCert")
+		if err != nil {
+			return nil, err
 		}
-		if _, err := os.Stat(TLSClientCertFilepath); err == nil {
-			TLSClientCert, err = os.ReadFile(TLSClientCertFilepath)
-			if err != nil {
-				return nil, fmt.Errorf("unable to read TLSClientCert from file %s", TLSClientCertFilepath)
-			}
-		} else {
-			TLSClientCert = []byte(e.TLSClientCert)
-		}
+		TLSClientCert = data
 	}
 
 	if e.TLSClientKey != "" {
-		TLSClientKeyFilepath := e.TLSClientKey
-		if !filepath.IsAbs(e.TLSClientKey) {
-			TLSClientKeyFilepath = filepath.Join(workdir, e.TLSClientKey)
+		data, err := loadPEMOrFile(workdir, e.TLSClientKey, "TLSClientKey")
+		if err != nil {
+			return nil, err
 		}
-		if _, err := os.Stat(TLSClientKeyFilepath); err == nil {
-			TLSClientKey, err = os.ReadFile(TLSClientKeyFilepath)
-			if err != nil {
-				return nil, fmt.Errorf("unable to read TLSClientKey from file %s", TLSClientKeyFilepath)
-			}
-		} else {
-			TLSClientKey = []byte(e.TLSClientKey)
-		}
+		TLSClientKey = data
 	}
 
 	if len(TLSClientCert) > 0 && len(TLSClientKey) > 0 {

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -279,10 +279,9 @@ func (e Executor) getRequest(ctx context.Context, workdir string) (*http.Request
 	if e.Body != "" {
 		body = bytes.NewBuffer([]byte(e.Body))
 	} else if e.BodyFile != "" {
-		bodyfilePath := e.BodyFile
-		if !filepath.IsAbs(e.BodyFile) {
-			// Only join with the workdir with relative path
-			bodyfilePath = filepath.Join(workdir, e.BodyFile)
+		bodyfilePath, errResolve := venom.ResolveWorkdirPath(workdir, e.BodyFile)
+		if errResolve != nil {
+			return nil, errResolve
 		}
 		if _, err := os.Stat(bodyfilePath); !os.IsNotExist(err) {
 			temp, err := os.ReadFile(bodyfilePath)

--- a/executors/http/http_test.go
+++ b/executors/http/http_test.go
@@ -16,48 +16,61 @@ import (
 	"github.com/ovh/venom"
 )
 
-func generateClientFile(t *testing.T) (string, string) {
-	TLSClientKey, err := os.CreateTemp(os.TempDir(), "TLSClientKey.*.key")
-	require.NoError(t, err)
-	TLSClientKeyFileName := TLSClientKey.Name()
-	t.Logf("generating file %q", TLSClientKeyFileName)
-	cmd := exec.Command("openssl", "genrsa", "-out", TLSClientKeyFileName, "2048")
+// generateClientFile creates a TLS key and self-signed certificate inside dir.
+// Returns the file names (relative to dir) so tests can resolve them through
+// venom.ResolveWorkdirPath.
+func generateClientFile(t *testing.T, dir string) (string, string) {
+	keyPath := "TLSClientKey.key"
+	certPath := "TLSClientCert.crt"
+	absKey := dir + "/" + keyPath
+	absCert := dir + "/" + certPath
+
+	t.Logf("generating file %q", absKey)
+	cmd := exec.Command("openssl", "genrsa", "-out", absKey, "2048")
 	output, err := cmd.CombinedOutput()
 	t.Log(string(output))
 	require.NoError(t, err)
 
-	TLSClientCert, err := os.CreateTemp(os.TempDir(), "TLSClientCert.*.crt")
-	require.NoError(t, err)
-	TLSClientCertFilename := TLSClientCert.Name()
-	t.Logf("generating file %q", TLSClientCertFilename)
-	cmd = exec.Command("openssl", "req", "-batch", "-subj", "/C=GB/ST=Yorks/L=York/O=MyCompany Ltd./OU=IT/CN=mysubdomain.mydomain.com", "-new", "-x509", "-sha256", "-key", TLSClientKeyFileName, "-out", TLSClientCertFilename, "-days", "365")
+	t.Logf("generating file %q", absCert)
+	cmd = exec.Command("openssl", "req", "-batch", "-subj", "/C=GB/ST=Yorks/L=York/O=MyCompany Ltd./OU=IT/CN=mysubdomain.mydomain.com", "-new", "-x509", "-sha256", "-key", absKey, "-out", absCert, "-days", "365")
 	output, err = cmd.CombinedOutput()
 	t.Log(string(output))
 	require.NoError(t, err)
 
-	return TLSClientKeyFileName, TLSClientCertFilename
+	return keyPath, certPath
+}
+
+func ctxWithWorkdir(workdir string) context.Context {
+	return context.WithValue(context.Background(), venom.ContextKey("var.venom.testsuite.workdir"), workdir)
 }
 
 func TestExecutor_TLSOptions_From_File(t *testing.T) {
-	TLSClientKeyFileName, TLSClientCertFilename := generateClientFile(t)
+	workdir := t.TempDir()
+	keyName, certName := generateClientFile(t, workdir)
+
+	rootCA, err := os.ReadFile("../../tests/http/tls/digicert-root-ca.crt")
+	require.NoError(t, err)
+	rootCAPath := "digicert-root-ca.crt"
+	require.NoError(t, os.WriteFile(workdir+"/"+rootCAPath, rootCA, 0o600))
 
 	e := Executor{
 		IgnoreVerifySSL: true,
-		TLSClientCert:   TLSClientCertFilename,
-		TLSClientKey:    TLSClientKeyFileName,
-		TLSRootCA:       "../../tests/http/tls/digicert-root-ca.crt",
+		TLSClientCert:   certName,
+		TLSClientKey:    keyName,
+		TLSRootCA:       rootCAPath,
 	}
-	opts, err := e.TLSOptions(context.Background())
+	opts, err := e.TLSOptions(ctxWithWorkdir(workdir))
 	require.NoError(t, err)
 	require.Len(t, opts, 3)
 }
 
 func TestExecutor_TLSOptions_From_String(t *testing.T) {
-	TLSClientKeyFileName, TLSClientCertFilename := generateClientFile(t)
+	workdir := t.TempDir()
+	keyName, certName := generateClientFile(t, workdir)
 
-	TLSClientCert, err := os.ReadFile(TLSClientCertFilename)
+	TLSClientCert, err := os.ReadFile(workdir + "/" + certName)
 	require.NoError(t, err)
-	TLSClientKey, err := os.ReadFile(TLSClientKeyFileName)
+	TLSClientKey, err := os.ReadFile(workdir + "/" + keyName)
 	require.NoError(t, err)
 	TLSRootCA, err := os.ReadFile("../../tests/http/tls/digicert-root-ca.crt")
 	require.NoError(t, err)
@@ -66,9 +79,17 @@ func TestExecutor_TLSOptions_From_String(t *testing.T) {
 		TLSClientKey:  string(TLSClientKey),
 		TLSRootCA:     string(TLSRootCA),
 	}
-	opts, err := e.TLSOptions(context.Background())
+	opts, err := e.TLSOptions(ctxWithWorkdir(workdir))
 	require.NoError(t, err)
 	require.Len(t, opts, 2)
+}
+
+func TestExecutor_TLSOptions_RejectAbsolutePath(t *testing.T) {
+	e := Executor{
+		TLSRootCA: "/etc/ssl/certs/ca-certificates.crt",
+	}
+	_, err := e.TLSOptions(ctxWithWorkdir(t.TempDir()))
+	require.Error(t, err)
 }
 
 func TestInterpolation_Of_String(t *testing.T) {

--- a/executors/imap/README.md
+++ b/executors/imap/README.md
@@ -10,6 +10,7 @@ Venom IMAP executor implements a few IMAP commands such as FETCH, APPEND, MOVE, 
 ```yaml
 auth:
   withtls: false
+  ignore_verify_ssl: false # Optional, default false. Set to true to disable TLS certificate verification (e.g. self-signed certs).
   host: yourimaphost
   port: 143 # Most probably 993 if using TLS
   user: imap@venom.com

--- a/executors/imap/imap.go
+++ b/executors/imap/imap.go
@@ -275,7 +275,7 @@ type Client struct {
 
 type AuthConfig struct {
 	WithTLS         bool   `json:"withtls,omitempty" yaml:"withtls,omitempty"`
-	IgnoreVerifySSL bool   `json:"ignore_verify_ssl,omitempty" yaml:"ignore_verify_ssl,omitempty"`
+	IgnoreVerifySSL bool   `json:"ignore_verify_ssl,omitempty" yaml:"ignore_verify_ssl,omitempty" mapstructure:"ignore_verify_ssl"`
 	Host            string `json:"host,omitempty" yaml:"host,omitempty"`
 	Port            string `json:"port,omitempty" yaml:"port,omitempty"`
 	User            string `json:"user,omitempty" yaml:"user,omitempty"`

--- a/executors/imap/imap.go
+++ b/executors/imap/imap.go
@@ -274,11 +274,12 @@ type Client struct {
 }
 
 type AuthConfig struct {
-	WithTLS  bool   `json:"withtls,omitempty" yaml:"withtls,omitempty"`
-	Host     string `json:"host,omitempty" yaml:"host,omitempty"`
-	Port     string `json:"port,omitempty" yaml:"port,omitempty"`
-	User     string `json:"user,omitempty" yaml:"user,omitempty"`
-	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	WithTLS         bool   `json:"withtls,omitempty" yaml:"withtls,omitempty"`
+	IgnoreVerifySSL bool   `json:"ignore_verify_ssl,omitempty" yaml:"ignore_verify_ssl,omitempty"`
+	Host            string `json:"host,omitempty" yaml:"host,omitempty"`
+	Port            string `json:"port,omitempty" yaml:"port,omitempty"`
+	User            string `json:"user,omitempty" yaml:"user,omitempty"`
+	Password        string `json:"password,omitempty" yaml:"password,omitempty"`
 }
 
 // Executor represents a Test Executor
@@ -870,7 +871,8 @@ func (e Executor) connect(host, port, imapUsername, imapPassword string) (*imap.
 	)
 	if e.Auth.WithTLS {
 		c, err = imap.DialTLS(host+":"+port, &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: e.Auth.IgnoreVerifySSL,
+			ServerName:         host,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("unable to dialTLS: %s", err)

--- a/executors/kafka/kafka.go
+++ b/executors/kafka/kafka.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -190,9 +188,12 @@ func (e Executor) produceMessages(workdir string) error {
 	messages := []*sarama.ProducerMessage{}
 
 	if e.MessagesFile != "" {
-		path := filepath.Join(workdir, e.MessagesFile)
-		if _, err = os.Stat(path); err == nil {
-			content, err := os.ReadFile(path)
+		messagesPath, err := venom.ResolveWorkdirPath(workdir, e.MessagesFile)
+		if err != nil {
+			return err
+		}
+		if _, err = os.Stat(messagesPath); err == nil {
+			content, err := os.ReadFile(messagesPath)
 			if err != nil {
 				return err
 			}
@@ -243,7 +244,10 @@ func (e Executor) getMessageValue(m *Message, workdir string) ([]byte, error) {
 	subject := fmt.Sprintf("%s-value", m.Topic) // Using topic name strategy
 	schemaFile := strings.Trim(m.AvroSchemaFile, " ")
 	if len(schemaFile) != 0 {
-		schemaPath := path.Join(workdir, schemaFile)
+		schemaPath, err := venom.ResolveWorkdirPath(workdir, schemaFile)
+		if err != nil {
+			return nil, err
+		}
 		schemaBlob, err := os.ReadFile(schemaPath)
 		if err != nil {
 			return nil, fmt.Errorf("can't read from %s: %w", schemaPath, err)
@@ -282,7 +286,10 @@ func (e Executor) getRAWMessageValue(m *Message, workdir string) ([]byte, error)
 		return []byte(m.Value), nil
 	}
 	// Read from file
-	s := path.Join(workdir, m.ValueFile)
+	s, err := venom.ResolveWorkdirPath(workdir, m.ValueFile)
+	if err != nil {
+		return nil, err
+	}
 	value, err := os.ReadFile(s)
 	if err != nil {
 		return nil, fmt.Errorf("can't read from %s: %w", s, err)

--- a/executors/mongo/mongo.go
+++ b/executors/mongo/mongo.go
@@ -40,7 +40,7 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (any, error) {
 		return nil, err
 	}
 
-	venom.Debug(ctx, "connecting to database: %s\n", e.URI)
+	venom.Debug(ctx, "connecting to database: %s\n", venom.RedactURI(e.URI))
 	mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(e.URI))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)

--- a/executors/mongo/mongo.go
+++ b/executors/mongo/mongo.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -78,7 +78,11 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (any, error) {
 				}
 			}
 
-			dirEntries, err := os.ReadDir(path.Join(venom.StringVarFromCtx(ctx, "venom.testsuite.workdir"), loadFixturesAction.Folder))
+			folderPath, errResolve := venom.ResolveWorkdirPath(venom.StringVarFromCtx(ctx, "venom.testsuite.workdir"), loadFixturesAction.Folder)
+			if errResolve != nil {
+				return nil, errResolve
+			}
+			dirEntries, err := os.ReadDir(folderPath)
 			if err != nil {
 				return nil, err
 			}
@@ -89,7 +93,7 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (any, error) {
 					continue
 				}
 
-				extension := path.Ext(file.Name())
+				extension := filepath.Ext(file.Name())
 				if extension != ".yaml" && extension != ".yml" {
 					continue
 				}
@@ -97,8 +101,8 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (any, error) {
 			}
 
 			for _, fixture := range fixtures {
-				collectionName := strings.TrimSuffix(fixture, path.Ext(fixture))
-				filePath := path.Join(venom.StringVarFromCtx(ctx, "venom.testsuite.workdir"), loadFixturesAction.Folder, fixture)
+				collectionName := strings.TrimSuffix(fixture, filepath.Ext(fixture))
+				filePath := filepath.Join(folderPath, fixture)
 
 				file, err := os.Open(filePath)
 				if err != nil {
@@ -159,7 +163,10 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (any, error) {
 			var documents []any
 
 			if insertAction.File != "" {
-				filePath := path.Join(venom.StringVarFromCtx(ctx, "venom.testsuite.workdir"), insertAction.File)
+				filePath, errResolve := venom.ResolveWorkdirPath(venom.StringVarFromCtx(ctx, "venom.testsuite.workdir"), insertAction.File)
+				if errResolve != nil {
+					return nil, errResolve
+				}
 				file, err := os.Open(filePath)
 				if err != nil {
 					return nil, err

--- a/executors/ovhapi/ovhapi.go
+++ b/executors/ovhapi/ovhapi.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -285,9 +284,12 @@ func (e Executor) getRequestBody(workdir string) (res interface{}, err error) {
 	if e.Body != "" {
 		bytes = []byte(e.Body)
 	} else if e.BodyFile != "" {
-		path := filepath.Join(workdir, e.BodyFile)
-		if _, err = os.Stat(path); !os.IsNotExist(err) {
-			bytes, err = os.ReadFile(path)
+		bodyPath, errResolve := venom.ResolveWorkdirPath(workdir, e.BodyFile)
+		if errResolve != nil {
+			return nil, errResolve
+		}
+		if _, err = os.Stat(bodyPath); !os.IsNotExist(err) {
+			bytes, err = os.ReadFile(bodyPath)
 			if err != nil {
 				return nil, err
 			}

--- a/executors/plugins/README.md
+++ b/executors/plugins/README.md
@@ -77,10 +77,14 @@ testcases:
     - result.body ShouldContainSubstring world
 ```
 
-Run venom:
+Run venom (the `--lib-dir` flag must point to the directory containing the
+compiled `.so` plugin; auto-discovery from the testsuite workdir is no longer
+supported for security reasons):
 
 ```
-$ ./venom run test.yml
+$ ./venom run --lib-dir=./lib test.yml
 ```
+
+Plugin names are restricted to the `[A-Za-z0-9_-]` character set.
 
 Feel free to open a Pull Request with your executors.

--- a/executors/rabbitmq/rabbitmq.go
+++ b/executors/rabbitmq/rabbitmq.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ovh/venom"
 
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 // Name of executor

--- a/executors/readfile/readfile.go
+++ b/executors/readfile/readfile.go
@@ -89,9 +89,9 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 func (e *Executor) readfile(ctx context.Context, workdir string) (Result, error) {
 	result := Result{}
 
-	absPath := e.Path
-	if !filepath.IsAbs(absPath) {
-		absPath = filepath.Join(workdir, e.Path)
+	absPath, err := venom.ResolveWorkdirPath(workdir, e.Path)
+	if err != nil {
+		return result, err
 	}
 
 	fileInfo, _ := os.Stat(absPath) // nolint

--- a/executors/redis/redis.go
+++ b/executors/redis/redis.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 
 	"github.com/gomodule/redigo/redis"
 	shellwords "github.com/mattn/go-shellwords"
@@ -71,7 +70,11 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 
 	var commands []string
 	if e.FilePath != "" {
-		commands, err = file2lines(path.Join(workdir, e.FilePath))
+		filePath, errResolve := venom.ResolveWorkdirPath(workdir, e.FilePath)
+		if errResolve != nil {
+			return nil, errResolve
+		}
+		commands, err = file2lines(filePath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to load file")
 		}

--- a/executors/smtp/README.md
+++ b/executors/smtp/README.md
@@ -14,6 +14,7 @@ testcases:
   steps:
   - type: smtp
     withtls: false
+    ignore_verify_ssl: false # Optional, default false. Set to true to disable TLS certificate verification (e.g. self-signed certs).
     host: localhost
     port: 25 # 465 if using TLS
     user: yourSMTPUsername # Optional, only works with TLS

--- a/executors/smtp/smtp.go
+++ b/executors/smtp/smtp.go
@@ -25,7 +25,7 @@ func New() venom.Executor {
 // Executor represents a Test Exec
 type Executor struct {
 	WithTLS         bool   `json:"withtls,omitempty" yaml:"withtls,omitempty"`
-	IgnoreVerifySSL bool   `json:"ignore_verify_ssl,omitempty" yaml:"ignore_verify_ssl,omitempty"`
+	IgnoreVerifySSL bool   `json:"ignore_verify_ssl,omitempty" yaml:"ignore_verify_ssl,omitempty" mapstructure:"ignore_verify_ssl"`
 	Host            string `json:"host,omitempty" yaml:"host,omitempty"`
 	Port            string `json:"port,omitempty" yaml:"port,omitempty"`
 	User            string `json:"user,omitempty" yaml:"user,omitempty"`

--- a/executors/smtp/smtp.go
+++ b/executors/smtp/smtp.go
@@ -24,15 +24,16 @@ func New() venom.Executor {
 
 // Executor represents a Test Exec
 type Executor struct {
-	WithTLS  bool   `json:"withtls,omitempty" yaml:"withtls,omitempty"`
-	Host     string `json:"host,omitempty" yaml:"host,omitempty"`
-	Port     string `json:"port,omitempty" yaml:"port,omitempty"`
-	User     string `json:"user,omitempty" yaml:"user,omitempty"`
-	Password string `json:"password,omitempty" yaml:"password,omitempty"`
-	To       string `json:"to,omitempty" yaml:"to,omitempty"`
-	From     string `json:"from,omitempty" yaml:"from,omitempty"`
-	Subject  string `json:"subject,omitempty" yaml:"subject,omitempty"`
-	Body     string `json:"body,omitempty" yaml:"body,omitempty"`
+	WithTLS         bool   `json:"withtls,omitempty" yaml:"withtls,omitempty"`
+	IgnoreVerifySSL bool   `json:"ignore_verify_ssl,omitempty" yaml:"ignore_verify_ssl,omitempty"`
+	Host            string `json:"host,omitempty" yaml:"host,omitempty"`
+	Port            string `json:"port,omitempty" yaml:"port,omitempty"`
+	User            string `json:"user,omitempty" yaml:"user,omitempty"`
+	Password        string `json:"password,omitempty" yaml:"password,omitempty"`
+	To              string `json:"to,omitempty" yaml:"to,omitempty"`
+	From            string `json:"from,omitempty" yaml:"from,omitempty"`
+	Subject         string `json:"subject,omitempty" yaml:"subject,omitempty"`
+	Body            string `json:"body,omitempty" yaml:"body,omitempty"`
 }
 
 // Result represents a step result
@@ -105,7 +106,7 @@ func (e *Executor) sendEmail(ctx context.Context) error {
 	message += "\r\n" + e.Body
 
 	tlsconfig := &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: e.IgnoreVerifySSL,
 		ServerName:         e.Host,
 	}
 

--- a/executors/sql/sql.go
+++ b/executors/sql/sql.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"context"
 	"os"
-	"path"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -88,7 +87,10 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, er
 		}
 	} else if e.File != "" {
 		workdir := venom.StringVarFromCtx(ctx, "venom.testsuite.workdir")
-		file := path.Join(workdir, e.File)
+		file, err := venom.ResolveWorkdirPath(workdir, e.File)
+		if err != nil {
+			return nil, err
+		}
 		venom.Debug(ctx, "loading SQL file from %s\n", file)
 		sbytes, errs := os.ReadFile(file)
 		if errs != nil {

--- a/executors/sql/sql.go
+++ b/executors/sql/sql.go
@@ -62,7 +62,7 @@ func (e Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, er
 		return nil, err
 	}
 	// Connect to the database and ping it.
-	venom.Debug(ctx, "connecting to database %s, %s\n", e.Driver, e.DSN)
+	venom.Debug(ctx, "connecting to database %s, %s\n", e.Driver, venom.RedactURI(e.DSN))
 	db, err := sqlx.Connect(e.Driver, e.DSN)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to connect to database")

--- a/executors/ssh/README.md
+++ b/executors/ssh/README.md
@@ -12,9 +12,16 @@ In your yaml file, you can use:
   - command mandatory
   - user optional (default is OS username)
   - password optional (mandatory if no privatekey is found)
-  - privatekey optional (default is $HOME/.ssh/id_rsa)
+  - privatekey optional (default is $HOME/.ssh/id_rsa).
+                       Relative paths are resolved under the testsuite workdir.
+                       Absolute paths must be located under the user's $HOME.
   - sudo optional
   - sudopassword optional (default to password)
+  - insecure_ignore_host_key optional (default false). When false, the server
+                                       host key is verified against
+                                       $HOME/.ssh/known_hosts. Set to true to
+                                       skip verification (insecure).
+  - timeout optional (default 30). Connection timeout, in seconds.
 ```
 
 Example

--- a/executors/ssh/ssh.go
+++ b/executors/ssh/ssh.go
@@ -40,7 +40,10 @@ type Executor struct {
 	Sudo                  string `json:"sudo,omitempty" yaml:"sudo,omitempty"`
 	SudoPassword          string `json:"sudopassword,omitempty" yaml:"sudopassword,omitempty"`
 	InsecureIgnoreHostKey bool   `json:"insecure_ignore_host_key,omitempty" yaml:"insecure_ignore_host_key,omitempty"`
+	Timeout               int    `json:"timeout,omitempty" yaml:"timeout,omitempty"` // connection timeout in seconds, default 30
 }
+
+const defaultSSHTimeoutSeconds = 30
 
 // Result represents a step result
 type Result struct {
@@ -75,7 +78,8 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 	start := time.Now()
 	result := Result{}
 
-	client, session, err := connectToHost(e.User, e.Password, e.PrivateKey, e.Host, e.Sudo, e.InsecureIgnoreHostKey)
+	workdir := venom.StringVarFromCtx(ctx, "venom.testsuite.workdir")
+	client, session, err := connectToHost(e.User, e.Password, e.PrivateKey, e.Host, e.Sudo, workdir, e.InsecureIgnoreHostKey, e.Timeout)
 	if err != nil {
 		result.Err = err.Error()
 	} else {
@@ -145,7 +149,7 @@ func handleSudo(in io.Writer, out *Buffer, quit chan bool, password string) {
 	}
 }
 
-func connectToHost(u, pass, key, host, sudo string, insecureIgnoreHostKey bool) (*ssh.Client, *ssh.Session, error) {
+func connectToHost(u, pass, key, host, sudo, workdir string, insecureIgnoreHostKey bool, timeoutSeconds int) (*ssh.Client, *ssh.Session, error) {
 	// Default user is current username
 	if u == "" {
 		osUser, err := user.Current()
@@ -161,7 +165,7 @@ func connectToHost(u, pass, key, host, sudo string, insecureIgnoreHostKey bool) 
 		auth = []ssh.AuthMethod{ssh.Password(pass)}
 	} else {
 		// Load the the private key
-		key, err := privateKey(key)
+		key, err := privateKey(key, workdir)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -173,10 +177,15 @@ func connectToHost(u, pass, key, host, sudo string, insecureIgnoreHostKey bool) 
 		return nil, nil, err
 	}
 
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = defaultSSHTimeoutSeconds
+	}
+
 	sshConfig := &ssh.ClientConfig{
 		User:            u,
 		Auth:            auth,
 		HostKeyCallback: hostKeyCallback,
+		Timeout:         time.Duration(timeoutSeconds) * time.Second,
 	}
 
 	// If host doen't contain port, set the default port
@@ -212,7 +221,7 @@ func connectToHost(u, pass, key, host, sudo string, insecureIgnoreHostKey bool) 
 	return client, session, nil
 }
 
-func privateKey(file string) (key ssh.Signer, err error) {
+func privateKey(file, workdir string) (key ssh.Signer, err error) {
 	// Default private key is $HOME/.ssh/id_rsa
 	if file == "" {
 		usr, err := user.Current()
@@ -220,6 +229,26 @@ func privateKey(file string) (key ssh.Signer, err error) {
 			return nil, err
 		}
 		file = filepath.Join(usr.HomeDir, ".ssh", "id_rsa")
+	} else if filepath.IsAbs(file) {
+		// Absolute paths are only allowed under the user's $HOME, to prevent
+		// a malicious testsuite from pointing to /etc/shadow or similar.
+		usr, err := user.Current()
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve current user to validate privatekey path: %w", err)
+		}
+		clean := filepath.Clean(file)
+		homePrefix := filepath.Clean(usr.HomeDir) + string(os.PathSeparator)
+		if !strings.HasPrefix(clean, homePrefix) {
+			return nil, fmt.Errorf("absolute privatekey path %q must be located under the user's home directory %q", file, usr.HomeDir)
+		}
+		file = clean
+	} else {
+		// Resolve relative paths under the testsuite workdir.
+		resolved, err := venom.ResolveWorkdirPath(workdir, file)
+		if err != nil {
+			return nil, fmt.Errorf("invalid privatekey path: %w", err)
+		}
+		file = resolved
 	}
 
 	// Read the file

--- a/executors/ssh/ssh.go
+++ b/executors/ssh/ssh.go
@@ -39,8 +39,8 @@ type Executor struct {
 	PrivateKey            string `json:"privatekey,omitempty" yaml:"privatekey,omitempty"`
 	Sudo                  string `json:"sudo,omitempty" yaml:"sudo,omitempty"`
 	SudoPassword          string `json:"sudopassword,omitempty" yaml:"sudopassword,omitempty"`
-	InsecureIgnoreHostKey bool   `json:"insecure_ignore_host_key,omitempty" yaml:"insecure_ignore_host_key,omitempty"`
-	Timeout               int    `json:"timeout,omitempty" yaml:"timeout,omitempty"` // connection timeout in seconds, default 30
+	InsecureIgnoreHostKey bool   `json:"insecure_ignore_host_key,omitempty" yaml:"insecure_ignore_host_key,omitempty" mapstructure:"insecure_ignore_host_key"`
+	Timeout               int    `json:"timeout,omitempty" yaml:"timeout,omitempty" mapstructure:"timeout"` // connection timeout in seconds, default 30
 }
 
 const defaultSSHTimeoutSeconds = 30

--- a/executors/ssh/ssh.go
+++ b/executors/ssh/ssh.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 
 	"github.com/ovh/venom"
 )
@@ -31,13 +32,14 @@ func New() venom.Executor {
 
 // Executor represents a Test Exec
 type Executor struct {
-	Host         string `json:"host,omitempty" yaml:"host,omitempty"`
-	Command      string `json:"command,omitempty" yaml:"command,omitempty"`
-	User         string `json:"user,omitempty" yaml:"user,omitempty"`
-	Password     string `json:"password,omitempty" yaml:"password,omitempty"`
-	PrivateKey   string `json:"privatekey,omitempty" yaml:"privatekey,omitempty"`
-	Sudo         string `json:"sudo,omitempty" yaml:"sudo,omitempty"`
-	SudoPassword string `json:"sudopassword,omitempty" yaml:"sudopassword,omitempty"`
+	Host                  string `json:"host,omitempty" yaml:"host,omitempty"`
+	Command               string `json:"command,omitempty" yaml:"command,omitempty"`
+	User                  string `json:"user,omitempty" yaml:"user,omitempty"`
+	Password              string `json:"password,omitempty" yaml:"password,omitempty"`
+	PrivateKey            string `json:"privatekey,omitempty" yaml:"privatekey,omitempty"`
+	Sudo                  string `json:"sudo,omitempty" yaml:"sudo,omitempty"`
+	SudoPassword          string `json:"sudopassword,omitempty" yaml:"sudopassword,omitempty"`
+	InsecureIgnoreHostKey bool   `json:"insecure_ignore_host_key,omitempty" yaml:"insecure_ignore_host_key,omitempty"`
 }
 
 // Result represents a step result
@@ -73,7 +75,7 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 	start := time.Now()
 	result := Result{}
 
-	client, session, err := connectToHost(e.User, e.Password, e.PrivateKey, e.Host, e.Sudo)
+	client, session, err := connectToHost(e.User, e.Password, e.PrivateKey, e.Host, e.Sudo, e.InsecureIgnoreHostKey)
 	if err != nil {
 		result.Err = err.Error()
 	} else {
@@ -143,7 +145,7 @@ func handleSudo(in io.Writer, out *Buffer, quit chan bool, password string) {
 	}
 }
 
-func connectToHost(u, pass, key, host, sudo string) (*ssh.Client, *ssh.Session, error) {
+func connectToHost(u, pass, key, host, sudo string, insecureIgnoreHostKey bool) (*ssh.Client, *ssh.Session, error) {
 	// Default user is current username
 	if u == "" {
 		osUser, err := user.Current()
@@ -166,10 +168,15 @@ func connectToHost(u, pass, key, host, sudo string) (*ssh.Client, *ssh.Session, 
 		auth = []ssh.AuthMethod{ssh.PublicKeys(key)}
 	}
 
+	hostKeyCallback, err := buildHostKeyCallback(insecureIgnoreHostKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	sshConfig := &ssh.ClientConfig{
 		User:            u,
 		Auth:            auth,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
 	}
 
 	// If host doen't contain port, set the default port
@@ -212,9 +219,7 @@ func privateKey(file string) (key ssh.Signer, err error) {
 		if err != nil {
 			return nil, err
 		}
-		file = filepath.Join(usr.HomeDir + "/.ssh/id_rsa")
-	} else {
-		file = os.ExpandEnv(file)
+		file = filepath.Join(usr.HomeDir, ".ssh", "id_rsa")
 	}
 
 	// Read the file
@@ -228,4 +233,27 @@ func privateKey(file string) (key ssh.Signer, err error) {
 		return nil, err
 	}
 	return key, nil
+}
+
+// buildHostKeyCallback returns the ssh.HostKeyCallback to use for the
+// connection. By default it verifies the server key against the user's
+// $HOME/.ssh/known_hosts. If insecureIgnoreHostKey is true, all server
+// keys are accepted (legacy behaviour, only for trusted environments).
+func buildHostKeyCallback(insecureIgnoreHostKey bool) (ssh.HostKeyCallback, error) {
+	if insecureIgnoreHostKey {
+		return ssh.InsecureIgnoreHostKey(), nil
+	}
+	usr, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve current user to locate known_hosts: %w", err)
+	}
+	knownHostsPath := filepath.Join(usr.HomeDir, ".ssh", "known_hosts")
+	if _, err := os.Stat(knownHostsPath); err != nil {
+		return nil, fmt.Errorf("known_hosts file %q is not available (%w); populate it or set 'insecure_ignore_host_key: true' to bypass host key verification", knownHostsPath, err)
+	}
+	cb, err := knownhosts.New(knownHostsPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load known_hosts from %q: %w", knownHostsPath, err)
+	}
+	return cb, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -26,13 +26,13 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/linkedin/goavro/v2 v2.12.0
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/mattn/go-zglob v0.0.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b
 	github.com/ovh/go-ovh v1.9.0
 	github.com/pkg/errors v0.9.1
+	github.com/rabbitmq/amqp091-go v1.11.0
 	github.com/rockbears/yaml v0.4.0
 	github.com/rubenv/sql-migrate v1.5.2
 	github.com/sijms/go-ora v1.3.2
@@ -40,7 +40,6 @@ require (
 	github.com/spf13/cast v1.5.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
-	github.com/streadway/amqp v1.1.0
 	github.com/stretchr/testify v1.11.1
 	github.com/yesnault/go-imap v0.0.0-20160710142244-eb9bbb66bd7b
 	go.mongodb.org/mongo-driver v1.12.1
@@ -62,6 +61,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1052,6 +1052,8 @@ github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjz
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
+github.com/rabbitmq/amqp091-go v1.11.0 h1:HxIctVm9Gid/Vtn706necmZ7Wj6pgGI2eqplRbEY8O8=
+github.com/rabbitmq/amqp091-go v1.11.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -1094,8 +1096,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/streadway/amqp v1.1.0 h1:py12iX8XSyI7aN/3dUT8DFIDJazNJsVJdxNVEpnQTZM=
-github.com/streadway/amqp v1.1.0/go.mod h1:WYSrTEYHOXHd0nwFeUXAe2G2hRnQT+deZJJf88uS9Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/path_utils.go
+++ b/path_utils.go
@@ -1,0 +1,29 @@
+package venom
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveWorkdirPath joins userPath under workdir and ensures the result
+// stays inside workdir. Absolute paths and "../" escapes are rejected.
+// Returns the cleaned path, or an error if the input is unsafe.
+func ResolveWorkdirPath(workdir, userPath string) (string, error) {
+	if filepath.IsAbs(userPath) {
+		return "", fmt.Errorf("absolute path %q is not allowed; use a path relative to the testsuite workdir", userPath)
+	}
+
+	cleanWorkdir := filepath.Clean(workdir)
+	joined := filepath.Join(cleanWorkdir, userPath)
+
+	rel, err := filepath.Rel(cleanWorkdir, joined)
+	if err != nil {
+		return "", fmt.Errorf("invalid path %q: %w", userPath, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes the testsuite workdir", userPath)
+	}
+
+	return joined, nil
+}

--- a/path_utils_test.go
+++ b/path_utils_test.go
@@ -1,0 +1,44 @@
+package venom
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveWorkdirPath(t *testing.T) {
+	workdir := filepath.Clean("/tmp/venom-workdir")
+
+	tests := []struct {
+		name     string
+		userPath string
+		wantErr  bool
+	}{
+		{name: "simple relative path", userPath: "fixtures/data.yml", wantErr: false},
+		{name: "nested relative path", userPath: "a/b/c/file.txt", wantErr: false},
+		{name: "current dir", userPath: ".", wantErr: false},
+		{name: "absolute path rejected", userPath: "/etc/passwd", wantErr: true},
+		{name: "parent escape rejected", userPath: "../secret", wantErr: true},
+		{name: "deep parent escape rejected", userPath: "a/../../etc/passwd", wantErr: true},
+		{name: "exact escape to parent rejected", userPath: "..", wantErr: true},
+		{name: "empty path resolves to workdir", userPath: "", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveWorkdirPath(workdir, tt.userPath)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got resolved path %q", tt.userPath, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for input %q: %v", tt.userPath, err)
+			}
+			rel, errRel := filepath.Rel(workdir, got)
+			if errRel != nil || rel == ".." || len(rel) >= 2 && rel[:2] == ".." {
+				t.Fatalf("resolved path %q is outside workdir", got)
+			}
+		})
+	}
+}

--- a/process_files.go
+++ b/process_files.go
@@ -11,10 +11,99 @@ import (
 
 	"github.com/mattn/go-zglob"
 	"github.com/rockbears/yaml"
+	yamlv3 "gopkg.in/yaml.v3"
 
 	"github.com/ovh/venom/interpolate"
 	"github.com/pkg/errors"
 )
+
+// testCaseLineInfo holds source line numbers for a single test case.
+type testCaseLineInfo struct {
+	TestCaseLine   int     // line of the testcase mapping node
+	StepLines      []int   // line of each step mapping node
+	AssertionLines [][]int // [stepIdx][assertIdx] line numbers
+}
+
+// extractLineNumbers parses raw YAML bytes using gopkg.in/yaml.v3 to extract
+// source line numbers for testcases, steps, and assertions.
+func extractLineNumbers(content []byte) []testCaseLineInfo {
+	var doc yamlv3.Node
+	if err := yamlv3.Unmarshal(content, &doc); err != nil {
+		return nil
+	}
+
+	// doc is a DocumentNode containing the root MappingNode
+	if doc.Kind != yamlv3.DocumentNode || len(doc.Content) == 0 {
+		return nil
+	}
+	root := doc.Content[0]
+	if root.Kind != yamlv3.MappingNode {
+		return nil
+	}
+
+	// Find "testcases" key in root mapping
+	var testcasesNode *yamlv3.Node
+	for i := 0; i < len(root.Content)-1; i += 2 {
+		if root.Content[i].Value == "testcases" {
+			testcasesNode = root.Content[i+1]
+			break
+		}
+	}
+	if testcasesNode == nil || testcasesNode.Kind != yamlv3.SequenceNode {
+		return nil
+	}
+
+	result := make([]testCaseLineInfo, 0, len(testcasesNode.Content))
+	for _, tcNode := range testcasesNode.Content {
+		if tcNode.Kind != yamlv3.MappingNode {
+			result = append(result, testCaseLineInfo{})
+			continue
+		}
+
+		info := testCaseLineInfo{
+			TestCaseLine: tcNode.Line,
+		}
+
+		// Find "steps" in testcase mapping
+		var stepsNode *yamlv3.Node
+		for i := 0; i < len(tcNode.Content)-1; i += 2 {
+			if tcNode.Content[i].Value == "steps" {
+				stepsNode = tcNode.Content[i+1]
+				break
+			}
+		}
+
+		if stepsNode != nil && stepsNode.Kind == yamlv3.SequenceNode {
+			info.StepLines = make([]int, len(stepsNode.Content))
+			info.AssertionLines = make([][]int, len(stepsNode.Content))
+
+			for stepIdx, stepNode := range stepsNode.Content {
+				info.StepLines[stepIdx] = stepNode.Line
+
+				if stepNode.Kind != yamlv3.MappingNode {
+					continue
+				}
+
+				// Find "assertions" in step mapping
+				for i := 0; i < len(stepNode.Content)-1; i += 2 {
+					if stepNode.Content[i].Value == "assertions" {
+						assertionsNode := stepNode.Content[i+1]
+						if assertionsNode.Kind == yamlv3.SequenceNode {
+							info.AssertionLines[stepIdx] = make([]int, len(assertionsNode.Content))
+							for aIdx, aNode := range assertionsNode.Content {
+								info.AssertionLines[stepIdx][aIdx] = aNode.Line
+							}
+						}
+						break
+					}
+				}
+			}
+		}
+
+		result = append(result, info)
+	}
+	return result
+}
 
 func getFilesPath(path []string) ([]string, error) {
 	filePaths := make([]string, 0)
@@ -125,9 +214,18 @@ func (v *Venom) readFiles(ctx context.Context, filesPath []string) (err error) {
 			Vars:        testSuiteInput.Vars,
 			Secrets:     testSuiteInput.Secrets,
 		}
+
+		// Extract source line numbers from original YAML (before interpolation)
+		lineInfos := extractLineNumbers(btes)
+
 		for i := range testSuiteInput.TestCases {
 			ts.TestCases[i] = TestCase{
 				TestCaseInput: testSuiteInput.TestCases[i],
+			}
+			if i < len(lineInfos) {
+				ts.TestCases[i].SourceLine = lineInfos[i].TestCaseLine
+				ts.TestCases[i].StepSourceLines = lineInfos[i].StepLines
+				ts.TestCases[i].AssertionSourceLines = lineInfos[i].AssertionLines
 			}
 		}
 		Info(ctx, "Has %d Secrets", len(ts.Secrets))

--- a/process_files_test.go
+++ b/process_files_test.go
@@ -251,3 +251,90 @@ func Test_getFilesPath_files_order(t *testing.T) {
 	require.True(t, strings.HasSuffix(output[0], "a.yml"))
 	require.True(t, strings.HasSuffix(output[1], "A.yml"))
 }
+
+func Test_extractLineNumbers(t *testing.T) {
+	yaml := []byte(`name: HTTP testsuite
+vars:
+  input: "this my input"
+
+testcases:
+- name: get http testcase
+  steps:
+  - type: http
+    method: GET
+    url: https://example.com
+    assertions:
+    - result.statuscode ShouldEqual 200
+    - result.body ShouldContainSubstring hello
+
+- name: post http testcase
+  steps:
+  - type: http
+    method: POST
+    url: https://example.com/api
+    assertions:
+    - result.statuscode ShouldEqual 201
+  - type: exec
+    script: echo done
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring done
+`)
+
+	infos := extractLineNumbers(yaml)
+	require.Len(t, infos, 2)
+
+	// First testcase
+	require.Equal(t, 6, infos[0].TestCaseLine)
+	require.Len(t, infos[0].StepLines, 1)
+	require.Equal(t, 8, infos[0].StepLines[0])
+	require.Len(t, infos[0].AssertionLines, 1)
+	require.Len(t, infos[0].AssertionLines[0], 2)
+	require.Equal(t, 12, infos[0].AssertionLines[0][0])
+	require.Equal(t, 13, infos[0].AssertionLines[0][1])
+
+	// Second testcase
+	require.Equal(t, 15, infos[1].TestCaseLine)
+	require.Len(t, infos[1].StepLines, 2)
+	require.Equal(t, 17, infos[1].StepLines[0])
+	require.Equal(t, 22, infos[1].StepLines[1])
+	require.Len(t, infos[1].AssertionLines, 2)
+	require.Len(t, infos[1].AssertionLines[0], 1)
+	require.Equal(t, 21, infos[1].AssertionLines[0][0])
+	require.Len(t, infos[1].AssertionLines[1], 2)
+	require.Equal(t, 25, infos[1].AssertionLines[1][0])
+	require.Equal(t, 26, infos[1].AssertionLines[1][1])
+}
+
+func Test_findSourceLine(t *testing.T) {
+	tc := TestCase{
+		SourceLine:      6,
+		StepSourceLines: []int{8, 17},
+		AssertionSourceLines: [][]int{
+			{12, 13},
+			{21, 25, 26},
+		},
+	}
+
+	// Assertion line found
+	require.Equal(t, 12, tc.findSourceLine(0, 0))
+	require.Equal(t, 13, tc.findSourceLine(0, 1))
+	require.Equal(t, 21, tc.findSourceLine(1, 0))
+	require.Equal(t, 25, tc.findSourceLine(1, 1))
+	require.Equal(t, 26, tc.findSourceLine(1, 2))
+
+	// No assertion index -> step line
+	require.Equal(t, 8, tc.findSourceLine(0, -1))
+	require.Equal(t, 17, tc.findSourceLine(1, -1))
+
+	// Out of bounds assertion -> step line
+	require.Equal(t, 8, tc.findSourceLine(0, 5))
+	require.Equal(t, 17, tc.findSourceLine(1, 10))
+
+	// Out of bounds step -> testcase line
+	require.Equal(t, 6, tc.findSourceLine(5, -1))
+
+	// Empty testcase
+	tc2 := TestCase{}
+	require.Equal(t, 0, tc2.findSourceLine(0, 0))
+}

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -371,7 +371,7 @@ loopRawTestSteps:
 				Error(ctx, "teststep output vars are: %v", redactedOutputVars)
 
 				if isRequired {
-					failure := newFailure(ctx, *tc, stepNumber, rangedIndex, "", errors.New("At least one required assertion failed, skipping remaining steps"))
+					failure := newFailure(ctx, *tc, stepNumber, rangedIndex, -1, "", errors.New("At least one required assertion failed, skipping remaining steps"))
 					tsResult.appendFailure(*failure)
 					v.printTestStepResult(tc, tsResult, tsIn, stepNumber, true)
 					return

--- a/process_teststep.go
+++ b/process_teststep.go
@@ -36,7 +36,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 		if err != nil {
 			// we save the failure only if it's the last attempt
 			if tsResult.Retries == e.Retry() {
-				failure := newFailure(ctx, *tc, stepNumber, rangedIndex, "", err)
+				failure := newFailure(ctx, *tc, stepNumber, rangedIndex, -1, "", err)
 				tsResult.appendFailure(*failure)
 			}
 			continue
@@ -66,7 +66,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 			tc.computedVerbose = append(tc.computedVerbose, fmt.Sprintf("writing %s", filename))
 		}
 
-		for ninfo, i := range e.Info() {
+		for _, i := range e.Info() {
 			info, err := interpolate.Do(i, mapResultString)
 			if err != nil {
 				Error(ctx, "unable to parse %q: %v", i, err)
@@ -75,17 +75,10 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 			if info == "" {
 				continue
 			}
-			filename := StringVarFromCtx(ctx, "venom.testsuite.filename")
-			lineNumber := findLineNumber(filename, tc.originalName, stepNumber, i, ninfo+1)
+			filepath := StringVarFromCtx(ctx, "venom.testsuite.filepath")
+			lineNumber := tc.findSourceLine(stepNumber, -1)
 			if lineNumber > 0 {
-				info += fmt.Sprintf(" (%s:%d)", filename, lineNumber)
-			} else if tc.IsExecutor {
-				filename = StringVarFromCtx(ctx, "venom.executor.filename")
-				originalName := StringVarFromCtx(ctx, "venom.executor.name")
-				lineNumber = findLineNumber(filename, originalName, stepNumber, i, ninfo+1)
-				if lineNumber > 0 {
-					info += fmt.Sprintf(" (%s:%d)", filename, lineNumber)
-				}
+				info += fmt.Sprintf(" (%s:%d)", filepath, lineNumber)
 			}
 			Info(ctx, info, nil)
 			tsResult.ComputedInfo = append(tsResult.ComputedInfo, info)
@@ -114,7 +107,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 			break
 		}
 		if len(failures) > 0 {
-			failure := newFailure(ctx, *tc, stepNumber, rangedIndex, "", fmt.Errorf("retry conditions not fulfilled, skipping %d remaining retries", e.Retry()-tsResult.Retries))
+			failure := newFailure(ctx, *tc, stepNumber, rangedIndex, -1, "", fmt.Errorf("retry conditions not fulfilled, skipping %d remaining retries", e.Retry()-tsResult.Retries))
 			tsResult.Errors = append(tsResult.Errors, *failure)
 			break
 		}

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -63,10 +63,6 @@ func (v *Venom) runTestSuite(ctx context.Context, ts *TestSuite) error {
 
 	ts.Vars.Add(("venom.testsuite.totalSteps"), totalSteps)
 	ts.Status = StatusRun
-	Info(ctx, "With secrets in testsuite")
-	for _, v := range ts.Secrets {
-		Info(ctx, "secret  %+v", v)
-	}
 	// ##### RUN Test Cases Here
 	v.runTestCases(ctx, ts)
 

--- a/redact.go
+++ b/redact.go
@@ -1,0 +1,49 @@
+package venom
+
+import (
+	"regexp"
+	"strings"
+)
+
+// mysqlDSNRegexp matches MySQL-style DSNs of the form
+// "user:password@tcp(host:port)/dbname". The capture group keeps the
+// username so the redacted value still identifies the connection.
+var mysqlDSNRegexp = regexp.MustCompile(`^([^:@/\s]+):[^@]*@`)
+
+// RedactURI returns a copy of s with any embedded credentials replaced by
+// "***". Two formats are recognised:
+//
+//   - URI form ("scheme://user:password@host/..."): the password component
+//     of the userinfo is masked.
+//   - MySQL DSN form ("user:password@tcp(host:port)/db"): the password is
+//     masked, the username is preserved.
+//
+// Inputs that do not match a known credential pattern are returned
+// unchanged, so plain SQLite paths or ":memory:" are passed through.
+func RedactURI(s string) string {
+	if s == "" {
+		return s
+	}
+	if i := strings.Index(s, "://"); i >= 0 {
+		// URI form. We do not use net/url for the rebuild because
+		// url.URL.String escapes "*" into "%2A" in the userinfo, which
+		// makes the redacted value unreadable.
+		scheme := s[:i]
+		rest := s[i+3:]
+		at := strings.Index(rest, "@")
+		if at < 0 {
+			return s
+		}
+		userinfo := rest[:at]
+		afterAt := rest[at:] // starts with '@'
+		colon := strings.Index(userinfo, ":")
+		if colon < 0 {
+			return s // no password to redact
+		}
+		return scheme + "://" + userinfo[:colon] + ":***" + afterAt
+	}
+	if mysqlDSNRegexp.MatchString(s) {
+		return mysqlDSNRegexp.ReplaceAllString(s, "$1:***@")
+	}
+	return s
+}

--- a/redact_test.go
+++ b/redact_test.go
@@ -1,0 +1,35 @@
+package venom
+
+import "testing"
+
+func TestRedactURI(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "postgres URI with password", in: "postgres://u:p@h/db", want: "postgres://u:***@h/db"},
+		{name: "postgres URI with options", in: "postgres://u:p@h:5432/db?sslmode=disable", want: "postgres://u:***@h:5432/db?sslmode=disable"},
+		{name: "mongodb URI", in: "mongodb://u:p@h:27017/?retryWrites=true", want: "mongodb://u:***@h:27017/?retryWrites=true"},
+		{name: "redis URI no user", in: "redis://:secret@h:6379", want: "redis://:***@h:6379"},
+		{name: "amqp URI", in: "amqp://u:p@h:5672/vhost", want: "amqp://u:***@h:5672/vhost"},
+		{name: "URI without password", in: "postgres://u@h/db", want: "postgres://u@h/db"},
+		{name: "URI without user", in: "https://example.com/foo", want: "https://example.com/foo"},
+		{name: "MySQL DSN", in: "u:p@tcp(h:3306)/db", want: "u:***@tcp(h:3306)/db"},
+		{name: "MySQL DSN with options", in: "user:s3cret@tcp(host:3306)/dbname?parseTime=true", want: "user:***@tcp(host:3306)/dbname?parseTime=true"},
+		{name: "SQLite memory", in: ":memory:", want: ":memory:"},
+		{name: "SQLite file", in: "/path/to/file.db", want: "/path/to/file.db"},
+		{name: "SQLite relative", in: "file:test.db", want: "file:test.db"},
+		{name: "plain string", in: "not-a-dsn", want: "not-a-dsn"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactURI(tt.in)
+			if got != tt.want {
+				t.Fatalf("RedactURI(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/ssh.yml
+++ b/tests/ssh.yml
@@ -5,9 +5,11 @@ testcases:
   - type: ssh
     user: venom
     host: localhost:2222
+    password: testvenom
     insecure_ignore_host_key: true
     command: echo foo
     assertions:
+    - result.err ShouldBeEmpty
     - result.code ShouldEqual 0
     - result.timeseconds ShouldBeLessThan 10
 
@@ -16,11 +18,13 @@ testcases:
   - type: ssh
     user: venom
     host: localhost:2222
+    password: testvenom
     insecure_ignore_host_key: true
     command: whoami
     sudo: root
     sudopassword: testvenom
     assertions:
+    - result.err ShouldBeEmpty
     - result.code ShouldEqual 0
     - result.systemout ShouldEqual root
     - result.timeseconds ShouldBeLessThan 10
@@ -30,11 +34,13 @@ testcases:
   - type: ssh
     user: venom
     host: localhost:2222
+    password: testvenom
     insecure_ignore_host_key: true
     command: whoami
     sudo: venom
     sudopassword: testvenom
     assertions:
+    - result.err ShouldBeEmpty
     - result.code ShouldEqual 0
     - result.systemout ShouldEqual venom
     - result.timeseconds ShouldBeLessThan 10

--- a/tests/ssh.yml
+++ b/tests/ssh.yml
@@ -5,7 +5,7 @@ testcases:
   - type: ssh
     user: venom
     host: localhost:2222
-    privatekey: "$HOME/.ssh/id_rsa"
+    insecure_ignore_host_key: true
     command: echo foo
     assertions:
     - result.code ShouldEqual 0
@@ -16,7 +16,7 @@ testcases:
   - type: ssh
     user: venom
     host: localhost:2222
-    privatekey: "$HOME/.ssh/id_rsa"
+    insecure_ignore_host_key: true
     command: whoami
     sudo: root
     sudopassword: testvenom
@@ -30,7 +30,7 @@ testcases:
   - type: ssh
     user: venom
     host: localhost:2222
-    privatekey: "$HOME/.ssh/id_rsa"
+    insecure_ignore_host_key: true
     command: whoami
     sudo: venom
     sudopassword: testvenom

--- a/types.go
+++ b/types.go
@@ -177,6 +177,11 @@ type TestCase struct {
 	computedVerbose []string `json:"-" yaml:"-"`
 	IsExecutor      bool     `json:"-" yaml:"-"`
 	IsEvaluated     bool     `json:"-" yaml:"-"`
+
+	// Source line numbers extracted from YAML parsing (1-indexed)
+	SourceLine           int     `json:"-" yaml:"-"` // line of the testcase definition
+	StepSourceLines      []int   `json:"-" yaml:"-"` // line of each step (indexed by step number)
+	AssertionSourceLines [][]int `json:"-" yaml:"-"` // [stepIdx][assertIdx] -> line number
 }
 
 type TestStepResult struct {
@@ -284,9 +289,12 @@ type FailureXML struct {
 	Message string `xml:"message,attr,omitempty" json:"message" yaml:"message,omitempty"`
 }
 
-func newFailure(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertion string, err error) *Failure {
-	filename := StringVarFromCtx(ctx, "venom.testsuite.filename")
-	lineNumber := findLineNumber(filename, tc.originalName, stepNumber, assertion, -1)
+func newFailure(ctx context.Context, tc TestCase, stepNumber int, rangedIndex int, assertionIndex int, assertion string, err error) *Failure {
+	filepath := StringVarFromCtx(ctx, "venom.testsuite.filepath")
+
+	// Try to get line number from stored source lines
+	lineNumber := tc.findSourceLine(stepNumber, assertionIndex)
+
 	var value string
 	if assertion != "" {
 		value = fmt.Sprintf(`Testcase %q, step #%d-%d: Assertion %q failed. %s (%v:%d)`,
@@ -295,7 +303,7 @@ func newFailure(ctx context.Context, tc TestCase, stepNumber int, rangedIndex in
 			rangedIndex,
 			RemoveNotPrintableChar(assertion),
 			RemoveNotPrintableChar(err.Error()),
-			filename,
+			filepath,
 			lineNumber,
 		)
 	} else {
@@ -304,13 +312,13 @@ func newFailure(ctx context.Context, tc TestCase, stepNumber int, rangedIndex in
 			stepNumber,
 			rangedIndex,
 			RemoveNotPrintableChar(err.Error()),
-			filename,
+			filepath,
 			lineNumber,
 		)
 	}
 
 	failure := Failure{
-		TestcaseClassname:  filename,
+		TestcaseClassname:  filepath,
 		TestcaseName:       tc.Name,
 		TestcaseLineNumber: lineNumber,
 		StepNumber:         stepNumber,
@@ -320,6 +328,27 @@ func newFailure(ctx context.Context, tc TestCase, stepNumber int, rangedIndex in
 	}
 
 	return &failure
+}
+
+// findSourceLine returns the best source line number for a given step and assertion.
+// It tries the assertion line first, then falls back to the step line.
+func (tc TestCase) findSourceLine(stepNumber int, assertionIndex int) int {
+	// Try assertion-level line number
+	if assertionIndex >= 0 && stepNumber < len(tc.AssertionSourceLines) {
+		assertions := tc.AssertionSourceLines[stepNumber]
+		if assertionIndex < len(assertions) && assertions[assertionIndex] > 0 {
+			return assertions[assertionIndex]
+		}
+	}
+	// Fall back to step line
+	if stepNumber < len(tc.StepSourceLines) && tc.StepSourceLines[stepNumber] > 0 {
+		return tc.StepSourceLines[stepNumber]
+	}
+	// Fall back to testcase line
+	if tc.SourceLine > 0 {
+		return tc.SourceLine
+	}
+	return 0
 }
 
 func (f Failure) String() string {

--- a/venom.go
+++ b/venom.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"plugin"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -20,6 +21,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 )
+
+// pluginNamePattern restricts plugin names to a safe character set,
+// preventing path traversal via the YAML "type" field.
+var pluginNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 var (
 	// Version is set with -ldflags "-X github.com/ovh/venom/venom.Version=$(VERSION)"
@@ -338,26 +343,47 @@ func (v *Venom) registerUserAssertFunc(ctx context.Context, name string) error {
 }
 
 func (v *Venom) registerPlugin(ctx context.Context, name string, vars map[string]string) error {
-	workdir := vars["venom.testsuite.workdir"]
-	// try to load from testsuite path
-	p, err := plugin.Open(path.Join(workdir, "lib", name+".so"))
-	if err != nil {
-		// try to load from venom binary path
-		p, err = plugin.Open(path.Join("lib", name+".so"))
-		if err != nil {
-			return fmt.Errorf("unable to load plugin %q.so", name)
+	if !pluginNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid plugin name %q: only [A-Za-z0-9_-] characters are allowed", name)
+	}
+
+	if v.LibDir == "" {
+		return fmt.Errorf("plugin %q cannot be loaded: --lib-dir is not set", name)
+	}
+
+	var lastErr error
+	for _, lp := range strings.Split(v.LibDir, string(os.PathListSeparator)) {
+		dir := strings.TrimSpace(lp)
+		if dir == "" {
+			continue
 		}
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		candidate := filepath.Join(absDir, name+".so")
+		p, err := plugin.Open(candidate)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		symbolExecutor, err := p.Lookup("Plugin")
+		if err != nil {
+			return err
+		}
+		executor, ok := symbolExecutor.(Executor)
+		if !ok {
+			return fmt.Errorf("plugin %q does not export a valid Executor symbol", name)
+		}
+		v.RegisterExecutorPlugin(name, executor)
+		return nil
 	}
 
-	symbolExecutor, err := p.Lookup("Plugin")
-	if err != nil {
-		return err
+	if lastErr != nil {
+		return fmt.Errorf("unable to load plugin %q from --lib-dir: %w", name, lastErr)
 	}
-
-	executor := symbolExecutor.(Executor)
-	v.RegisterExecutorPlugin(name, executor)
-
-	return nil
+	return fmt.Errorf("unable to load plugin %q: not found in --lib-dir", name)
 }
 
 func VarFromCtx(ctx context.Context, varname string) interface{} {

--- a/venom_output.html
+++ b/venom_output.html
@@ -16,6 +16,9 @@
   <!-- Showdown for Markdown (if needed) -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/2.1.0/showdown.min.js"></script>
 
+  <!-- DOMPurify to sanitise rendered Markdown / HTML and prevent XSS -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.11/purify.min.js"></script>
+
   <!-- Custom Tailwind Config -->
   <script>
     tailwind.config = {
@@ -491,7 +494,10 @@
         renderMarkdown(text) {
           if (!text) return '';
           const converter = new showdown.Converter();
-          return converter.makeHtml(text);
+          const dirty = converter.makeHtml(text);
+          // Sanitise the generated HTML to prevent XSS through user-supplied
+          // content (testsuite descriptions, step results, etc.).
+          return DOMPurify.sanitize(dirty);
         },
 
         formatDuration(seconds) {

--- a/venom_output.html
+++ b/venom_output.html
@@ -1,519 +1,1407 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tailwind Template</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Venom · Test Report</title>
 
-  <!-- Alpine Plugins -->
-  <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
+<!-- Showdown for Markdown (suite descriptions) -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/2.1.0/showdown.min.js"
+        integrity="sha512-LhccdVNGe2QMEfI3x4DVV3ckMRe36TfydKss6mJpdHjNFiV07dFpS2xzeZedptKZrwxfICJpez09iNioiSZ3hA=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"></script>
 
-  <!-- Alpine.js -->
-  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+<!-- DOMPurify to sanitise rendered Markdown / HTML and prevent XSS -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.11/purify.min.js"
+        integrity="sha512-ce0fmuEgWrpnIXWKQrSgJ5FsBsr/hnOsxdWvk5lu1GThckasLwc+TAFERLNIwWnWqBoWV4GPDJiz2PSPntinVA=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"></script>
 
-  <!-- Showdown for Markdown (if needed) -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/2.1.0/showdown.min.js"></script>
+<style>
+/* ---------- TOKENS ---------- */
+:root {
+  --font-sans: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, "Menlo", monospace;
 
-  <!-- DOMPurify to sanitise rendered Markdown / HTML and prevent XSS -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.11/purify.min.js"></script>
+  /* Light theme defaults */
+  --bg: #fbfbfa;
+  --bg-elev: #ffffff;
+  --bg-sidebar: #f4f4f1;
+  --bg-code: #0f1115;
+  --bg-hover: #eeefea;
+  --bg-selected: #e8eee8;
+  --border: #e5e5df;
+  --border-strong: #d4d4cc;
+  --fg: #1a1a17;
+  --fg-muted: #6b6b63;
+  --fg-dim: #94948a;
+  --fg-code: #d6d6cf;
 
-  <!-- Custom Tailwind Config -->
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            'brand': '#3b82f6',
-          }
-        }
-      }
-    }
-  </script>
+  /* Status (venom palette: poison-green pass, ember-red fail, ash skip) */
+  --pass: oklch(58% 0.13 158);
+  --pass-bg: oklch(96% 0.03 158);
+  --pass-strong: oklch(45% 0.14 158);
+  --fail: oklch(58% 0.18 25);
+  --fail-bg: oklch(96% 0.03 25);
+  --fail-strong: oklch(48% 0.19 25);
+  --skip: oklch(60% 0.01 100);
+  --skip-bg: oklch(96% 0.005 100);
+  --skip-strong: oklch(45% 0.01 100);
 
-  <style type="text/tailwindcss">
-    @layer components {
-      .pill-pass {
-        @apply inline-flex items-center px-2.5 py-0.5 rounded font-medium bg-green-100 text-green-800;
-      }
-      .pill-fail {
-        @apply inline-flex items-center px-2.5 py-0.5 rounded font-medium bg-red-100 text-red-800;
-      }
-      .pill-skip {
-        @apply inline-flex items-center px-2.5 py-0.5 rounded font-medium bg-gray-100 text-gray-800;
-      }
-      .pill-info {
-        @apply inline-flex items-center px-2.5 py-0.5 rounded font-medium bg-blue-100 text-gray-500;
-      }
-      .border-pass {
-        @apply border-green-500;
-      }
-      .border-fail {
-        @apply border-red-500;
-      }
-      .border-skip {
-        @apply border-gray-500;
-      }
-    }
-  </style>
+  --accent: oklch(58% 0.13 158);
+
+  --radius: 6px;
+  --radius-sm: 4px;
+  --gap: 12px;
+
+  --row-h: 44px;
+}
+[data-theme="dark"] {
+  --bg: #0e1014;
+  --bg-elev: #15181d;
+  --bg-sidebar: #0a0c10;
+  --bg-code: #06080a;
+  --bg-hover: #1c2027;
+  --bg-selected: #1a2620;
+  --border: #1f242c;
+  --border-strong: #2a3038;
+  --fg: #e8e8e3;
+  --fg-muted: #9ba0a8;
+  --fg-dim: #6b7079;
+  --fg-code: #d6d6cf;
+
+  --pass: oklch(70% 0.14 158);
+  --pass-bg: oklch(22% 0.04 158);
+  --pass-strong: oklch(78% 0.14 158);
+  --fail: oklch(70% 0.18 25);
+  --fail-bg: oklch(22% 0.04 25);
+  --fail-strong: oklch(78% 0.19 25);
+  --skip: oklch(65% 0.01 100);
+  --skip-bg: oklch(22% 0.005 100);
+  --skip-strong: oklch(78% 0.01 100);
+  --accent: oklch(70% 0.14 158);
+}
+[data-density="compact"] { --row-h: 36px; --gap: 8px; }
+[data-density="cozy"]    { --row-h: 52px; --gap: 16px; }
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; height: 100%; }
+body {
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+button { font-family: inherit; font-size: inherit; color: inherit; cursor: pointer; }
+
+/* ---------- LAYOUT ---------- */
+.app {
+  display: grid;
+  grid-template-rows: 48px 1fr;
+  height: 100vh;
+}
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 16px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+  height: 48px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+.brand-mark {
+  font-size: 18px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px; height: 22px;
+  filter: saturate(1.05);
+  transform: translateY(-0.5px);
+}
+.brand-sub {
+  color: var(--fg-muted);
+  font-weight: 400;
+  font-size: 12px;
+  margin-left: 2px;
+}
+.summary {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-left: auto;
+  font-size: 12px;
+}
+.summary-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+}
+.summary-stat .num {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 12.5px;
+  color: var(--fg);
+}
+.summary-stat .dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+}
+.dot.pass { background: var(--pass); }
+.dot.fail { background: var(--fail); }
+.dot.skip { background: var(--skip); }
+.summary-divider {
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+}
+.global-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.global-status.pass { color: var(--pass-strong); background: var(--pass-bg); }
+.global-status.fail { color: var(--fail-strong); background: var(--fail-bg); }
+.global-status.skip { color: var(--skip-strong); background: var(--skip-bg); }
+
+.icon-btn {
+  width: 30px; height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted);
+  transition: background 80ms;
+}
+.icon-btn:hover { background: var(--bg-hover); color: var(--fg); }
+.icon-btn.active { background: var(--bg-selected); color: var(--accent); }
+
+/* ---------- BODY GRID ---------- */
+.body {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  min-height: 0;
+}
+.sidebar {
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.sidebar-head {
+  padding: 12px 12px 8px;
+  border-bottom: 1px solid var(--border);
+}
+.search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 5px 9px;
+  margin-bottom: 8px;
+}
+.search:focus-within { border-color: var(--accent); }
+.search input {
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 12.5px;
+}
+.search svg { color: var(--fg-dim); flex-shrink: 0; }
+
+.filter-row {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+  transition: all 80ms;
+}
+.chip:hover { background: var(--bg-hover); }
+.chip.active { background: var(--bg-elev); color: var(--fg); border-color: var(--border-strong); }
+.chip .dot { width: 6px; height: 6px; border-radius: 50%; }
+
+.suite-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0 24px;
+}
+.suite-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+  height: var(--row-h);
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  user-select: none;
+  position: relative;
+}
+.suite-row:hover { background: var(--bg-hover); }
+.suite-row.selected {
+  background: var(--bg-selected);
+  border-left-color: var(--accent);
+}
+.suite-idx {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+  min-width: 22px;
+}
+.suite-main { min-width: 0; }
+.suite-name {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.suite-meta {
+  display: flex;
+  gap: 8px;
+  font-size: 10.5px;
+  color: var(--fg-dim);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  margin-top: 1px;
+}
+.suite-status {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.suite-status.pass { background: var(--pass); }
+.suite-status.fail { background: var(--fail); box-shadow: 0 0 0 3px var(--fail-bg); }
+.suite-status.skip { background: var(--skip); }
+
+/* ---------- MAIN ---------- */
+.main {
+  overflow-y: auto;
+  background: var(--bg);
+  min-width: 0;
+}
+.main-inner {
+  max-width: 1100px;
+  padding: 24px 28px 80px;
+}
+.suite-header {
+  margin-bottom: 18px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+}
+.breadcrumb {
+  font-size: 11.5px;
+  color: var(--fg-dim);
+  font-family: var(--font-mono);
+  margin-bottom: 6px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.breadcrumb .sep { opacity: 0.5; }
+.suite-title {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.suite-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-top: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.suite-meta-row .label {
+  color: var(--fg-dim);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-right: 6px;
+}
+.suite-meta-row .val {
+  font-family: var(--font-mono);
+  color: var(--fg);
+}
+.suite-meta-row .vars-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg);
+}
+.suite-meta-row .vars-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+.suite-description {
+  margin-top: 14px;
+  padding: 12px 14px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--fg);
+}
+.suite-description :first-child { margin-top: 0; }
+.suite-description :last-child { margin-bottom: 0; }
+.suite-description code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-hover);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.suite-description pre {
+  background: var(--bg-code);
+  color: var(--fg-code);
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+}
+.suite-description a { color: var(--accent); text-decoration: none; }
+.suite-description a:hover { text-decoration: underline; }
+
+/* ---------- TESTCASES ---------- */
+.tc {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 10px;
+  overflow: hidden;
+}
+.tc-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 14px;
+  border-left: 3px solid transparent;
+  cursor: pointer;
+  user-select: none;
+}
+.tc.pass .tc-head { border-left-color: var(--pass); }
+.tc.fail .tc-head { border-left-color: var(--fail); }
+.tc.skip .tc-head { border-left-color: var(--skip); }
+.tc-head:hover { background: var(--bg-hover); }
+.tc-toggle {
+  width: 18px; height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-dim);
+  transition: transform 120ms;
+}
+.tc.expanded .tc-toggle { transform: rotate(90deg); }
+.tc-name {
+  font-weight: 500;
+  font-size: 13.5px;
+  letter-spacing: -0.005em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tc-name .prefix { color: var(--fg-dim); font-weight: 400; margin-right: 4px; font-size: 12px; font-family: var(--font-mono); }
+.tc-dur {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.status-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  font-family: var(--font-mono);
+}
+.status-tag.pass { color: var(--pass-strong); background: var(--pass-bg); }
+.status-tag.fail { color: var(--fail-strong); background: var(--fail-bg); }
+.status-tag.skip { color: var(--skip-strong); background: var(--skip-bg); }
+
+.tc-body { display: none; border-top: 1px solid var(--border); }
+.tc.expanded .tc-body { display: block; }
+
+/* ---------- STEPS ---------- */
+.step {
+  border-bottom: 1px solid var(--border);
+}
+.step:last-child { border-bottom: 0; }
+.step-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 14px 8px 32px;
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+}
+.step-head:hover { background: var(--bg-hover); }
+.step-head::before {
+  content: "";
+  position: absolute;
+  left: 18px;
+  top: 50%;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  transform: translateY(-50%);
+}
+.step.pass .step-head::before { background: var(--pass); }
+.step.fail .step-head::before { background: var(--fail); }
+.step.skip .step-head::before { background: var(--skip); }
+.step-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+  min-width: 28px;
+}
+.step-name {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--fg);
+}
+.step-retries {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: oklch(from var(--accent) l c h / 0.12);
+  color: var(--accent);
+}
+.step-dur {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.step-toggle {
+  color: var(--fg-dim);
+  transition: transform 120ms;
+}
+.step.expanded .step-toggle { transform: rotate(90deg); }
+.step-body { display: none; padding: 0 14px 14px 32px; }
+.step.expanded .step-body { display: block; }
+
+/* tabs */
+.tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+  overflow-x: auto;
+}
+.tab-btn {
+  background: transparent;
+  border: 0;
+  padding: 7px 11px;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+  margin-bottom: -1px;
+  font-family: var(--font-mono);
+  position: relative;
+}
+.tab-btn:hover { color: var(--fg); }
+.tab-btn.active { color: var(--fg); border-bottom-color: var(--accent); }
+.tab-btn .badge {
+  display: inline-block;
+  margin-left: 5px;
+  padding: 0 5px;
+  border-radius: 6px;
+  background: var(--bg-hover);
+  font-size: 10px;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.tab-btn.has-error { color: var(--fail-strong); }
+.tab-btn.has-error.active { border-bottom-color: var(--fail); }
+
+/* code blocks */
+pre.code {
+  background: var(--bg-code);
+  color: var(--fg-code);
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre;
+  tab-size: 2;
+}
+pre.code .yk { color: oklch(75% 0.13 230); }
+pre.code .ys { color: oklch(75% 0.13 158); }
+pre.code .yn { color: oklch(78% 0.13 80); }
+pre.code .yc { color: var(--fg-dim); font-style: italic; }
+pre.code .yb { color: oklch(78% 0.13 25); }
+pre.code .yd { color: oklch(70% 0.04 80); }
+
+.errors-panel {
+  background: var(--fail-bg);
+  border: 1px solid color-mix(in oklch, var(--fail) 25%, transparent);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fail-strong);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.info-panel {
+  background: oklch(from var(--accent) l c h / 0.07);
+  border: 1px solid oklch(from var(--accent) l c h / 0.2);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--accent);
+  white-space: pre-wrap;
+}
+
+.assertion-row {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 8px;
+  align-items: start;
+  padding: 4px 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.assertion-row .mark { color: var(--pass); margin-top: 1px; }
+.assertion-row.fail .mark { color: var(--fail); }
+.assertion-row.fail { color: var(--fail-strong); }
+
+/* timeline footer */
+.timeline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-dim);
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--border);
+}
+.timeline .line { flex: 1; height: 1px; background: var(--border); }
+.timeline .dur { color: var(--fg-muted); }
+
+/* empty state */
+.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--fg-dim);
+  flex-direction: column;
+  gap: 12px;
+  padding: 60px 20px;
+  text-align: center;
+}
+.empty .ico {
+  width: 56px; height: 56px;
+  border-radius: 50%;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-dim);
+}
+
+/* drawer */
+.drawer-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms;
+  z-index: 50;
+}
+.drawer-backdrop.open { opacity: 1; pointer-events: auto; }
+.drawer {
+  position: fixed;
+  top: 0; right: 0; bottom: 0;
+  width: min(640px, 90vw);
+  background: var(--bg-elev);
+  border-left: 1px solid var(--border);
+  transform: translateX(100%);
+  transition: transform 200ms cubic-bezier(0.2, 0, 0, 1);
+  display: flex;
+  flex-direction: column;
+  z-index: 51;
+}
+.drawer.open { transform: translateX(0); }
+.drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.drawer-title { font-weight: 600; font-size: 14px; }
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 18px;
+}
+
+/* Tweaks */
+.tweaks {
+  position: fixed;
+  bottom: 16px; right: 16px;
+  width: 280px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.06);
+  font-size: 12px;
+  z-index: 100;
+  display: none;
+}
+.tweaks.open { display: block; }
+.tweaks-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.tweaks-body { padding: 10px 12px; }
+.tweak-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.tweak-row .lbl { color: var(--fg); font-size: 12px; }
+.seg {
+  display: inline-flex;
+  background: var(--bg-hover);
+  border-radius: 6px;
+  padding: 2px;
+}
+.seg button {
+  background: transparent;
+  border: 0;
+  padding: 4px 9px;
+  border-radius: 4px;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+}
+.seg button.on { background: var(--bg-elev); color: var(--fg); box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.toggle {
+  width: 32px; height: 18px;
+  border-radius: 999px;
+  background: var(--border-strong);
+  position: relative;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  transition: background 120ms;
+}
+.toggle::after {
+  content: ""; position: absolute;
+  width: 14px; height: 14px;
+  background: white;
+  border-radius: 50%;
+  top: 2px; left: 2px;
+  transition: left 120ms;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+}
+.toggle.on { background: var(--accent); }
+.toggle.on::after { left: 16px; }
+
+/* scrollbars */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 10px; border: 2px solid transparent; background-clip: content-box; }
+::-webkit-scrollbar-thumb:hover { background-color: var(--fg-dim); }
+::-webkit-scrollbar-track { background: transparent; }
+</style>
 </head>
+<body>
 
-<body class="bg-gray-50 h-screen flex flex-col" x-data="methods">
-  <!-- Fixed Header -->
-  <header class="bg-white shadow-sm border-b px-4 flex-shrink-0" x-data="reportData">
-    <div class="flex justify-between items-center h-16">
-      <div class="flex items-center">
-        <span class="text-2xl mr-3">🐍</span>
-        <h1 class="text-xl font-semibold text-gray-900">Venom Test Results</h1>
-        <div class="flex flex-wrap pl-2">
-          <span :class="`pill-${status.toLowerCase()}`" class="text-lg" x-text="status"></span>
-        </div>
-      </div>
-      <div class="flex items-center space-x-4">
-        <span x-text="formatDuration(duration)"></span>
-
-        <!-- Summary badges -->
-        <div class="flex flex-wrap gap-2">
-          <span class="pill-pass text-xs">
-            <span x-text="nbTestsuitesPass"></span> &nbsp; PASS
-          </span>
-          <span class="pill-fail text-xs">
-            <span x-text="nbTestsuitesFail"></span> &nbsp; FAIL
-          </span>
-          <span class="pill-skip text-xs">
-            <span x-text="nbTestsuitesSkip"></span> &nbsp; SKIP
-          </span>
-        </div>
-      </div>
+<div class="app" id="app">
+  <header class="topbar">
+    <div class="brand">
+      <span class="brand-mark" aria-hidden="true">🐍</span>
+      <span>Venom</span>
+      <span class="brand-sub" id="topRunDate">—</span>
     </div>
+
+    <div class="summary" id="summary"></div>
+
+    <button class="icon-btn" id="tweaksBtn" title="Tweaks (T)" aria-label="Tweaks">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+        <circle cx="12" cy="12" r="3"></circle>
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+      </svg>
+    </button>
   </header>
 
-  <!-- Main Container -->
-  <div class="flex flex-1 overflow-hidden bg-white border-r border-gray-200" x-data="reportData">
-    <!-- Left Sidebar Navigation -->
-    <nav class="w-64 overflow-y-auto">
-      <div class="flex items-center justify-between mb-2 p-4">
-        <h2 class="text-lg font-semibold text-gray-900">Test Suites</h2>
-        <span class="text-xs text-gray-500" x-text="`${test_suites.length} total`"></span>
+  <div class="body">
+    <aside class="sidebar">
+      <div class="sidebar-head">
+        <label class="search">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.5-3.5"></path></svg>
+          <input id="searchInput" placeholder="Search test suites…" />
+        </label>
+        <div class="filter-row" id="filterRow"></div>
       </div>
+      <div class="suite-list" id="suiteList"></div>
+    </aside>
 
-
-      <ul class="divide-y divide-gray-100">
-        <template x-for="(suite, index) in test_suites" :key="index">
-          <li>
-            <button @click="selectSuite(index)"
-              :class="{'bg-blue-50 border-l-4 border-blue-500': selectedSuite === index}"
-              class="w-full text-left px-4 py-3 hover:bg-gray-50 transition-colors duration-150 relative group">
-              <div class="flex items-start justify-between">
-                <div x-text="index + 1" class="text-sm pr-1"></div>
-                <div class="flex-1 min-w-0">
-                  <p class="text-sm font-medium text-gray-900 truncate" x-text="suite.name || 'Unnamed Suite'"></p>
-                  <p class="text-xs text-gray-500 mt-1">
-                    <span x-text="formatDuration(suite.duration)"></span>
-                  </p>
-                </div>
-                <div class="ml-2 flex-shrink-0">
-                  <span :class="`pill-${suite.status.toLowerCase()}`" class="text-xs" x-text="suite.status"></span>
-                </div>
-              </div>
-            </button>
-          </li>
-
-          <!-- Summary badges -->
-          <div class="flex flex-wrap gap-2">
-            <span class="pill-pass text-xs">
-              <span x-text="suite.nbTestsuitesPass"></span> &nbsp; PASS
-            </span>
-            <span class="pill-fail text-xs">
-              <span x-text="suite.nbTestsuitesFail"></span> &nbsp; FAIL
-            </span>
-            <span class="pill-skip text-xs">
-              <span x-text="suite.nbTestsuitesSkip"></span> &nbsp; SKIP
-            </span>
-          </div>
-
-          <!-- Overall stats -->
-          <div class="mt-3 text-xs text-gray-600 space-y-1">
-            <div>Duration: <span class="font-mono text-gray-900" x-text="formatDuration(totalDuration)"></span></div>
-            <div>Start: <span class="font-mono text-gray-900" x-text="formatDate(startTime)"></span></div>
-            <div>End: <span class="font-mono text-gray-900" x-text="formatDate(endTime)"></span></div>
-          </div>
-
-        </template>
-      </ul>
-    </nav>
-
-    <!-- Center Content Area -->
-    <main class="flex-1 overflow-y-auto bg-white">
-      <div class="p-6">
-
-        <template x-if="selectedSuite !== null && test_suites[selectedSuite]">
-          <div>
-            <!-- Suite Header -->
-            <div class="bg-white rounded-lg shadow-sm mb-6">
-              <div class="flex items-start justify-between mb-4">
-                <div>
-                  <h2 class="text-2xl font-bold text-gray-900" x-text="test_suites[selectedSuite].name"></h2>
-                  <div class="mt-2 flex items-center gap-4 text-sm text-gray-600">
-                    <span>📁 <span x-text="test_suites[selectedSuite].filepath"></span></span>
-                  </div>
-                </div>
-
-                <div class="flex flex-wrap gap-2">
-                  <span class="pill-pass text-xs">
-                    <span x-text="test_suites[selectedSuite].nbTestcasesPass"></span> &nbsp; PASS
-                  </span>
-                  <span class="pill-fail text-xs">
-                    <span x-text="test_suites[selectedSuite].nbTestcasesFail"></span> &nbsp; FAIL
-                  </span>
-                  <span class="pill-skip text-xs">
-                    <span x-text="test_suites[selectedSuite].nbTestcasesSkip"></span> &nbsp; SKIP
-                  </span>
-                </div>
-              </div>
-
-              <!-- Suite Description -->
-              <div x-show="test_suites[selectedSuite].description"
-                x-html="renderMarkdown(test_suites[selectedSuite].description)" class="prose prose-sm max-w-none mb-4">
-              </div>
-
-              <!-- Suite Info -->
-              <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-                <div class="bg-gray-50 rounded p-3">
-                  <div class="text-gray-500">Duration</div>
-                  <div class="font-mono font-medium" x-text="formatDuration(test_suites[selectedSuite].duration)">
-                  </div>
-                </div>
-                <div class="bg-gray-50 rounded p-3">
-                  <div class="text-gray-500">Test Cases</div>
-                  <div class="font-mono font-medium" x-text="test_suites[selectedSuite].testcases?.length || 0"></div>
-                </div>
-                <div class="bg-gray-50 rounded p-3">
-                  <div class="text-gray-500">Variables</div>
-                  <div class="font-mono font-medium">
-                    <button @click="toggleModal()" class="text-blue-600 hover:text-blue-800"
-                      x-text="Object.keys(test_suites[selectedSuite].vars || {}).length">
-                    </button>
-                  </div>
-                </div>
-                <div class="bg-gray-50 rounded p-3">
-                  <div class="text-gray-500">Workdir</div>
-                  <div class="font-mono font-medium text-xs truncate" :title="test_suites[selectedSuite].workdir"
-                    x-text="test_suites[selectedSuite].workdir">
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Test Cases -->
-            <div class="space-y-4">
-              <template x-for="(testcase, tcIndex) in test_suites[selectedSuite].testcases" :key="tcIndex">
-                <div :class="`border-${testcase.status.toLowerCase()}`"
-                  class="bg-white rounded-lg shadow-sm border-l-4 overflow-hidden">
-                  <div class="p-2 border-b border-gray-200">
-                    <div class="flex items-center justify-between p-1">
-                      <h3 class="text-lg font-medium text-gray-900">
-                        Test Case: <span x-text="testcase.name"></span>
-                      </h3>
-                      <div class="flex flex-wrap pl-2">
-                        <span :class="`pill-${testcase.status.toLowerCase()}`" class="text-lg"
-                          x-text="testcase.status"></span>
-                      </div>
-                    </div>
-
-                    <!-- Test Steps -->
-                    <div class="divide-y divide-gray-200">
-                      <template x-for="(step, stepIndex) in testcase.results" :key="stepIndex">
-                        <div class="p-2" x-data="{ expanded: false }" :class="expanded ? 'bg-gray-50' : 'bg-white'">
-                          <div class="flex items-center justify-between">
-                            <div class="flex items-center space-x-3">
-                              <span class="text-sm text-gray-500">Step <span x-text="step.number + 1"></span><span
-                                  x-show="step.rangedEnable" x-text="`:${step.rangedIndex}`"></span></span>
-                              <span class="font-medium text-gray-900" x-text="step.name"></span>
-                            </div>
-                            <div class="flex items-center space-x-2">
-                              <span x-show="step.retries > 0" class="pill-info text-sm"
-                                x-text="`Retries: ${step.retries}`"></span>
-                              <span class="text-sm text-gray-500 font-mono"
-                                x-text="formatDuration(step.duration)"></span>
-                              <span :class="`pill-${step.status.toLowerCase()}`" class="text-xs"
-                                x-text="step.status"></span>
-                              <button @click="expanded = !expanded" class="text-gray-400 hover:text-gray-600">
-                                <svg class="w-5 h-5 transform transition-transform" :class="{'rotate-180': expanded}"
-                                  fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M19 9l-7 7-7-7"></path>
-                                </svg>
-                              </button>
-                            </div>
-                          </div>
-
-                          <!-- Step Details (Collapsible) -->
-                          <div x-show="expanded" x-collapse>
-                            <div class="mt-4 space-y-2">
-                              <!-- Tab buttons -->
-                              <div class="flex flex-wrap gap-2 mb-4" x-data="{ activeTab: 'info' }">
-                                <button @click="activeTab = activeTab === 'info' ? 'none' : 'info'"
-                                  :class="{'bg-red-100 text-blue-700': activeTab === 'info'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  Info
-                                </button>
-                                <button @click="activeTab = activeTab === 'errors' ? 'none' : 'errors'"
-                                  :class="{'bg-red-100 text-red-700': activeTab === 'errors'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  Errors
-                                </button>
-                                <button @click="activeTab = activeTab === 'raw' ? 'none' : 'raw'"
-                                  :class="{'bg-blue-100 text-blue-700': activeTab === 'raw'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  Raw
-                                </button>
-                                <button @click="activeTab = activeTab === 'interpolated' ? 'none' : 'interpolated'"
-                                  :class="{'bg-blue-100 text-blue-700': activeTab === 'interpolated'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  Raw Interpolated
-                                </button>
-                                <button @click="activeTab = activeTab === 'assertions' ? 'none' : 'assertions'"
-                                  :class="{'bg-green-100 text-green-700': activeTab === 'assertions'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  Assertions
-                                </button>
-                                <button @click="activeTab = activeTab === 'inputvars' ? 'none' : 'inputvars'"
-                                  :class="{'bg-green-100 text-green-700': activeTab === 'inputvars'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  Input Vars
-                                </button>
-                                <button @click="activeTab = activeTab === 'computedvars' ? 'none' : 'computedvars'"
-                                  :class="{'bg-green-100 text-green-700': activeTab === 'computedvars'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  Computed Vars
-                                </button>
-                                <button @click="activeTab = activeTab === 'systemout' ? 'none' : 'systemout'"
-                                  :class="{'bg-green-100 text-green-700': activeTab === 'systemout'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  System Out
-                                </button>
-                                <button @click="activeTab = activeTab === 'systemerr' ? 'none' : 'systemerr'"
-                                  :class="{'bg-green-100 text-green-700': activeTab === 'systemerr'}"
-                                  class="px-3 py-1 text-sm rounded-md bg-gray-100 hover:bg-gray-200 transition-colors">
-                                  System Error
-                                </button>
-
-                                <!-- Tab content -->
-                                <div class="w-full mt-4">
-                                  <!-- Info -->
-                                  <div x-show="activeTab === 'info'" class="bg-blue-50 rounded-lg p-4">
-                                    <template x-for="info in step.computedInfos">
-                                      <div class="text-sm text-blue-800 font-mono" x-text="info"></div>
-                                    </template>
-                                  </div>
-
-                                  <!-- Errors -->
-                                  <div x-show="activeTab === 'errors'" class="bg-red-50 rounded-lg p-4">
-                                    <template x-for="error in step.errors">
-                                      <div class="text-sm text-red-700 font-mono" x-text="error.value"></div>
-                                    </template>
-                                  </div>
-
-                                  <!-- Raw -->
-                                  <div x-show="activeTab === 'raw'" class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
-                                    <pre class="text-sm text-gray-300" x-text="atob(step.raw)"></pre>
-                                  </div>
-
-                                  <!-- Raw Intrerpolated -->
-                                  <div x-show="activeTab === 'interpolated'"
-                                    class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
-                                    <pre class="text-sm text-gray-300" x-text="atob(step.interpolated)"></pre>
-                                  </div>
-
-                                  <!-- Assertions -->
-                                  <div x-show="activeTab === 'assertions'" class="bg-gray-100 rounded-lg p-4 space-y-2">
-                                    <template x-for="assertion in step.assertionsApplied.assertions">
-                                      <div class="flex items-center space-x-2">
-                                        <span :class="assertion.isOK ? 'text-green-600' : 'text-red-600'">
-                                          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                                            <path x-show="assertion.isOK" fill-rule="evenodd"
-                                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                              clip-rule="evenodd"></path>
-                                            <path x-show="!assertion.isOK" fill-rule="evenodd"
-                                              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                                              clip-rule="evenodd"></path>
-                                          </svg>
-                                        </span>
-                                        <span class="text-sm font-mono" x-text="assertion.assertion"></span>
-                                      </div>
-                                    </template>
-                                  </div>
-
-                                  <!-- Input Vars  -->
-                                  <div x-show="activeTab === 'inputvars'"
-                                    class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
-                                    <pre class="text-sm text-gray-300" x-text="JSON.stringify(step.inputVars, null, 2)">
-                                    </pre>
-                                  </div>
-
-                                  <!-- Computed Vars -->
-                                  <div x-show="activeTab === 'computedvars'"
-                                    class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
-                                    <pre class="text-sm text-gray-300"
-                                      x-text="JSON.stringify(step.computedVars, null, 2)"></pre>
-                                  </div>
-
-                                  <!-- System Out -->
-                                  <div x-show="activeTab === 'systemout'"
-                                    class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
-                                    <pre class="text-sm text-gray-300" x-text="step.systemout"></pre>
-                                  </div>
-
-                                  <!-- System Error -->
-                                  <div x-show="activeTab === 'systemerr'"
-                                    class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
-                                    <pre class="text-sm text-gray-300" x-text="step.systemerr"></pre>
-                                  </div>
-
-                                  <div class="mt-2 p-2 bg-gray-50 text-xs text-gray-600">
-                                    <div class="flex items-center ">
-                                      <span class="font-mono" x-text="formatDate(step.start)"></span>
-                                      <div class="flex-grow mx-2 h-px bg-gray-400"></div>
-                                      <span class="font-mono" x-text="formatDuration(step.duration)"></span>
-                                      <div class="flex-grow mx-2 h-px bg-gray-400"></div>
-                                      <span class="font-mono" x-text="formatDate(step.end)"></span>
-                                    </div>
-                                  </div>
-
-                                </div> <!-- end Tab Content -->
-
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </template>
-                    </div>
-
-                    <!-- Test Case Footer -->
-                    <div class="p-2 bg-gray-50 text-xs text-gray-600">
-                      <div class="flex items-center ">
-                        <span class="font-mono" x-text="formatDate(testcase.start)"></span>
-                        <div class="flex-grow mx-2 h-px bg-gray-400"></div>
-                        <span class="font-mono" x-text="formatDuration(testcase.duration)"></span>
-                        <div class="flex-grow mx-2 h-px bg-gray-400"></div>
-                        <span class="font-mono" x-text="formatDate(testcase.end)"></span>
-                      </div>
-                    </div>
-
-                  </div>
-              </template>
-            </div>
-          </div>
-        </template>
-
-        <!-- Empty State -->
-        <template x-if="selectedSuite === null">
-          <div class="flex items-center justify-center h-full">
-            <div class="text-center">
-              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2">
-                </path>
-              </svg>
-              <h3 class="mt-2 text-sm font-medium text-gray-900">No test suite selected</h3>
-              <p class="mt-1 text-sm text-gray-500">Select a test suite from the sidebar to view details.</p>
-            </div>
-          </div>
-        </template>
-
-      </div>
-    </main>
-
-    <!-- Right Drawer -->
-    <div x-show="isModalOpen" x-on:click.away="toggleModal()" class="relative z-10" aria-labelledby="drawer-title"
-      role="dialog" aria-modal="true" x-transition x-cloak>
-      <!-- Background backdrop, show/hide based on slide-over state. -->
-      <div class="fixed inset-0"></div>
-
-      <div class="fixed inset-0 overflow-hidden">
-        <div class="absolute inset-0 overflow-hidden">
-          <div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
-            <!-- Slide-over
-                panel, show/hide based on slide-over state.
-                Entering: "transform transition ease-in-out duration-500 sm:duration-700" From: "translate-x-full"
-                To: "translate-x-0" Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
-                From: "translate-x-0" To: "translate-x-full" 
-              -->
-            <div class="pointer-events-auto w-screen max-w-3xl">
-              <div class="flex h-full flex-col overflow-y-scroll bg-white py-6 shadow-xl">
-                <div class="px-4 sm:px-6">
-                  <div class="flex items-start justify-between">
-                    <h2 class="text-base font-semibold text-gray-900" id="drawer-title">Variables</h2>
-                    <div class="ml-3 flex h-7 items-center">
-                      <button type="button" @click="isModalOpen = false"
-                        class="relative rounded-md bg-white text-gray-400 hover:text-gray-500 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:outline-hidden">
-                        <span class="absolute -inset-2.5"></span>
-                        <span class="sr-only">Close panel</span>
-                        <svg class="size-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-                          aria-hidden="true" data-slot="icon">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-                <div class="relative mt-6 flex-1 px-4 sm:px-6">
-
-                  <!-- Drawer Content -->
-                  <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                    <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">Test Suite Variables</h3>
-                    <div class="bg-gray-900 rounded-lg p-4 overflow-x-auto max-h-96">
-                      <pre class="text-sm text-gray-300"
-                        x-text="JSON.stringify(test_suites[selectedSuite]?.vars || {}, null, 2)">
-                      </pre>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </div>
-          </div>
+    <main class="main" id="main">
+      <div class="empty" id="emptyState">
+        <div class="ico">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+            <path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"></path>
+            <rect x="9" y="3" width="6" height="4" rx="1"></rect>
+          </svg>
+        </div>
+        <div>
+          <div style="font-size:13px;color:var(--fg);font-weight:500;margin-bottom:2px;">No suite selected</div>
+          <div>Pick one from the sidebar to inspect cases &amp; steps</div>
         </div>
       </div>
+    </main>
+  </div>
+</div>
+
+<!-- Drawer (Variables) -->
+<div class="drawer-backdrop" id="drawerBackdrop"></div>
+<aside class="drawer" id="drawer" aria-hidden="true">
+  <div class="drawer-head">
+    <div class="drawer-title" id="drawerTitle">Variables</div>
+    <button class="icon-btn" id="drawerClose" aria-label="Close">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"></path></svg>
+    </button>
+  </div>
+  <div class="drawer-body" id="drawerBody"></div>
+</aside>
+
+<!-- Tweaks panel -->
+<div class="tweaks" id="tweaksPanel">
+  <div class="tweaks-head">
+    Tweaks
+    <button class="icon-btn" id="tweaksClose" aria-label="Close">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"></path></svg>
+    </button>
+  </div>
+  <div class="tweaks-body">
+    <div class="tweak-row">
+      <span class="lbl">Theme</span>
+      <div class="seg" data-tweak="theme">
+        <button data-val="light">Light</button>
+        <button data-val="dark">Dark</button>
+        <button data-val="auto">Auto</button>
+      </div>
+    </div>
+    <div class="tweak-row">
+      <span class="lbl">Density</span>
+      <div class="seg" data-tweak="density">
+        <button data-val="compact">Compact</button>
+        <button data-val="default">Default</button>
+        <button data-val="cozy">Cozy</button>
+      </div>
+    </div>
+    <div class="tweak-row">
+      <span class="lbl">Accent</span>
+      <div class="seg" data-tweak="accent">
+        <button data-val="venom" title="Venom">●</button>
+        <button data-val="indigo" title="Indigo">●</button>
+        <button data-val="amber" title="Amber">●</button>
+        <button data-val="rose" title="Rose">●</button>
+      </div>
+    </div>
+    <div class="tweak-row">
+      <span class="lbl">Auto-expand failures</span>
+      <button class="toggle" id="tweakAutoExpand"></button>
+    </div>
+    <div class="tweak-row">
+      <span class="lbl">Hide passing cases</span>
+      <button class="toggle" id="tweakHidePass"></button>
     </div>
   </div>
-  <script>
-    document.addEventListener('alpine:init', () => {
-      Alpine.data('methods', () => ({
-        isModalOpen: false,
-        toggleModal() {
-          this.isModalOpen = !this.isModalOpen;
-        },
-        selectedSuite: null,
-        selectSuite(index) {
-          this.selectedSuite = index;
-        },
+</div>
 
-        renderMarkdown(text) {
-          if (!text) return '';
-          const converter = new showdown.Converter();
-          const dirty = converter.makeHtml(text);
-          // Sanitise the generated HTML to prevent XSS through user-supplied
-          // content (testsuite descriptions, step results, etc.).
-          return DOMPurify.sanitize(dirty);
-        },
+<script>
+window.__REPORT_DATA__ = {{.JSONValue}};
+</script>
 
-        formatDuration(seconds) {
-          return `${parseFloat(seconds).toFixed(2)}s`;
-        },
+<script>
+/* Venom Test Report — vanilla JS UI */
+(function () {
+  const data = window.__REPORT_DATA__ || { test_suites: [] };
+  const suites = data.test_suites || [];
 
-        formatDate(dateString) {
-          if (!dateString) return 'N/A';
-          return new Date(dateString).toLocaleString();
-        },
-      }));
+  // ---------- helpers ----------
+  const __q = (s, r=document) => r.querySelector(s);
+  const __qa = (s, r=document) => Array.from(r.querySelectorAll(s));
+  const fmt = {
+    dur(s) {
+      if (s == null || isNaN(s)) return '—';
+      const n = +s;
+      if (n < 0.001) return '<1ms';
+      if (n < 1) return Math.round(n * 1000) + 'ms';
+      if (n < 60) return n.toFixed(2) + 's';
+      const m = Math.floor(n/60), r = n - m*60;
+      return `${m}m ${r.toFixed(1)}s`;
+    },
+    date(s) {
+      if (!s) return '—';
+      try {
+        const d = new Date(s);
+        return d.toLocaleString(undefined, { hour12: false });
+      } catch { return s; }
+    },
+    time(s) {
+      if (!s) return '—';
+      try {
+        const d = new Date(s);
+        const pad = n => String(n).padStart(2, '0');
+        return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${String(d.getMilliseconds()).padStart(3, '0')}`;
+      } catch { return s; }
+    },
+    decode(v) {
+      if (v == null) return '';
+      if (typeof v !== 'string') {
+        try { return JSON.stringify(v, null, 2); } catch { return String(v); }
+      }
+      // Try base64 first (the Go side encodes raw/interpolated as base64).
+      try { return decodeURIComponent(escape(atob(v))); }
+      catch {
+        try { return atob(v); }
+        catch { return v; }
+      }
+    },
+  };
+  const lc = s => (s || '').toLowerCase();
+  const escapeHtml = s => String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 
-      Alpine.data('reportData', () => ({{.JSONValue}}));
-    })
+  // Render markdown safely (DOMPurify + showdown loaded above).
+  function renderMarkdown(text) {
+    if (!text) return '';
+    if (typeof showdown === 'undefined' || typeof DOMPurify === 'undefined') {
+      return escapeHtml(text);
+    }
+    const converter = new showdown.Converter({ simplifiedAutoLink: true, openLinksInNewWindow: true });
+    return DOMPurify.sanitize(converter.makeHtml(text));
+  }
 
-  </script>
+  // YAML highlighter — tokenize first, then escape & wrap to avoid regex collision with injected markup
+  function highlightYaml(src) {
+    if (!src) return '';
+    const tokens = [];
+    const place = (cls, txt) => { tokens.push({cls, txt}); return `${tokens.length-1}`; };
+    let s = src;
+    s = s.replace(/^(\s*)(#.*)$/gm, (_, sp, c) => sp + place('yc', c));
+    s = s.replace(/('[^']*'|"[^"]*")/g, m => place('ys', m));
+    s = s.replace(/^(\s*)(-)(\s)/gm, (_, sp, d, e) => sp + place('yd', d) + e);
+    s = s.replace(/^(\s*)([A-Za-z0-9_.\-]+)(\s*:)/gm, (_, sp, k, c) => sp + place('yk', k) + c);
+    s = s.replace(/(:\s*)(true|false|null|~)\b/g, (_, c, b) => c + place('yb', b));
+    s = s.replace(/(:\s*)(-?\d+(?:\.\d+)?)\b/g, (_, c, n) => c + place('yn', n));
+    let out = escapeHtml(s);
+    out = out.replace(/(\d+)/g, (_, i) => {
+      const t = tokens[+i];
+      return `<span class="${t.cls}">${escapeHtml(t.txt)}</span>`;
+    });
+    return out;
+  }
+  function highlightJson(src) {
+    if (!src) return '';
+    const tokens = [];
+    const place = (cls, txt) => { tokens.push({cls, txt}); return `${tokens.length-1}`; };
+    let s = src;
+    s = s.replace(/("(?:\\.|[^"\\])*")(\s*:)/g, (_, k, c) => place('yk', k) + c);
+    s = s.replace(/(:\s*)("(?:\\.|[^"\\])*")/g, (_, c, v) => c + place('ys', v));
+    s = s.replace(/(:\s*)(-?\d+(?:\.\d+)?)/g, (_, c, n) => c + place('yn', n));
+    s = s.replace(/(:\s*)(true|false|null)\b/g, (_, c, b) => c + place('yb', b));
+    let out = escapeHtml(s);
+    out = out.replace(/(\d+)/g, (_, i) => {
+      const t = tokens[+i];
+      return `<span class="${t.cls}">${escapeHtml(t.txt)}</span>`;
+    });
+    return out;
+  }
+
+  // ---------- state ----------
+  const state = {
+    selected: null,
+    filter: 'all',
+    query: '',
+    expandedTC: new Set(),
+    expandedSteps: new Set(),
+    activeTabs: new Map(),
+    tweaks: loadTweaks(),
+  };
+
+  function loadTweaks() {
+    let t = {};
+    try { t = JSON.parse(localStorage.getItem('venom.tweaks') || '{}'); } catch {}
+    return Object.assign({
+      theme: 'light',
+      density: 'default',
+      accent: 'venom',
+      autoExpand: true,
+      hidePass: false,
+    }, t);
+  }
+  function saveTweaks() {
+    try { localStorage.setItem('venom.tweaks', JSON.stringify(state.tweaks)); } catch {}
+  }
+
+  // ---------- top summary ----------
+  function renderSummary() {
+    const elTop = __q('#topRunDate');
+    elTop.textContent = data.start ? fmt.date(data.start) : '';
+
+    const totals = { pass: 0, fail: 0, skip: 0, total: 0 };
+    suites.forEach(s => {
+      totals.total++;
+      const k = lc(s.status);
+      if (totals[k] != null) totals[k]++;
+    });
+
+    const root = __q('#summary');
+    root.innerHTML = `
+      <span class="global-status ${lc(data.status)}">${escapeHtml(data.status || '—')}</span>
+      <span class="summary-divider"></span>
+      <span class="summary-stat"><span class="dot pass"></span><span class="num">${totals.pass}</span> <span style="color:var(--fg-dim)">pass</span></span>
+      <span class="summary-stat"><span class="dot fail"></span><span class="num" style="color:${totals.fail>0?'var(--fail-strong)':''}">${totals.fail}</span> <span style="color:var(--fg-dim)">fail</span></span>
+      <span class="summary-stat"><span class="dot skip"></span><span class="num">${totals.skip}</span> <span style="color:var(--fg-dim)">skip</span></span>
+      <span class="summary-divider"></span>
+      <span class="summary-stat"><span style="color:var(--fg-dim)">total</span><span class="num">${totals.total}</span></span>
+      <span class="summary-stat"><span style="color:var(--fg-dim)">duration</span><span class="num">${fmt.dur(data.duration)}</span></span>
+    `;
+  }
+
+  // ---------- filters ----------
+  function renderFilters() {
+    const totals = { all: suites.length, pass: 0, fail: 0, skip: 0 };
+    suites.forEach(s => { const k = lc(s.status); if (totals[k] != null) totals[k]++; });
+    const items = [
+      { id: 'all', label: 'All', n: totals.all },
+      { id: 'fail', label: 'Fail', n: totals.fail, dot: 'fail' },
+      { id: 'pass', label: 'Pass', n: totals.pass, dot: 'pass' },
+      { id: 'skip', label: 'Skip', n: totals.skip, dot: 'skip' },
+    ];
+    __q('#filterRow').innerHTML = items.map(i => `
+      <button class="chip ${state.filter === i.id ? 'active':''}" data-filter="${i.id}">
+        ${i.dot ? `<span class="dot ${i.dot}"></span>` : ''}${i.label}
+        <span style="color:var(--fg-dim)">${i.n}</span>
+      </button>`).join('');
+    __qa('#filterRow .chip').forEach(b => b.onclick = () => {
+      state.filter = b.dataset.filter;
+      renderFilters();
+      renderSuiteList();
+    });
+  }
+
+  // ---------- sidebar ----------
+  function visibleSuites() {
+    const q = state.query.trim().toLowerCase();
+    return suites
+      .map((s, i) => ({ s, i }))
+      .filter(({ s }) => {
+        if (state.filter !== 'all' && lc(s.status) !== state.filter) return false;
+        if (q && !((s.name||'') + ' ' + (s.shortname||'') + ' ' + (s.filepath||'')).toLowerCase().includes(q)) return false;
+        return true;
+      });
+  }
+  function renderSuiteList() {
+    const list = __q('#suiteList');
+    const items = visibleSuites();
+    if (!items.length) {
+      list.innerHTML = `<div style="padding:18px 14px;color:var(--fg-dim);font-size:12px">No suites match.</div>`;
+      return;
+    }
+    list.innerHTML = items.map(({ s, i }) => {
+      const sel = state.selected === i ? 'selected' : '';
+      const stCls = lc(s.status);
+      const tcCount = (s.testcases || []).length;
+      const failed = +s.nbTestcasesFail || 0;
+      return `
+        <div class="suite-row ${sel}" data-i="${i}">
+          <div class="suite-idx">${String(i+1).padStart(3,'0')}</div>
+          <div class="suite-main">
+            <div class="suite-name" title="${escapeHtml(s.name||'')}">${escapeHtml(s.name || s.shortname || 'Unnamed')}</div>
+            <div class="suite-meta">
+              <span>${tcCount} ${tcCount===1?'case':'cases'}</span>
+              ${failed?`<span style="color:var(--fail-strong)">${failed} fail</span>`:''}
+              <span>${fmt.dur(s.duration)}</span>
+            </div>
+          </div>
+          <div class="suite-status ${stCls}" title="${escapeHtml(s.status||'')}"></div>
+        </div>`;
+    }).join('');
+    __qa('#suiteList .suite-row').forEach(r => r.onclick = () => selectSuite(+r.dataset.i));
+  }
+
+  // ---------- main suite view ----------
+  function selectSuite(i) {
+    state.selected = i;
+    state.expandedTC.clear();
+    state.expandedSteps.clear();
+    state.activeTabs.clear();
+    if (state.tweaks.autoExpand && i != null && suites[i]) {
+      const s = suites[i];
+      (s.testcases || []).forEach((tc, ti) => {
+        if (lc(tc.status) === 'fail') state.expandedTC.add(ti);
+      });
+    }
+    renderSuiteList();
+    renderMain();
+    const main = __q('#main');
+    if (main) main.scrollTop = 0;
+  }
+  function renderMain() {
+    const main = __q('#main');
+    if (state.selected == null || !suites[state.selected]) {
+      main.innerHTML = `<div class="empty"><div class="ico">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+          <path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"></path>
+          <rect x="9" y="3" width="6" height="4" rx="1"></rect></svg></div>
+        <div><div style="font-size:13px;color:var(--fg);font-weight:500;margin-bottom:2px;">No suite selected</div>
+        <div>Pick one from the sidebar to inspect cases &amp; steps</div></div></div>`;
+      return;
+    }
+    const s = suites[state.selected];
+    const tcs = s.testcases || [];
+    const desc = s.description ? `<div class="suite-description">${renderMarkdown(s.description)}</div>` : '';
+
+    main.innerHTML = `
+      <div class="main-inner">
+        <header class="suite-header">
+          <div class="breadcrumb">
+            <span>${escapeHtml(s.filepath || s.filename || '')}</span>
+          </div>
+          <h1 class="suite-title">
+            <span>${escapeHtml(s.name || 'Unnamed')}</span>
+            <span class="status-tag ${lc(s.status)}">${escapeHtml(s.status||'—')}</span>
+          </h1>
+          <div class="suite-meta-row">
+            <span><span class="label">Cases</span><span class="val">${tcs.length}</span></span>
+            <span><span class="label">Pass</span><span class="val" style="color:var(--pass-strong)">${s.nbTestcasesPass||0}</span></span>
+            <span><span class="label">Fail</span><span class="val" style="color:${(s.nbTestcasesFail||0)>0?'var(--fail-strong)':'var(--fg)'}">${s.nbTestcasesFail||0}</span></span>
+            <span><span class="label">Skip</span><span class="val">${s.nbTestcasesSkip||0}</span></span>
+            <span><span class="label">Duration</span><span class="val">${fmt.dur(s.duration)}</span></span>
+            <span><span class="label">Started</span><span class="val">${fmt.time(s.start)}</span></span>
+            ${s.workdir ? `<span><span class="label">Workdir</span><span class="val" title="${escapeHtml(s.workdir)}">${escapeHtml(s.workdir)}</span></span>` : ''}
+            <span><span class="label">Vars</span><button class="vars-btn" id="varsBtn">${Object.keys(s.vars||{}).length} vars →</button></span>
+          </div>
+          ${desc}
+        </header>
+        <div id="tcList"></div>
+      </div>`;
+
+    const varsBtn = __q('#varsBtn');
+    if (varsBtn) varsBtn.onclick = () => openDrawer('Test suite variables', s.vars || {});
+
+    renderTestcases(s, tcs);
+  }
+
+  function renderTestcases(suite, tcs) {
+    const root = __q('#tcList');
+    if (!tcs.length) {
+      root.innerHTML = `<div style="color:var(--fg-dim);padding:18px 0;">No test cases.</div>`;
+      return;
+    }
+    root.innerHTML = tcs.map((tc, ti) => {
+      if (state.tweaks.hidePass && lc(tc.status) === 'pass') return '';
+      const expanded = state.expandedTC.has(ti);
+      const stCls = lc(tc.status);
+      const steps = tc.results || [];
+      return `
+        <div class="tc ${stCls} ${expanded?'expanded':''}" data-ti="${ti}">
+          <div class="tc-head" data-tc-toggle="${ti}">
+            <span class="tc-toggle">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="m9 18 6-6-6-6"></path></svg>
+            </span>
+            <span class="tc-name"><span class="prefix">case</span>${escapeHtml(tc.name||'')}</span>
+            <span class="tc-dur">${steps.length} ${steps.length===1?'step':'steps'} · ${fmt.dur(tc.duration)}</span>
+            <span class="status-tag ${stCls}">${escapeHtml(tc.status||'—')}</span>
+          </div>
+          <div class="tc-body">${expanded ? renderSteps(ti, steps) : ''}</div>
+        </div>`;
+    }).join('');
+
+    __qa('#tcList [data-tc-toggle]').forEach(h => h.onclick = () => {
+      const ti = +h.dataset.tcToggle;
+      if (state.expandedTC.has(ti)) state.expandedTC.delete(ti);
+      else state.expandedTC.add(ti);
+      renderTestcases(suite, tcs);
+    });
+
+    bindStepHandlers(suite, tcs);
+  }
+
+  function renderSteps(ti, steps) {
+    if (!steps.length) return `<div style="padding:14px;color:var(--fg-dim);font-size:12px">No steps</div>`;
+    return steps.map((step, si) => {
+      const key = `${ti}.${si}`;
+      const expanded = state.expandedSteps.has(key);
+      const stCls = lc(step.status);
+      const num = (step.number != null ? step.number + 1 : si + 1);
+      const stepName = step.name || step.type || 'step';
+      const errs = (step.errors || []).filter(e => e && e.value);
+      return `
+        <div class="step ${stCls} ${expanded?'expanded':''}" data-step-key="${key}">
+          <div class="step-head" data-step-toggle="${key}">
+            <span class="step-num">step ${String(num).padStart(2,'0')}${step.rangedEnable?`:${step.rangedIndex}`:''}</span>
+            <span class="step-name">${escapeHtml(stepName)}</span>
+            ${step.retries>0?`<span class="step-retries">↻ ${step.retries}</span>`:''}
+            <span class="step-dur">${fmt.dur(step.duration)}</span>
+            <span class="step-toggle">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="m9 18 6-6-6-6"></path></svg>
+            </span>
+          </div>
+          <div class="step-body">${expanded ? renderStepBody(key, step, errs) : ''}</div>
+        </div>`;
+    }).join('');
+  }
+
+  function renderStepBody(key, step, errs) {
+    const tabs = [];
+    if (errs.length) tabs.push({ id: 'errors', label: 'Errors', n: errs.length, hasError: true });
+    const assertions = step.assertionsApplied?.assertions || [];
+    if (assertions.length) {
+      const failedN = assertions.filter(a => !a.isOK).length;
+      tabs.push({ id: 'assertions', label: 'Assertions', n: assertions.length, hasError: failedN > 0 });
+    }
+    if (step.computedInfos && step.computedInfos.length) tabs.push({ id: 'info', label: 'Info', n: step.computedInfos.length });
+    if (step.raw) tabs.push({ id: 'raw', label: 'Raw' });
+    if (step.interpolated && step.interpolated !== step.raw) tabs.push({ id: 'interpolated', label: 'Interpolated' });
+    if (step.inputVars && Object.keys(step.inputVars).length) tabs.push({ id: 'inputvars', label: 'Input vars', n: Object.keys(step.inputVars).length });
+    if (step.computedVars && Object.keys(step.computedVars).length) tabs.push({ id: 'computedvars', label: 'Computed vars', n: Object.keys(step.computedVars).length });
+    if (step.systemout && String(step.systemout).trim()) tabs.push({ id: 'systemout', label: 'stdout' });
+    if (step.systemerr && String(step.systemerr).trim()) tabs.push({ id: 'systemerr', label: 'stderr' });
+
+    if (!tabs.length) {
+      return `<div style="color:var(--fg-dim);font-size:12px;padding:8px 0;">No additional output for this step.</div>${renderTimeline(step)}`;
+    }
+
+    let active = state.activeTabs.get(key);
+    if (!tabs.find(t => t.id === active)) {
+      active = tabs.find(t => t.hasError)?.id || tabs[0].id;
+      state.activeTabs.set(key, active);
+    }
+
+    return `
+      <div class="tabs" data-tabs="${key}">
+        ${tabs.map(t => `<button class="tab-btn ${t.id===active?'active':''} ${t.hasError?'has-error':''}" data-tab="${t.id}">${t.label}${t.n!=null?`<span class="badge">${t.n}</span>`:''}</button>`).join('')}
+      </div>
+      <div class="tab-content">${renderTab(active, step, errs, assertions)}</div>
+      ${renderTimeline(step)}
+    `;
+  }
+
+  function renderTab(id, step, errs, assertions) {
+    switch (id) {
+      case 'errors':
+        return `<div class="errors-panel">${errs.map(e => escapeHtml(e.value)).join('\n\n')}</div>`;
+      case 'assertions':
+        if (!assertions.length) return `<div style="color:var(--fg-dim);font-size:12px">No assertions.</div>`;
+        return `<div>${assertions.map(a => `
+          <div class="assertion-row ${a.isOK?'':'fail'}">
+            <span class="mark">${a.isOK?'✓':'✗'}</span>
+            <span>${escapeHtml(a.assertion)}${!a.isOK && a.error?`<div style="color:var(--fail-strong);margin-top:2px;font-size:11.5px">${escapeHtml(a.error.value || a.error)}</div>`:''}</span>
+          </div>`).join('')}</div>`;
+      case 'info':
+        return `<div class="info-panel">${(step.computedInfos||[]).map(escapeHtml).join('\n')}</div>`;
+      case 'raw':
+        return `<pre class="code">${highlightYaml(fmt.decode(step.raw))}</pre>`;
+      case 'interpolated':
+        return `<pre class="code">${highlightYaml(fmt.decode(step.interpolated))}</pre>`;
+      case 'inputvars':
+        return `<pre class="code">${highlightJson(JSON.stringify(step.inputVars, null, 2))}</pre>`;
+      case 'computedvars':
+        return `<pre class="code">${highlightJson(JSON.stringify(step.computedVars, null, 2))}</pre>`;
+      case 'systemout':
+        return `<pre class="code">${escapeHtml(step.systemout)}</pre>`;
+      case 'systemerr':
+        return `<pre class="code">${escapeHtml(step.systemerr)}</pre>`;
+      default:
+        return '';
+    }
+  }
+
+  function renderTimeline(step) {
+    return `
+      <div class="timeline">
+        <span>${fmt.time(step.start)}</span>
+        <span class="line"></span>
+        <span class="dur">${fmt.dur(step.duration)}</span>
+        <span class="line"></span>
+        <span>${fmt.time(step.end)}</span>
+      </div>`;
+  }
+
+  function bindStepHandlers(suite, tcs) {
+    __qa('#tcList [data-step-toggle]').forEach(h => h.onclick = () => {
+      const key = h.dataset.stepToggle;
+      if (state.expandedSteps.has(key)) state.expandedSteps.delete(key);
+      else state.expandedSteps.add(key);
+      renderTestcases(suite, tcs);
+    });
+    __qa('#tcList [data-tabs]').forEach(tabs => {
+      const key = tabs.dataset.tabs;
+      __qa('button.tab-btn', tabs).forEach(b => b.onclick = () => {
+        state.activeTabs.set(key, b.dataset.tab);
+        renderTestcases(suite, tcs);
+      });
+    });
+  }
+
+  // ---------- drawer ----------
+  function openDrawer(title, varsObj) {
+    __q('#drawerTitle').textContent = title;
+    __q('#drawerBody').innerHTML = `<pre class="code">${highlightJson(JSON.stringify(varsObj, null, 2))}</pre>`;
+    __q('#drawer').classList.add('open');
+    __q('#drawerBackdrop').classList.add('open');
+  }
+  function closeDrawer() {
+    __q('#drawer').classList.remove('open');
+    __q('#drawerBackdrop').classList.remove('open');
+  }
+  __q('#drawerClose').onclick = closeDrawer;
+  __q('#drawerBackdrop').onclick = closeDrawer;
+
+  // ---------- search ----------
+  __q('#searchInput').addEventListener('input', e => {
+    state.query = e.target.value;
+    renderSuiteList();
+  });
+
+  // ---------- tweaks ----------
+  const accentMap = {
+    venom: 'oklch(58% 0.13 158)',
+    indigo: 'oklch(55% 0.18 270)',
+    amber: 'oklch(70% 0.16 75)',
+    rose: 'oklch(60% 0.18 18)',
+  };
+  function applyTweaks() {
+    const t = state.tweaks;
+    let theme = t.theme;
+    if (theme === 'auto') theme = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.setAttribute('data-density', t.density);
+    document.documentElement.style.setProperty('--accent', accentMap[t.accent] || accentMap.venom);
+    if (t.accent !== 'venom') {
+      document.documentElement.style.setProperty('--pass', accentMap[t.accent] || accentMap.venom);
+    } else {
+      document.documentElement.style.removeProperty('--pass');
+    }
+    __qa('.seg').forEach(seg => {
+      const k = seg.dataset.tweak;
+      __qa('button', seg).forEach(b => b.classList.toggle('on', b.dataset.val === t[k]));
+    });
+    __q('#tweakAutoExpand').classList.toggle('on', !!t.autoExpand);
+    __q('#tweakHidePass').classList.toggle('on', !!t.hidePass);
+    saveTweaks();
+  }
+  __qa('.seg').forEach(seg => {
+    const k = seg.dataset.tweak;
+    __qa('button', seg).forEach(b => b.onclick = () => {
+      state.tweaks[k] = b.dataset.val;
+      applyTweaks();
+      if (state.selected != null) renderMain();
+    });
+  });
+  __q('#tweakAutoExpand').onclick = () => { state.tweaks.autoExpand = !state.tweaks.autoExpand; applyTweaks(); };
+  __q('#tweakHidePass').onclick = () => { state.tweaks.hidePass = !state.tweaks.hidePass; applyTweaks(); if (state.selected != null) renderMain(); };
+
+  __q('#tweaksBtn').onclick = () => __q('#tweaksPanel').classList.toggle('open');
+  __q('#tweaksClose').onclick = () => __q('#tweaksPanel').classList.remove('open');
+
+  // keyboard
+  window.addEventListener('keydown', e => {
+    if (e.target.tagName === 'INPUT') return;
+    if (e.key === 't' || e.key === 'T') __q('#tweaksPanel').classList.toggle('open');
+    if (e.key === 'Escape') { closeDrawer(); __q('#tweaksPanel').classList.remove('open'); }
+    if (e.key === '/' && !e.metaKey && !e.ctrlKey) { e.preventDefault(); __q('#searchInput').focus(); }
+    if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && state.selected != null) {
+      const list = visibleSuites().map(v => v.i);
+      const pos = list.indexOf(state.selected);
+      if (pos >= 0) {
+        const next = e.key === 'ArrowDown' ? Math.min(list.length-1, pos+1) : Math.max(0, pos-1);
+        selectSuite(list[next]);
+        const el = document.querySelector(`.suite-row[data-i="${list[next]}"]`);
+        if (el) el.scrollIntoView({ block: 'nearest' });
+        e.preventDefault();
+      }
+    }
+  });
+
+  // ---------- init ----------
+  applyTweaks();
+  renderSummary();
+  renderFilters();
+  renderSuiteList();
+  // auto-select first failed, or first
+  const firstFail = suites.findIndex(s => lc(s.status) === 'fail');
+  selectSuite(firstFail >= 0 ? firstFail : (suites.length ? 0 : null));
+})();
+</script>
 </body>
-
 </html>


### PR DESCRIPTION
HTML Report more compact / add filter and search.

TLS, SSH host key, path traversal, secret logging
  - Drop the loop logging secret names on testsuite startup.
  - Add ResolveWorkdirPath helper rejecting absolute paths and ".." escapes;
    apply it across 8 file-based executors (sql, dbfixtures, redis, mongo,
    kafka, ovhapi, http, readfile).
  - SMTP/IMAP: TLS now verified by default; opt-out via `ignore_verify_ssl`.
  - SSH: host key verified against ~/.ssh/known_hosts by default; opt-out via
    `insecure_ignore_host_key`. Removed os.ExpandEnv on `privatekey`.
  - Update tests/ssh.yml accordingly.

Plugin loading, HTTP TLS paths, exec hardening, SSH timeout,
  HTML XSS, SSH privatekey
  - venom.go: load .so plugins only from --lib-dir (no auto-discovery from
    workdir); validate plugin name against [A-Za-z0-9_-].
  - HTTP: reject absolute paths for tls_root_ca / tls_client_cert /
    tls_client_key; detect inline PEM via "-----BEGIN".
  - exec: create temp script atomically (O_EXCL, 0o700); fix Windows .ps1
    rename; document stdout/stderr synchronization.
  - SSH: add `timeout` field (default 30s); restrict privatekey absolute
    paths to $HOME, resolve relative paths under workdir.
  - HTML report: sanitize markdown rendering with DOMPurify.
  - Update READMEs (http, smtp, imap, ssh, plugins).

Dependencies, update checksums, DSN redaction
  - Migrate executors/rabbitmq from archived streadway/amqp to
    rabbitmq/amqp091-go (drop-in).
  - Remove direct dependency on mattn/go-sqlite3; consolidate on
    modernc.org/sqlite with `sqlite3` alias for YAML backward compatibility.
  - venom update: download checksums.txt from the GitHub release and verify
    SHA256 of the binary before applying; refuse update if checksums absent.
  - Add RedactURI helper and apply it to SQL, dbfixtures and Mongo
    connection logs to prevent credential leaks via venom.log.
  - Fix missing `mapstructure:"..."` tags on snake_case bool/int fields
    (ignore_verify_ssl, insecure_ignore_host_key, timeout) which silently
    reverted the opt-in/opt-out flags to zero-value.

  BREAKING CHANGES
  - SMTP/IMAP require `ignore_verify_ssl: true` for self-signed certs.
  - SSH requires populated ~/.ssh/known_hosts or
    `insecure_ignore_host_key: true`.
  - File paths in the affected executors must be relative to the testsuite
    workdir; absolute paths are rejected.
  - HTTP TLS file paths must be relative to workdir.
  - SSH privatekey absolute paths must be under $HOME.
  - .so plugins now require --lib-dir.
  - `venom update` requires the GitHub release to publish checksums.txt
    alongside binaries.