### PR TITLE
fix: Redact declared secrets from reports and debug logs

### DIFF
--- a/executors/exec/exec.go
+++ b/executors/exec/exec.go
@@ -194,7 +194,7 @@ func (Executor) Run(ctx context.Context, step venom.TestStep) (interface{}, erro
 			if n > 0 {
 				chunk := buf[:n]
 				sb.Write(chunk)
-				venom.Debug(ctx, venom.HideSensitive(ctx, string(chunk)))
+				venom.Debug(ctx, "%s", string(chunk))
 			}
 			if err != nil {
 				break

--- a/log.go
+++ b/log.go
@@ -2,9 +2,10 @@ package venom
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -43,55 +44,161 @@ func asJsonString(i interface{}) string {
 
 // HideSensitive replace the value with __hidden__
 func HideSensitive(ctx context.Context, arg interface{}) string {
-	s := ctx.Value(ContextKey("secrets"))
-
-	// Fast path: if no secrets to hide, avoid unnecessary string conversion
-	if s == nil {
+	secrets, ok := ctx.Value(ContextKey("secrets")).([]string)
+	if !ok || len(secrets) == 0 {
 		if str, ok := arg.(string); ok {
 			return str
 		}
 		return fmt.Sprint(arg)
 	}
-	cleanVars := fmt.Sprint(arg)
 
-	switch reflect.TypeOf(s).Kind() {
-	case reflect.Slice:
-		secrets := reflect.ValueOf(s)
-		for i := 0; i < secrets.Len(); i++ {
-			secret := fmt.Sprint(secrets.Index(i).Interface())
-			cleanVars = strings.ReplaceAll(cleanVars, secret, "__hidden__")
+	return replaceSecrets(fmt.Sprint(arg), secrets)
+}
+
+func replaceSecrets(s string, secrets []string) string {
+	sorted := append([]string(nil), secrets...)
+	sort.Slice(sorted, func(i, j int) bool { return len(sorted[i]) > len(sorted[j]) })
+	for _, secret := range sorted {
+		if secret == "" {
+			continue
+		}
+		s = strings.ReplaceAll(s, secret, "__hidden__")
+	}
+	return s
+}
+
+func secretKeySet(secretKeys []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(secretKeys))
+	for _, k := range secretKeys {
+		set[k] = struct{}{}
+	}
+	return set
+}
+
+func redactMapVars(ctx context.Context, vars H, secretKeys []string) {
+	if len(vars) == 0 || len(secretKeys) == 0 {
+		return
+	}
+	secretSet := secretKeySet(secretKeys)
+	for k, val := range vars {
+		if strings.HasPrefix(k, "venom.") {
+			continue
+		}
+		if _, ok := secretSet[k]; ok {
+			vars[k] = "__hidden__"
+			continue
+		}
+		vars[k] = HideSensitive(ctx, val)
+	}
+}
+
+func redactStringMap(ctx context.Context, vars map[string]string, secretKeys []string) {
+	if len(vars) == 0 || len(secretKeys) == 0 {
+		return
+	}
+	secretSet := secretKeySet(secretKeys)
+	for k, val := range vars {
+		if strings.HasPrefix(k, "venom.") {
+			continue
+		}
+		if _, ok := secretSet[k]; ok {
+			vars[k] = "__hidden__"
+			continue
+		}
+		vars[k] = HideSensitive(ctx, val)
+	}
+}
+
+func redactLogArgs(ctx context.Context, args ...interface{}) []interface{} {
+	if ctx == nil {
+		return args
+	}
+	secrets, ok := ctx.Value(ContextKey("secrets")).([]string)
+	if !ok || len(secrets) == 0 {
+		return args
+	}
+	if len(args) == 0 {
+		return args
+	}
+	redacted := make([]interface{}, len(args))
+	for i, arg := range args {
+		redacted[i] = HideSensitive(ctx, arg)
+	}
+	return redacted
+}
+
+// hideSensitiveBytes redacts secrets in byte-oriented step output while preserving []byte type for JSON encoding.
+func hideSensitiveBytes(ctx context.Context, data interface{}) []byte {
+	if data == nil {
+		return nil
+	}
+	switch v := data.(type) {
+	case []byte:
+		return []byte(HideSensitive(ctx, string(v)))
+	case string:
+		return []byte(HideSensitive(ctx, v))
+	default:
+		return []byte(HideSensitive(ctx, fmt.Sprint(v)))
+	}
+}
+
+func appendDerivedSecrets(secrets []string, seen map[string]struct{}, vars H, secretKeys []string) []string {
+	secretSet := secretKeySet(secretKeys)
+	add := func(value string) {
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		secrets = append(secrets, value)
+	}
+
+	for _, key := range secretKeys {
+		val := fmt.Sprint(vars[key])
+		if val != "" && val != "<nil>" {
+			add(base64.StdEncoding.EncodeToString([]byte(val)))
 		}
 	}
 
-	return cleanVars
+	if _, ok := secretSet["basic_auth_password"]; ok {
+		user := fmt.Sprint(vars["basic_auth_user"])
+		pass := fmt.Sprint(vars["basic_auth_password"])
+		if pass != "" && pass != "<nil>" {
+			add(base64.StdEncoding.EncodeToString([]byte(user + ":" + pass)))
+		}
+	}
+
+	return secrets
 }
 
 func Debug(ctx context.Context, format string, args ...interface{}) {
 	fields := fieldsFromContext(ctx, fields...)
-	logger.WithFields(fields).Debugf(format, args...)
+	logger.WithFields(fields).Debugf(format, redactLogArgs(ctx, args...)...)
 }
 
 func Info(ctx context.Context, format string, args ...interface{}) {
 	fields := fieldsFromContext(ctx, fields...)
-	logger.WithFields(fields).Infof(format, args...)
+	logger.WithFields(fields).Infof(format, redactLogArgs(ctx, args...)...)
 }
 
 func Warn(ctx context.Context, format string, args ...interface{}) {
 	fields := fieldsFromContext(ctx, fields...)
-	logger.WithFields(fields).Warnf(format, args...)
+	logger.WithFields(fields).Warnf(format, redactLogArgs(ctx, args...)...)
 }
 
 func Warning(ctx context.Context, format string, args ...interface{}) {
 	fields := fieldsFromContext(ctx, fields...)
-	logger.WithFields(fields).Warningf(format, args...)
+	logger.WithFields(fields).Warningf(format, redactLogArgs(ctx, args...)...)
 }
 
 func Error(ctx context.Context, format string, args ...interface{}) {
 	fields := fieldsFromContext(ctx, fields...)
-	logger.WithFields(fields).Errorf(format, args...)
+	logger.WithFields(fields).Errorf(format, redactLogArgs(ctx, args...)...)
 }
 
 func Fatal(ctx context.Context, format string, args ...interface{}) {
 	fields := fieldsFromContext(ctx, fields...)
-	logger.WithFields(fields).Fatalf(format, args...)
+	logger.WithFields(fields).Fatalf(format, redactLogArgs(ctx, args...)...)
 }

--- a/log.go
+++ b/log.go
@@ -122,9 +122,24 @@ func redactLogArgs(ctx context.Context, args ...interface{}) []interface{} {
 	}
 	redacted := make([]interface{}, len(args))
 	for i, arg := range args {
-		redacted[i] = HideSensitive(ctx, arg)
+		redacted[i] = redactLogArg(secrets, arg)
 	}
 	return redacted
+}
+
+// redactLogArg redacts a single log argument. It only replaces the argument
+// with a string when a secret was actually found, so non-string arguments keep
+// their original type and format verbs like %d, %f and %t still work.
+func redactLogArg(secrets []string, arg interface{}) interface{} {
+	if arg == nil {
+		return nil
+	}
+	original := fmt.Sprint(arg)
+	cleaned := replaceSecrets(original, secrets)
+	if cleaned == original {
+		return arg
+	}
+	return cleaned
 }
 
 // hideSensitiveBytes redacts secrets in byte-oriented step output while preserving []byte type for JSON encoding.

--- a/log_test.go
+++ b/log_test.go
@@ -44,3 +44,24 @@ func TestLogFunctionsRedactSecrets(t *testing.T) {
 	assert.NotContains(t, buf.String(), "my_secret")
 	assert.Contains(t, buf.String(), "__hidden__")
 }
+
+func TestLogFunctionsPreserveNonStringFormatting(t *testing.T) {
+	InitTestLogger(t)
+	ctx := context.WithValue(context.Background(), ContextKey("secrets"), []string{"my_secret"})
+
+	var buf bytes.Buffer
+	logger.Logger.SetOutput(&buf)
+	logger.Logger.SetLevel(logrus.DebugLevel)
+	defer logger.Logger.SetOutput(os.Stdout)
+
+	Info(ctx, "Step #%d-%d content is: %s", 3, 7, "my_secret")
+	out := buf.String()
+	assert.NotContains(t, out, "%!d")
+	assert.Contains(t, out, "Step #3-7 content is: __hidden__")
+
+	buf.Reset()
+	Debug(ctx, "count=%d ratio=%.2f ok=%t", 42, 1.5, true)
+	out = buf.String()
+	assert.NotContains(t, out, "%!")
+	assert.Contains(t, out, "count=42 ratio=1.50 ok=true")
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,9 +1,12 @@
 package venom
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,4 +19,28 @@ func TestHideSensitive(t *testing.T) {
 	assert.Equal(t, "1234", HideSensitive(ctx, 1234))
 	assert.Equal(t, "__hidden__!", HideSensitive(ctx, "Doe!"))
 	assert.Equal(t, "__hidden__ __hidden__", HideSensitive(ctx, "Joe Doe"))
+}
+
+func TestLogFunctionsRedactSecrets(t *testing.T) {
+	InitTestLogger(t)
+	ctx := context.WithValue(context.Background(), ContextKey("secrets"), []string{"my_secret"})
+
+	var buf bytes.Buffer
+	logger.Logger.SetOutput(&buf)
+	logger.Logger.SetLevel(logrus.DebugLevel)
+	defer logger.Logger.SetOutput(os.Stdout)
+
+	Info(ctx, "step content: basic_auth_password: %s", "my_secret")
+	assert.NotContains(t, buf.String(), "my_secret")
+	assert.Contains(t, buf.String(), "__hidden__")
+
+	buf.Reset()
+	Debug(ctx, "with vars: %v", H{"basic_auth_password": "my_secret"})
+	assert.NotContains(t, buf.String(), "my_secret")
+	assert.Contains(t, buf.String(), "__hidden__")
+
+	buf.Reset()
+	Error(ctx, "interpolated step:\n%s", "basic_auth_password: my_secret\n")
+	assert.NotContains(t, buf.String(), "my_secret")
+	assert.Contains(t, buf.String(), "__hidden__")
 }

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -172,7 +172,17 @@ func (v *Venom) processSecrets(ctx context.Context, ts *TestSuite, tc *TestCase)
 	if tc != nil {
 		collect(tc.Vars)
 	}
-	computedSecrets = appendDerivedSecrets(computedSecrets, seen, ts.Vars, ts.Secrets)
+
+	// Derived secrets (e.g. base64 basic-auth tokens) must be computed from the
+	// effective vars, which may only define the secret at the test case level.
+	derivedVars := ts.Vars.Clone()
+	if derivedVars == nil {
+		derivedVars = H{}
+	}
+	if tc != nil {
+		derivedVars.AddAll(tc.Vars)
+	}
+	computedSecrets = appendDerivedSecrets(computedSecrets, seen, derivedVars, ts.Secrets)
 	return context.WithValue(ctx, ContextKey("secrets"), computedSecrets)
 }
 

--- a/process_testcase.go
+++ b/process_testcase.go
@@ -154,13 +154,25 @@ func (v *Venom) runTestCase(ctx context.Context, ts *TestSuite, tc *TestCase) {
 
 func (v *Venom) processSecrets(ctx context.Context, ts *TestSuite, tc *TestCase) context.Context {
 	computedSecrets := []string{}
-	for k, v := range tc.Vars {
-		for _, s := range ts.Secrets {
-			if strings.Compare(k, s) == 0 {
-				computedSecrets = append(computedSecrets, fmt.Sprint(v))
+	seen := map[string]struct{}{}
+	collect := func(vars H) {
+		for k, val := range vars {
+			for _, s := range ts.Secrets {
+				if k == s {
+					secretVal := fmt.Sprint(val)
+					if _, ok := seen[secretVal]; !ok {
+						seen[secretVal] = struct{}{}
+						computedSecrets = append(computedSecrets, secretVal)
+					}
+				}
 			}
 		}
 	}
+	collect(ts.Vars)
+	if tc != nil {
+		collect(tc.Vars)
+	}
+	computedSecrets = appendDerivedSecrets(computedSecrets, seen, ts.Vars, ts.Secrets)
 	return context.WithValue(ctx, ContextKey("secrets"), computedSecrets)
 }
 
@@ -259,9 +271,9 @@ loopRawTestSteps:
 			}
 
 			if ranged.Enabled {
-				Info(ctx, "Step #%d-%d content is: %s", stepNumber, rangedIndex, HideSensitive(ctx, content))
+				Info(ctx, "Step #%d-%d content is: %s", stepNumber, rangedIndex, content)
 			} else {
-				Info(ctx, "Step #%d content is: %s", stepNumber, HideSensitive(ctx, content))
+				Info(ctx, "Step #%d content is: %s", stepNumber, content)
 			}
 
 			data, err := yaml.Marshal(rawStep)
@@ -364,11 +376,7 @@ loopRawTestSteps:
 					isRequired = isRequired || e.AssertionRequired || v.StopOnFailure
 				}
 
-				redactedOutputVars := make(map[string]string)
-				for k, v := range tsResult.ComputedVars {
-					redactedOutputVars[k] = HideSensitive(ctx, v)
-				}
-				Error(ctx, "teststep output vars are: %v", redactedOutputVars)
+				Error(ctx, "teststep output vars are: %v", tsResult.ComputedVars)
 
 				if isRequired {
 					failure := newFailure(ctx, *tc, stepNumber, rangedIndex, "", errors.New("At least one required assertion failed, skipping remaining steps"))

--- a/process_teststep.go
+++ b/process_teststep.go
@@ -42,7 +42,7 @@ func (v *Venom) RunTestStep(ctx context.Context, e ExecutorRunner, tc *TestCase,
 			continue
 		}
 
-		Debug(ctx, "result of executor: %s", HideSensitive(ctx, result))
+		Debug(ctx, "result of executor: %s", result)
 		mapResult := GetExecutorResult(result)
 		mapResultString, _ := DumpString(result)
 

--- a/process_testsuite.go
+++ b/process_testsuite.go
@@ -53,6 +53,7 @@ func (v *Venom) runTestSuite(ctx context.Context, ts *TestSuite) error {
 	ts.ComputedVars = H{}
 
 	ctx = context.WithValue(ctx, ContextKey("testsuite"), ts.Name)
+	ctx = v.processSecrets(ctx, ts, nil)
 	Info(ctx, "Starting testsuite")
 	defer Info(ctx, "Ending testsuite")
 

--- a/venom_output.go
+++ b/venom_output.go
@@ -25,28 +25,30 @@ func init() {
 
 // CleanUpSecrets This method tries to hide all the sensitive variables
 func (v *Venom) CleanUpSecrets(testSuite TestSuite) TestSuite {
-	for _, testCase := range testSuite.TestCases {
-		ctx := v.processSecrets(context.Background(), &testSuite, &testCase)
-		for _, result := range testCase.TestStepResults {
-			for k, v := range result.ComputedVars {
-				if !strings.HasPrefix(k, "venom.") {
-					result.ComputedVars[k] = HideSensitive(ctx, v)
-				}
-			}
-			for k, v := range result.InputVars {
-				if !strings.HasPrefix(k, "venom.") {
-					result.InputVars[k] = HideSensitive(ctx, v)
-				}
-			}
-			for k, v := range testCase.TestCaseInput.Vars {
-				if !strings.HasPrefix(k, "venom.") {
-					testCase.TestCaseInput.Vars[k] = HideSensitive(ctx, v)
-				}
-			}
-			result.Raw = HideSensitive(ctx, fmt.Sprint(result.Raw))
-			result.Interpolated = HideSensitive(ctx, fmt.Sprint(result.Interpolated))
+	suiteCtx := v.processSecrets(context.Background(), &testSuite, nil)
+	testcaseCtxs := make([]context.Context, len(testSuite.TestCases))
+	for i := range testSuite.TestCases {
+		testcaseCtxs[i] = v.processSecrets(context.Background(), &testSuite, &testSuite.TestCases[i])
+	}
+
+	redactMapVars(suiteCtx, testSuite.Vars, testSuite.Secrets)
+
+	for i := range testSuite.TestCases {
+		testCase := &testSuite.TestCases[i]
+		ctx := testcaseCtxs[i]
+		redactMapVars(ctx, testCase.Vars, testSuite.Secrets)
+
+		for j := range testCase.TestStepResults {
+			result := &testCase.TestStepResults[j]
+			redactMapVars(ctx, result.ComputedVars, testSuite.Secrets)
+			redactStringMap(ctx, result.InputVars, testSuite.Secrets)
+			result.Raw = hideSensitiveBytes(ctx, result.Raw)
+			result.Interpolated = hideSensitiveBytes(ctx, result.Interpolated)
 			result.Systemout = HideSensitive(ctx, result.Systemout)
 			result.Systemerr = HideSensitive(ctx, result.Systemerr)
+			for k, info := range result.ComputedInfo {
+				result.ComputedInfo[k] = HideSensitive(ctx, info)
+			}
 		}
 	}
 	return testSuite

--- a/venom_output_test.go
+++ b/venom_output_test.go
@@ -103,6 +103,30 @@ func TestAppendDerivedSecretsBasicAuth(t *testing.T) {
 	assert.Equal(t, "__hidden__", HideSensitive(ctx, token))
 }
 
+func TestAppendDerivedSecretsFromTestCaseVars(t *testing.T) {
+	v := New()
+	ts := TestSuite{
+		Secrets: []string{"basic_auth_password"},
+		Vars:    H{},
+		TestCases: []TestCase{
+			{
+				TestCaseInput: TestCaseInput{
+					Vars: H{
+						"basic_auth_user":     "testuser",
+						"basic_auth_password": "my_secret",
+					},
+				},
+			},
+		},
+	}
+	ctx := v.processSecrets(context.Background(), &ts, &ts.TestCases[0])
+
+	token := base64.StdEncoding.EncodeToString([]byte("testuser:my_secret"))
+	assert.Equal(t, "__hidden__", HideSensitive(ctx, token))
+	assert.Equal(t, "__hidden__", HideSensitive(ctx, base64.StdEncoding.EncodeToString([]byte("my_secret"))))
+	assert.NotContains(t, HideSensitive(ctx, "Authorization: Basic "+token), token)
+}
+
 func TestHideSensitiveBasicAuthHeaderInCleanupContext(t *testing.T) {
 	v := New()
 	ts := TestSuite{

--- a/venom_output_test.go
+++ b/venom_output_test.go
@@ -1,0 +1,134 @@
+package venom
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanUpSecrets(t *testing.T) {
+	v := New()
+	ts := TestSuite{
+		Name:    "HTTP Auth Test",
+		Secrets: []string{"basic_auth_password"},
+		Vars: H{
+			"url":                 "http://127.0.0.1:8000",
+			"basic_auth_user":     "testuser",
+			"basic_auth_password": "my_secret",
+		},
+		TestCases: []TestCase{
+			{
+				TestCaseInput: TestCaseInput{
+					Name: "GET with credentials",
+					Vars: H{
+						"basic_auth_password": "my_secret",
+					},
+				},
+				TestStepResults: []TestStepResult{
+					{
+						Name: "GET-with-credentials",
+						InputVars: map[string]string{
+							"basic_auth_user":     "testuser",
+							"basic_auth_password": "my_secret",
+						},
+						Raw: []byte(`type: http
+basic_auth_password: "{{.basic_auth_password}}"
+`),
+						Interpolated: []byte(`type: http
+basic_auth_password: my_secret
+basic_auth_user: testuser
+method: GET
+`),
+						Systemout: "Authorization: Basic dGVzdHVzZXI6bXlfc2VjcmV0",
+					},
+				},
+			},
+		},
+	}
+
+	cleaned := v.CleanUpSecrets(ts)
+
+	assert.Equal(t, "__hidden__", cleaned.Vars["basic_auth_password"])
+	assert.Equal(t, "testuser", cleaned.Vars["basic_auth_user"])
+
+	result := cleaned.TestCases[0].TestStepResults[0]
+	assert.Equal(t, "__hidden__", result.InputVars["basic_auth_password"])
+	assert.NotContains(t, string(result.Raw.([]byte)), "my_secret")
+	assert.NotContains(t, string(result.Interpolated.([]byte)), "my_secret")
+	assert.NotContains(t, result.Systemout, "my_secret")
+	assert.NotContains(t, result.Systemout, "dGVzdHVzZXI6bXlfc2VjcmV0")
+
+	data, err := json.Marshal(cleaned)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "my_secret")
+}
+
+func TestHideSensitiveBytes(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ContextKey("secrets"), []string{"my_secret"})
+
+	redacted := hideSensitiveBytes(ctx, []byte("basic_auth_password: my_secret\n"))
+	assert.Equal(t, "basic_auth_password: __hidden__\n", string(redacted))
+}
+
+func TestReplaceSecretsLongestFirst(t *testing.T) {
+	secrets := []string{"foo", "foobar"}
+	assert.Equal(t, "__hidden__", replaceSecrets("foobar", secrets))
+}
+
+func TestAppendDerivedSecretsBasicAuth(t *testing.T) {
+	v := New()
+	ts := TestSuite{
+		Secrets: []string{"basic_auth_password"},
+		Vars: H{
+			"basic_auth_user":     "testuser",
+			"basic_auth_password": "my_secret",
+		},
+	}
+	ctx := v.processSecrets(context.Background(), &ts, nil)
+	secrets := ctx.Value(ContextKey("secrets")).([]string)
+
+	token := base64.StdEncoding.EncodeToString([]byte("testuser:my_secret"))
+	found := false
+	for _, s := range secrets {
+		if s == token {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "basic auth token should be registered as a derived secret")
+	assert.Equal(t, "__hidden__", HideSensitive(ctx, token))
+}
+
+func TestHideSensitiveBasicAuthHeaderInCleanupContext(t *testing.T) {
+	v := New()
+	ts := TestSuite{
+		Secrets: []string{"basic_auth_password"},
+		Vars: H{
+			"basic_auth_user":     "testuser",
+			"basic_auth_password": "my_secret",
+		},
+		TestCases: []TestCase{
+			{TestCaseInput: TestCaseInput{Vars: H{"basic_auth_password": "my_secret"}}},
+		},
+	}
+	ctx := v.processSecrets(context.Background(), &ts, &ts.TestCases[0])
+	out := HideSensitive(ctx, "Authorization: Basic dGVzdHVzZXI6bXlfc2VjcmV0")
+	assert.NotContains(t, out, "dGVzdHVzZXI6bXlfc2VjcmV0")
+}
+
+func TestProcessSecretsUsesTestSuiteVars(t *testing.T) {
+	v := New()
+	ts := TestSuite{
+		Secrets: []string{"token"},
+		Vars: H{
+			"token": "secret-value",
+		},
+	}
+
+	ctx := v.processSecrets(context.Background(), &ts, nil)
+	assert.Equal(t, "__hidden__", HideSensitive(ctx, "secret-value"))
+}


### PR DESCRIPTION
## Summary

- Fix `CleanUpSecrets` so redaction persists (pointer iteration) and covers suite vars, step raw/interpolated output, and computed info
- Redact structured maps by secret key; scan free text for secret values and derived encodings (base64, Basic Auth tokens)
- Auto-redact all log output when secrets are in context; load secrets at testsuite start

## Issue

- https://github.com/ovh/venom/issues/921

## Test plan

- [x] `TestCleanUpSecrets` — HTTP basic auth in vars, inputVars, YAML blobs, auth header, JSON output
- [x] `TestLogFunctionsRedactSecrets` — info/debug/error logs
- [x] `TestAppendDerivedSecretsBasicAuth` — encoded credential redaction
- [x] `go test .` passes